### PR TITLE
Fix TestJSONPeers test.

### DIFF
--- a/src/peers/json_peers.go
+++ b/src/peers/json_peers.go
@@ -3,6 +3,7 @@ package peers
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -51,6 +52,10 @@ func (j *JSONPeers) Peers() (*Peers, error) {
 		if err := dec.Decode(&peerSet); err != nil {
 			return nil, err
 		}
+	}
+
+	if len(peerSet) == 0 {
+		return nil, fmt.Errorf("peers not found")
 	}
 
 	return NewPeersFromSlice(peerSet), nil


### PR DESCRIPTION
It fixes the TestJSONPeers test in the `src/peers` package.

Please check if what you want to add to `go-lachesis` list meets [quality standards](https://github.com/Fantom-foundation/go-lachesis/blob/master/CONTRIBUTING.md#quality-standard) before sending pull request.

**Please provide package links to:**

- github.com repo:
- godoc.org:
- goreportcard.com:
- coverage service link ([cover.run](https://cover.run/), [gocover](http://gocover.io/), [coveralls](https://coveralls.io/) etc.), example: `[![cover.run](https://cover.run/go/github.com/user/repository.svg?style=flat&tag=golang-1.10)](https://cover.run/go?tag=golang-1.10&repo=github.com%2Fuser%2Frepository)`

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/Fantom-foundation/go-lachesis/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/Fantom-foundation/go-lachesis/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/Fantom-foundation/go-lachesis/blob/master/CONTRIBUTING.md#quality-standard).
