### PR TITLE
New implementation of network transport to synchronize nodes.

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -27,6 +27,7 @@ import:
 - package: github.com/facebookgo/pidfile
 - package: golang.org/x/sys/windows
 - package: golang.org/x/sys/windows/svc/eventlog
+- package: github.com/pkg/errors
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.2.2

--- a/src/net/fakenet/addr.go
+++ b/src/net/fakenet/addr.go
@@ -1,0 +1,17 @@
+package fakenet
+
+// Addr is a fake network address.
+type Addr struct {
+	AddressString string
+	NetworkString string
+}
+
+// Network returns name of the network (for example, "tcp", "udp").
+func (a Addr) Network() string {
+	return a.NetworkString
+}
+
+// String returns a string form of address.
+func (a Addr) String() string {
+	return a.AddressString
+}

--- a/src/net/fakenet/conn.go
+++ b/src/net/fakenet/conn.go
@@ -1,0 +1,62 @@
+package fakenet
+
+import (
+	"io"
+	"net"
+	"time"
+)
+
+// Conn is a fake connection.
+type Conn struct {
+	LAddress string
+	RAddress string
+	Reader   *io.PipeReader
+	Writer   *io.PipeWriter
+}
+
+// Read reads data from the fake connection.
+func (c *Conn) Read(b []byte) (int, error) {
+	return c.Reader.Read(b)
+}
+
+// Write writes data to the fake connection.
+func (c *Conn) Write(b []byte) (int, error) {
+	return c.Writer.Write(b)
+}
+
+// Close closes the fake connection.
+func (c *Conn) Close() error {
+	err := c.Writer.Close()
+	if err == nil {
+		err = c.Reader.Close()
+	}
+	return err
+}
+
+// LocalAddr returns the local network address.
+func (c *Conn) LocalAddr() net.Addr {
+	return Addr{
+		AddressString: c.LAddress,
+		NetworkString: "tcp",
+	}
+}
+
+// RemoteAddr returns the local network address.
+func (c *Conn) RemoteAddr() net.Addr {
+	return Addr{
+		AddressString: c.RAddress,
+		NetworkString: "tcp",
+	}
+}
+
+// SetDeadline sets the read and write deadlines associated
+// with the connection. Not implemented.
+func (c *Conn) SetDeadline(t time.Time) error { return nil }
+
+// SetReadDeadline sets the deadline for future Read calls
+// and any currently-blocked Read call. Not implemented.
+func (c *Conn) SetReadDeadline(t time.Time) error { return nil }
+
+// SetWriteDeadline sets the deadline for future Write calls
+// and any currently-blocked Write call. Not implemented.
+func (c *Conn) SetWriteDeadline(t time.Time) error { return nil }

--- a/src/net/fakenet/errors.go
+++ b/src/net/fakenet/errors.go
@@ -2,6 +2,8 @@ package fakenet
 
 import "github.com/pkg/errors"
 
+// Errors.
 var (
-	ErrListenerClosed = errors.New("listener closed")
+	ErrListenerClosed      = errors.New("listener closed")
+	ErrAddressAlreadyInUse = errors.New("address already in use")
 )

--- a/src/net/fakenet/errors.go
+++ b/src/net/fakenet/errors.go
@@ -1,0 +1,7 @@
+package fakenet
+
+import "github.com/pkg/errors"
+
+var (
+	ErrListenerClosed = errors.New("listener closed")
+)

--- a/src/net/fakenet/listener.go
+++ b/src/net/fakenet/listener.go
@@ -11,7 +11,7 @@ type Listener struct {
 	Address string
 	Input   chan *Conn
 
-	mtx      sync.Mutex
+	mtx      sync.RWMutex
 	shutdown bool
 }
 
@@ -54,4 +54,10 @@ func (l *Listener) Addr() net.Addr {
 		AddressString: l.Address,
 		NetworkString: "tcp",
 	}
+}
+
+func (l *Listener) isClosed() bool {
+	l.mtx.RLock()
+	defer l.mtx.RUnlock()
+	return l.shutdown
 }

--- a/src/net/fakenet/listener.go
+++ b/src/net/fakenet/listener.go
@@ -1,0 +1,57 @@
+package fakenet
+
+import (
+	"net"
+	"sync"
+)
+
+// Listener is a fake network listener.
+type Listener struct {
+	done    chan struct{}
+	Address string
+	Input   chan *Conn
+
+	mtx      sync.Mutex
+	shutdown bool
+}
+
+// NewListener creates a new fake listener.
+func NewListener(address string) *Listener {
+	return &Listener{
+		done:    make(chan struct{}),
+		Address: address,
+		Input:   make(chan *Conn),
+	}
+}
+
+// Accept waits for and returns the next connection to the fake listener.
+func (l *Listener) Accept() (conn net.Conn, err error) {
+	select {
+	case conn = <-l.Input:
+		return conn, nil
+	case <-l.done:
+		return nil, ErrListenerClosed
+	}
+}
+
+// Close closes the listener.
+func (l *Listener) Close() error {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	if l.shutdown {
+		return nil
+	}
+	l.shutdown = true
+
+	close(l.done)
+	return nil
+}
+
+// Addr returns the listener's fake network address.
+func (l *Listener) Addr() net.Addr {
+	return Addr{
+		AddressString: l.Address,
+		NetworkString: "tcp",
+	}
+}

--- a/src/net/fakenet/network.go
+++ b/src/net/fakenet/network.go
@@ -1,0 +1,88 @@
+package fakenet
+
+import (
+	"io"
+	"math/rand"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Network is a fake network.
+type Network struct {
+	rand  *rand.Rand
+	mtx   sync.Mutex
+	conns map[string]*Listener
+}
+
+// NewNetwork creates a new fake network.
+func NewNetwork(listeners ...*Listener) *Network {
+	m := make(map[string]*Listener)
+	for k := range listeners {
+		m[listeners[k].Address] = listeners[k]
+	}
+	return &Network{conns: m,
+		rand: rand.New(rand.NewSource(time.Now().UnixNano()))}
+}
+
+// CreateListener returns fake listener for a specific address.
+func (n *Network) CreateListener(
+	network, address string) (net.Listener, error) {
+	n.mtx.Lock()
+	defer n.mtx.Unlock()
+
+	// If listener does not exist, create new listener.
+	if _, ok := n.conns[address]; !ok {
+		n.conns[address] = NewListener(address)
+	}
+	return n.conns[address], nil
+}
+
+// CreateNetConn returns a fake connection to a fake node.
+func (n *Network) CreateNetConn(network,
+	address string, timeout time.Duration) (net.Conn, error) {
+
+	// If listener does not exist, create new listener.
+	n.mtx.Lock()
+	if _, ok := n.conns[address]; !ok {
+		n.conns[address] = NewListener(address)
+	}
+	n.mtx.Unlock()
+
+	serverRead, clientWrite := io.Pipe()
+	clientRead, serverWrite := io.Pipe()
+	ownAddr := n.randomIPAddress() + ":" + n.randomPort()
+	server := &Conn{
+		LAddress: address,
+		RAddress: ownAddr,
+		Reader:   serverRead,
+		Writer:   serverWrite,
+	}
+
+	client := &Conn{
+		LAddress: ownAddr,
+		RAddress: address,
+		Reader:   clientRead,
+		Writer:   clientWrite,
+	}
+
+	n.conns[address].Input <- server
+
+	return client, nil
+}
+
+func (n *Network) randomIPAddress() string {
+	var octet []string
+	for i := 0; i < 4; i++ {
+		number := n.rand.Intn(255)
+		octet = append(octet, strconv.Itoa(number))
+	}
+
+	return strings.Join(octet, ".")
+}
+
+func (n *Network) randomPort() string {
+	return strconv.Itoa(n.rand.Intn(65534))
+}

--- a/src/net/fakenet/network_test.go
+++ b/src/net/fakenet/network_test.go
@@ -1,0 +1,62 @@
+package fakenet_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Fantom-foundation/go-lachesis/src/net/fakenet"
+)
+
+func TestNetworkConnRefused(t *testing.T) {
+	address := "localhost:1234"
+
+	network := fakenet.NewNetwork()
+	_, err := network.CreateNetConn("tcp", address, time.Second)
+	if err == nil {
+		t.Fatal("error should not be null")
+	}
+
+	listener, err := network.CreateListener("tcp", address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	go func() {
+		for {
+			_, err := listener.Accept()
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	conn, err := network.CreateNetConn("tcp", address, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	listener.Close()
+
+	_, err = network.CreateNetConn("tcp", address, time.Second)
+	if err == nil {
+		t.Fatal("error should not be null")
+	}
+}
+
+func TestNetworkAddrAlreadyInUse(t *testing.T) {
+	address := "localhost:1234"
+
+	network := fakenet.NewNetwork()
+	listener, err := network.CreateListener("tcp", address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	_, err = network.CreateListener("tcp", address)
+	if err != fakenet.ErrAddressAlreadyInUse {
+		t.Fatal(err)
+	}
+}

--- a/src/net/inmem_transport.go
+++ b/src/net/inmem_transport.go
@@ -24,7 +24,7 @@ func NewInmemAddr() string {
 // InmemTransport implements the Transport interface, to allow lachesis to be
 // tested in-memory without going over a network.
 type InmemTransport struct {
-	consumerCh chan RPC
+	consumerCh chan *RPC
 	localAddr  string
 	timeout    time.Duration
 }
@@ -36,7 +36,7 @@ func NewInmemTransport(addr string) (string, *InmemTransport) {
 		addr = NewInmemAddr()
 	}
 	trans := &InmemTransport{
-		consumerCh: make(chan RPC, 16),
+		consumerCh: make(chan *RPC, 16),
 		localAddr:  addr,
 		timeout:    50 * time.Millisecond,
 	}
@@ -49,7 +49,7 @@ func NewInmemTransport(addr string) (string, *InmemTransport) {
 }
 
 // Consumer implements the Transport interface.
-func (i *InmemTransport) Consumer() <-chan RPC {
+func (i *InmemTransport) Consumer() <-chan *RPC {
 	return i.consumerCh
 }
 
@@ -88,8 +88,8 @@ func (i *InmemTransport) makeRPC(target string, args, resp interface{}, r io.Rea
 	}
 
 	// Send the RPC over
-	respCh := make(chan RPCResponse)
-	peer.consumerCh <- RPC{
+	respCh := make(chan *RPCResponse)
+	peer.consumerCh <- &RPC{
 		Command:  args,
 		Reader:   r,
 		RespChan: respCh,

--- a/src/net/net_transport.go
+++ b/src/net/net_transport.go
@@ -55,7 +55,7 @@ type NetworkTransport struct {
 	connPoolLock sync.Mutex
 	maxPool      int
 
-	consumeCh chan RPC
+	consumeCh chan *RPC
 
 	stream StreamLayer
 
@@ -105,7 +105,7 @@ func NewNetworkTransport(
 		cancel:    cancel,
 		ctx:       ctx,
 		connPool:  make(map[string][]*netConn),
-		consumeCh: make(chan RPC),
+		consumeCh: make(chan *RPC),
 		logger:    logger,
 		maxPool:   maxPool,
 		stream:    stream,
@@ -126,7 +126,7 @@ func (n *NetworkTransport) Close() {
 }
 
 // Consumer implements the Transport interface.
-func (n *NetworkTransport) Consumer() <-chan RPC {
+func (n *NetworkTransport) Consumer() <-chan *RPC {
 	return n.consumeCh
 }
 
@@ -354,8 +354,8 @@ func (n *NetworkTransport) handleCommand(r *bufio.Reader, dec *json.Decoder, enc
 	}
 
 	// Create the RPC object
-	respCh := make(chan RPCResponse, 1)
-	rpc := RPC{
+	respCh := make(chan *RPCResponse, 1)
+	rpc := &RPC{
 		RespChan: respCh,
 	}
 

--- a/src/net/peer/backend.go
+++ b/src/net/peer/backend.go
@@ -1,0 +1,261 @@
+package peer
+
+import (
+	"bufio"
+	"encoding/gob"
+	"io"
+	"net"
+	"net/rpc"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	lnet "github.com/Fantom-foundation/go-lachesis/src/net"
+)
+
+const (
+	lachesis = "Lachesis"
+	// TCP is a Transmission Control Protocol.
+	TCP = "tcp"
+)
+
+// SyncServer is an interface representing methods for sync server.
+type SyncServer interface {
+	ReceiverChannel() <-chan *lnet.RPC
+	ListenAndServe(network, address string) error
+	Close() error
+}
+
+// Backend is sync server.
+type Backend struct {
+	done        chan struct{}
+	idleTimeout time.Duration
+	listener    *net.TCPListener
+	logger      logrus.FieldLogger
+	receiver    chan *lnet.RPC
+	server      *rpc.Server
+
+	mtx      sync.RWMutex
+	shutdown bool
+
+	connsLock sync.Mutex
+	conns     map[net.Conn]bool
+
+	wg *sync.WaitGroup
+}
+
+// NewBackend creates new sync Backend.
+func NewBackend(receiveTimeout, processTimeout, idleTimeout time.Duration,
+	logger logrus.FieldLogger) *Backend {
+	conns := make(map[net.Conn]bool)
+	receiver := make(chan *lnet.RPC)
+	done := make(chan struct{})
+	rpcServer := rpc.NewServer()
+	rpcServer.RegisterName(lachesis, NewLachesis(
+		done, receiver, receiveTimeout, processTimeout))
+
+	return &Backend{
+		conns:       conns,
+		done:        done,
+		idleTimeout: idleTimeout,
+		logger:      logger,
+		receiver:    receiver,
+		server:      rpcServer,
+		wg:          &sync.WaitGroup{},
+	}
+}
+
+// ReceiverChannel returns a receiver channel.
+func (srv *Backend) ReceiverChannel() <-chan *lnet.RPC {
+	srv.mtx.RLock()
+	defer srv.mtx.RUnlock()
+	return srv.receiver
+}
+
+// ListenAndServe starts sync server.
+func (srv *Backend) ListenAndServe(network, address string) error {
+	srv.mtx.RLock()
+	shutdown := srv.shutdown
+	srv.mtx.RUnlock()
+
+	if shutdown {
+		return ErrServerAlreadyRunning
+	}
+
+	errChan := make(chan error)
+
+	go func() {
+		tcpAddr, err := net.ResolveTCPAddr(network, address)
+		if err != nil {
+			errChan <- err
+			return
+		}
+
+		listener, err := net.ListenTCP(network, tcpAddr)
+		if err != nil {
+			errChan <- err
+			return
+		}
+
+		srv.listener = listener
+
+		errChan <- nil
+
+		for {
+			conn, err := listener.AcceptTCP()
+			if err != nil {
+				return
+			}
+
+			srv.mtx.RLock()
+			shutdown := srv.shutdown
+			srv.mtx.RUnlock()
+
+			if shutdown {
+				return
+			}
+
+			srv.wg.Add(1)
+			go func() {
+				srv.connsLock.Lock()
+				srv.conns[conn] = true
+				srv.connsLock.Unlock()
+
+				defer func() {
+					srv.connsLock.Lock()
+					delete(srv.conns, conn)
+					srv.connsLock.Unlock()
+					srv.wg.Done()
+				}()
+				srv.serveConn(conn)
+			}()
+		}
+	}()
+
+	return <-errChan
+}
+
+//
+func (srv *Backend) serveConn(conn net.Conn) {
+	logger := srv.logger.WithFields(logrus.Fields{"method": "serveConn",
+		"remoteAddr": conn.RemoteAddr().String()})
+
+	buf := bufio.NewWriter(conn)
+	codec := &serverCodec{
+		rwc:         conn,
+		dec:         gob.NewDecoder(conn),
+		enc:         gob.NewEncoder(buf),
+		encBuf:      buf,
+		idleTimeout: srv.idleTimeout,
+	}
+	// Set idle timeout.
+	if err := codec.rwc.SetDeadline(
+		time.Now().Add(srv.idleTimeout)); err != nil {
+		logger.Error(err)
+		return
+	}
+
+	if err := srv.serveCodec(codec); err != io.EOF {
+		logger.Warn(err)
+	}
+}
+
+func (srv *Backend) serveCodec(codec rpc.ServerCodec) error {
+	defer codec.Close()
+
+	for {
+		if err := srv.server.ServeRequest(codec); err != nil {
+			return err
+		}
+	}
+}
+
+// Close stops sync server.
+func (srv *Backend) Close() error {
+	srv.mtx.Lock()
+	defer srv.mtx.Unlock()
+
+	if srv.shutdown {
+		return nil
+	}
+
+	srv.shutdown = true
+
+	if srv.listener == nil {
+		return nil
+	}
+
+	// Stop accepting new connections.
+	srv.listener.Close()
+
+	// Close current connections.
+	srv.connsLock.Lock()
+	for k := range srv.conns {
+		k.Close()
+	}
+	srv.connsLock.Unlock()
+
+	// Stop handler.
+	close(srv.done)
+
+	// Wait for all connections to complete.
+	srv.wg.Wait()
+	return nil
+}
+
+type serverCodec struct {
+	rwc         net.Conn
+	dec         *gob.Decoder
+	enc         *gob.Encoder
+	encBuf      *bufio.Writer
+	idleTimeout time.Duration
+	closed      bool
+}
+
+func (c *serverCodec) ReadRequestHeader(r *rpc.Request) error {
+	return c.decode(r)
+}
+
+func (c *serverCodec) ReadRequestBody(body interface{}) error {
+	return c.decode(body)
+}
+
+func (c *serverCodec) WriteResponse(
+	r *rpc.Response, body interface{}) (err error) {
+	if err = c.encode(r); err != nil {
+		if c.flush() == nil {
+			c.Close()
+		}
+		return
+	}
+	if err = c.encode(body); err != nil {
+		if c.flush() == nil {
+			c.Close()
+		}
+		return
+	}
+	return c.flush()
+}
+
+func (c *serverCodec) Close() error {
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+	return c.rwc.Close()
+}
+
+func (c *serverCodec) decode(e interface{}) error {
+	c.rwc.SetDeadline(time.Now().Add(c.idleTimeout))
+	return c.dec.Decode(e)
+}
+
+func (c *serverCodec) encode(e interface{}) error {
+	c.rwc.SetDeadline(time.Now().Add(c.idleTimeout))
+	return c.enc.Encode(e)
+}
+
+func (c *serverCodec) flush() error {
+	return c.encBuf.Flush()
+}

--- a/src/net/peer/backend_test.go
+++ b/src/net/peer/backend_test.go
@@ -1,0 +1,94 @@
+package peer_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/Fantom-foundation/go-lachesis/src/net"
+	"github.com/Fantom-foundation/go-lachesis/src/net/peer"
+	"github.com/Fantom-foundation/go-lachesis/src/utils"
+)
+
+func newAddress() string {
+	return "localhost:" + strconv.Itoa(int(utils.FreePort(peer.TCP)))
+}
+
+func newBackend(t *testing.T, logger logrus.FieldLogger, address string,
+	done chan struct{}, resp interface{}, receiveTimeout,
+	processTimeout, idleTimeout, delay time.Duration) *peer.Backend {
+	backend := peer.NewBackend(
+		receiveTimeout, processTimeout, idleTimeout, logger)
+	receiver := backend.ReceiverChannel()
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case req := <-receiver:
+				// Delay response.
+				time.Sleep(delay)
+
+				req.RespChan <- &net.RPCResponse{
+					Response: resp,
+				}
+			}
+		}
+	}()
+
+	if err := backend.ListenAndServe(peer.TCP, address); err != nil {
+		t.Fatal(err)
+	}
+
+	return backend
+}
+
+func TestBackendClose(t *testing.T) {
+	srvTimeout := time.Second * 30
+
+	done := make(chan struct{})
+	defer close(done)
+
+	reqNumber := 1000
+	result := make(chan error, reqNumber)
+	defer close(result)
+
+	address := newAddress()
+	backend := newBackend(t, logger, address, done, expSyncResponse,
+		srvTimeout, srvTimeout, srvTimeout, srvTimeout)
+	defer backend.Close()
+
+	rpcCli, err := peer.NewRPCClient(peer.TCP, address, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cli, err := peer.NewClient(rpcCli)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := func() {
+		resp := &net.SyncResponse{}
+		result <- cli.Sync(context.Background(), &net.SyncRequest{}, resp)
+	}
+
+	for i := 0; i < reqNumber; i++ {
+		go request()
+	}
+
+	if err := backend.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < reqNumber; i++ {
+		err := <-result
+		if err == nil {
+			t.Fatal("error must be not nil, got: nil")
+		}
+	}
+}

--- a/src/net/peer/backend_test.go
+++ b/src/net/peer/backend_test.go
@@ -2,13 +2,14 @@ package peer_test
 
 import (
 	"context"
+	"net"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/Fantom-foundation/go-lachesis/src/net"
+	lnet "github.com/Fantom-foundation/go-lachesis/src/net"
 	"github.com/Fantom-foundation/go-lachesis/src/net/peer"
 	"github.com/Fantom-foundation/go-lachesis/src/utils"
 )
@@ -17,11 +18,11 @@ func newAddress() string {
 	return "localhost:" + strconv.Itoa(int(utils.FreePort(peer.TCP)))
 }
 
-func newBackend(t *testing.T, logger logrus.FieldLogger, address string,
-	done chan struct{}, resp interface{}, receiveTimeout,
-	processTimeout, idleTimeout, delay time.Duration) *peer.Backend {
-	backend := peer.NewBackend(
-		receiveTimeout, processTimeout, idleTimeout, logger)
+func newBackend(t *testing.T, conf *peer.BackendConfig,
+	logger logrus.FieldLogger, address string, done chan struct{},
+	resp interface{}, delay time.Duration,
+	listenerFunc peer.CreateListenerFunc) *peer.Backend {
+	backend := peer.NewBackend(conf, logger, listenerFunc)
 	receiver := backend.ReceiverChannel()
 
 	go func() {
@@ -33,7 +34,7 @@ func newBackend(t *testing.T, logger logrus.FieldLogger, address string,
 				// Delay response.
 				time.Sleep(delay)
 
-				req.RespChan <- &net.RPCResponse{
+				req.RespChan <- &lnet.RPCResponse{
 					Response: resp,
 				}
 			}
@@ -49,6 +50,11 @@ func newBackend(t *testing.T, logger logrus.FieldLogger, address string,
 
 func TestBackendClose(t *testing.T) {
 	srvTimeout := time.Second * 30
+	conf := &peer.BackendConfig{
+		ReceiveTimeout: srvTimeout,
+		ProcessTimeout: srvTimeout,
+		IdleTimeout:    srvTimeout,
+	}
 
 	done := make(chan struct{})
 	defer close(done)
@@ -58,11 +64,12 @@ func TestBackendClose(t *testing.T) {
 	defer close(result)
 
 	address := newAddress()
-	backend := newBackend(t, logger, address, done, expSyncResponse,
-		srvTimeout, srvTimeout, srvTimeout, srvTimeout)
+	backend := newBackend(t, conf, logger, address, done,
+		expSyncResponse, srvTimeout, net.Listen)
 	defer backend.Close()
 
-	rpcCli, err := peer.NewRPCClient(peer.TCP, address, time.Second)
+	rpcCli, err := peer.NewRPCClient(
+		peer.TCP, address, time.Second, net.DialTimeout)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,8 +80,8 @@ func TestBackendClose(t *testing.T) {
 	}
 
 	request := func() {
-		resp := &net.SyncResponse{}
-		result <- cli.Sync(context.Background(), &net.SyncRequest{}, resp)
+		resp := &lnet.SyncResponse{}
+		result <- cli.Sync(context.Background(), &lnet.SyncRequest{}, resp)
 	}
 
 	for i := 0; i < reqNumber; i++ {

--- a/src/net/peer/client.go
+++ b/src/net/peer/client.go
@@ -1,0 +1,91 @@
+package peer
+
+import (
+	"context"
+	"net"
+	"net/rpc"
+	"time"
+
+	lnet "github.com/Fantom-foundation/go-lachesis/src/net"
+)
+
+// CreateSyncClientFunc is a function to create a sync client.
+type CreateSyncClientFunc = func(target string,
+	timeout time.Duration) (SyncClient, error)
+
+// RPCClient is an interface representing methods for a RPC Client.
+type RPCClient interface {
+	Go(serviceMethod string, args interface{},
+		reply interface{}, done chan *rpc.Call) *rpc.Call
+	Close() error
+}
+
+// SyncClient is an interface representing methods for sync client.
+type SyncClient interface {
+	Sync(ctx context.Context,
+		req *lnet.SyncRequest, resp *lnet.SyncResponse) error
+	ForceSync(ctx context.Context,
+		req *lnet.EagerSyncRequest, resp *lnet.EagerSyncResponse) error
+	FastForward(ctx context.Context,
+		req *lnet.FastForwardRequest, resp *lnet.FastForwardResponse) error
+	Close() error
+}
+
+// Client is a sync client.
+type Client struct {
+	connect RPCClient
+}
+
+// NewRPCClient creates new RPC client.
+func NewRPCClient(
+	network, address string, timeout time.Duration) (*rpc.Client, error) {
+	conn, err := net.DialTimeout(network, address, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	return rpc.NewClient(conn), nil
+}
+
+// NewClient creates new sync client.
+func NewClient(rpcClient RPCClient) (*Client, error) {
+	return &Client{connect: rpcClient}, nil
+}
+
+// Sync sends a sync request.
+func (c *Client) Sync(ctx context.Context,
+	req *lnet.SyncRequest, resp *lnet.SyncResponse) error {
+	return c.call(ctx, MethodSync, req, resp, nil)
+}
+
+// ForceSync sends a force sync request.
+func (c *Client) ForceSync(ctx context.Context,
+	req *lnet.EagerSyncRequest, resp *lnet.EagerSyncResponse) error {
+	return c.call(ctx, MethodForceSync, req, resp, nil)
+}
+
+// FastForward sends a fast forward request.
+func (c *Client) FastForward(ctx context.Context,
+	req *lnet.FastForwardRequest, resp *lnet.FastForwardResponse) error {
+	return c.call(ctx, MethodFastForward, req, resp, nil)
+}
+
+// Close closes a sync client.
+func (c *Client) Close() error {
+	return c.connect.Close()
+}
+
+func (c *Client) call(ctx context.Context, serviceMethod string,
+	req interface{}, resp interface{}, done chan *rpc.Call) error {
+	call := c.connect.Go(serviceMethod, req, resp, nil)
+
+	select {
+	case replay := <-call.Done:
+		if replay.Error != nil {
+			return replay.Error
+		}
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return nil
+}

--- a/src/net/peer/client.go
+++ b/src/net/peer/client.go
@@ -10,8 +10,12 @@ import (
 )
 
 // CreateSyncClientFunc is a function to create a sync client.
-type CreateSyncClientFunc = func(target string,
+type CreateSyncClientFunc func(target string,
 	timeout time.Duration) (SyncClient, error)
+
+// CreateNetConnFunc is a function to create new network connection.
+type CreateNetConnFunc func(network,
+	address string, timeout time.Duration) (net.Conn, error)
 
 // RPCClient is an interface representing methods for a RPC Client.
 type RPCClient interface {
@@ -38,8 +42,9 @@ type Client struct {
 
 // NewRPCClient creates new RPC client.
 func NewRPCClient(
-	network, address string, timeout time.Duration) (*rpc.Client, error) {
-	conn, err := net.DialTimeout(network, address, timeout)
+	network, address string, timeout time.Duration,
+	createNetConnFunc CreateNetConnFunc) (*rpc.Client, error) {
+	conn, err := createNetConnFunc(network, address, timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/src/net/peer/client_test.go
+++ b/src/net/peer/client_test.go
@@ -37,7 +37,7 @@ var (
 	expFastForwardRequest = &lnet.FastForwardRequest{FromID: 0}
 	expSyncRequest        = &lnet.SyncRequest{
 		FromID: 0,
-		Known:  map[int64]int64{0: 1, 1: 2, 2: 3},
+		Known:  map[uint64]int64{0: 1, 1: 2, 2: 3},
 	}
 
 	expSyncResponse = &lnet.SyncResponse{
@@ -53,7 +53,7 @@ var (
 				},
 			},
 		},
-		Known: map[int64]int64{0: 5, 1: 5, 2: 6},
+		Known: map[uint64]int64{0: 5, 1: 5, 2: 6},
 	}
 	testError = errors.New("error")
 )

--- a/src/net/peer/client_test.go
+++ b/src/net/peer/client_test.go
@@ -1,0 +1,223 @@
+package peer_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/rpc"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/Fantom-foundation/go-lachesis/src/net"
+	"github.com/Fantom-foundation/go-lachesis/src/net/peer"
+	"github.com/Fantom-foundation/go-lachesis/src/poset"
+)
+
+var (
+	expEagerSyncRequest = &net.EagerSyncRequest{
+		FromID: 0,
+		Events: []poset.WireEvent{
+			{
+				Body: poset.WireBody{
+					Transactions:         [][]byte(nil),
+					SelfParentIndex:      1,
+					OtherParentCreatorID: 10,
+					OtherParentIndex:     0,
+					CreatorID:            9,
+				},
+			},
+		},
+	}
+	expEagerSyncResponse  = &net.EagerSyncResponse{FromID: 1, Success: true}
+	expFastForwardRequest = &net.FastForwardRequest{FromID: 0}
+	expSyncRequest        = &net.SyncRequest{
+		FromID: 0,
+		Known:  map[int64]int64{0: 1, 1: 2, 2: 3},
+	}
+
+	expSyncResponse = &net.SyncResponse{
+		FromID: 1,
+		Events: []poset.WireEvent{
+			{
+				Body: poset.WireBody{
+					Transactions:         [][]byte(nil),
+					SelfParentIndex:      1,
+					OtherParentCreatorID: 10,
+					OtherParentIndex:     0,
+					CreatorID:            9,
+				},
+			},
+		},
+		Known: map[int64]int64{0: 5, 1: 5, 2: 6},
+	}
+	testError = errors.New("error")
+)
+
+type mockRpcClient struct {
+	t    *testing.T
+	err  error
+	resp interface{}
+}
+
+func newRPCClient(t *testing.T, err error, resp interface{}) *mockRpcClient {
+	return &mockRpcClient{t: t, err: err, resp: resp}
+}
+
+func (m *mockRpcClient) Go(serviceMethod string, args interface{},
+	reply interface{}, done chan *rpc.Call) *rpc.Call {
+	raw, err := json.Marshal(m.resp)
+	if err != nil {
+		m.t.Fatal(err)
+	}
+	if err := json.Unmarshal(raw, reply); err != nil {
+		m.t.Fatal(err)
+	}
+	call := &rpc.Call{}
+	call.Done = make(chan *rpc.Call, 10)
+	call.Error = m.err
+	call.Reply = reply
+	call.Done <- call
+	return call
+}
+
+func (m *mockRpcClient) Close() error {
+	return m.err
+}
+
+func newClient(t *testing.T, m *mockRpcClient) *peer.Client {
+	cli, err := peer.NewClient(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cli
+}
+
+func TestClientSync(t *testing.T) {
+	ctx := context.Background()
+	m := newRPCClient(t, testError, expSyncResponse)
+	cli := newClient(t, m)
+	defer cli.Close()
+
+	resp := &net.SyncResponse{}
+	if err := cli.Sync(
+		ctx, expSyncRequest, resp); err != testError {
+		t.Fatalf("expected error: %s, got: %s", testError, err)
+	}
+
+	m.err = nil
+
+	if err := cli.Sync(
+		ctx, expSyncRequest, resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(resp, expSyncResponse) {
+		t.Fatalf("failed to get response, expected: %+v, got: %+v",
+			expSyncResponse, resp)
+	}
+}
+
+func TestClientForceSync(t *testing.T) {
+	ctx := context.Background()
+	m := newRPCClient(t, testError, expEagerSyncResponse)
+	cli := newClient(t, m)
+	defer cli.Close()
+
+	resp := &net.EagerSyncResponse{}
+	if err := cli.ForceSync(
+		ctx, expEagerSyncRequest, resp); err != testError {
+		t.Fatalf("expected error: %s, got: %s", testError, err)
+	}
+
+	m.err = nil
+
+	if err := cli.ForceSync(
+		ctx, expEagerSyncRequest, resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(resp, expEagerSyncResponse) {
+		t.Fatalf("failed to get response, expected: %+v, got: %+v",
+			expEagerSyncResponse, resp)
+	}
+}
+
+func TestClientFastForward(t *testing.T) {
+	expResponse := newFastForwardResponse(t)
+	ctx := context.Background()
+	m := newRPCClient(t, testError, expResponse)
+	cli := newClient(t, m)
+	defer cli.Close()
+
+	resp := &net.FastForwardResponse{}
+	if err := cli.FastForward(
+		ctx, expFastForwardRequest, resp); err != testError {
+		t.Fatalf("expected error: %s, got: %s", testError, err)
+	}
+
+	m.err = nil
+
+	if err := cli.FastForward(
+		ctx, expFastForwardRequest, resp); err != nil {
+		t.Fatal(err)
+	}
+
+	checkFastForwardResponse(t, expResponse, resp)
+}
+
+func TestNewClient(t *testing.T) {
+	timeout := time.Second
+	done := make(chan struct{})
+	defer close(done)
+
+	address := newAddress()
+	backend := newBackend(t, logger, address, done, expSyncResponse,
+		timeout, timeout, timeout, 0)
+	defer backend.Close()
+
+	rpcCli, err := peer.NewRPCClient(peer.TCP, address, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cli, err := peer.NewClient(rpcCli)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := &net.SyncResponse{}
+	if err := cli.Sync(
+		context.Background(), &net.SyncRequest{}, resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(resp, expSyncResponse) {
+		t.Fatalf("failed to get response, expected: %+v, got: %+v",
+			expSyncResponse, resp)
+	}
+}
+
+func newFastForwardResponse(t *testing.T) *net.FastForwardResponse {
+	frame := poset.Frame{}
+	block, err := poset.NewBlockFromFrame(1, frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &net.FastForwardResponse{
+		FromID:   1,
+		Block:    block,
+		Frame:    frame,
+		Snapshot: []byte("snapshot"),
+	}
+}
+
+func checkFastForwardResponse(t *testing.T, exp, got *net.FastForwardResponse) {
+	if !got.Block.Equals(&exp.Block) || !got.Frame.Equals(&exp.Frame) ||
+		got.FromID != exp.FromID || !bytes.Equal(got.Snapshot, exp.Snapshot) {
+		t.Fatalf("bad response, expected: %+v, got: %+v", exp, got)
+	}
+}

--- a/src/net/peer/errors.go
+++ b/src/net/peer/errors.go
@@ -1,0 +1,13 @@
+package peer
+
+import "github.com/pkg/errors"
+
+// Errors.
+var (
+	ErrTransportStopped      = errors.New("transport stopped")
+	ErrClientProducerStopped = errors.New("client producer stopped")
+	ErrReceiverIsBusy        = errors.New("receiver is busy")
+	ErrProcessingTimeout     = errors.New("processing timeout")
+	ErrBadResult             = errors.New("bad result")
+	ErrServerAlreadyRunning  = errors.New("server already running")
+)

--- a/src/net/peer/peer.go
+++ b/src/net/peer/peer.go
@@ -1,0 +1,179 @@
+package peer
+
+import (
+	"context"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/Fantom-foundation/go-lachesis/src/net"
+)
+
+// NewSyncClientFunc creates a new sync client.
+type NewSyncClientFunc func(target string) (SyncClient, error)
+
+// SyncPeer is an interface representing methods for sync transport.
+type SyncPeer interface {
+	Sync(ctx context.Context, target string,
+		req *net.SyncRequest, resp *net.SyncResponse) error
+	ForceSync(ctx context.Context, target string,
+		req *net.EagerSyncRequest, resp *net.EagerSyncResponse) error
+	FastForward(ctx context.Context, target string,
+		req *net.FastForwardRequest, resp *net.FastForwardResponse) error
+	Close() error
+}
+
+// Peer implements SyncPeer interface.
+type Peer struct {
+	clientProducer ClientProducer
+	logger         logrus.FieldLogger
+	server         SyncServer
+
+	mtx      sync.RWMutex
+	shutdown bool
+
+	wg *sync.WaitGroup
+}
+
+// NewTransport creates a net transport.
+func NewTransport(logger logrus.FieldLogger,
+	clientProducer ClientProducer, server SyncServer) *Peer {
+	logger = logger.WithField("type", "transport")
+	return &Peer{
+		clientProducer: clientProducer,
+		logger:         logger,
+		server:         server,
+		wg:             &sync.WaitGroup{},
+	}
+}
+
+// Sync creates a sync request to a specific node.
+func (tr *Peer) Sync(ctx context.Context, target string,
+	req *net.SyncRequest, resp *net.SyncResponse) error {
+	if tr.isShutdown() {
+		return ErrTransportStopped
+	}
+
+	tr.wg.Add(1)
+	defer tr.wg.Done()
+
+	return tr.sync(ctx, target, req, resp)
+}
+
+func (tr *Peer) sync(ctx context.Context, target string,
+	req *net.SyncRequest, resp *net.SyncResponse) error {
+	logger := tr.logger.WithFields(logrus.Fields{"method": "sync",
+		"target": target})
+
+	cli, err := tr.clientProducer.Pop(target)
+	if err != nil {
+		logger.Error(err)
+		return err
+	}
+
+	if err := cli.Sync(ctx, req, resp); err != nil {
+		logger.Error(err)
+		return err
+	}
+	tr.clientProducer.Pull(target, cli)
+
+	return err
+}
+
+// ForceSync creates a force sync request to a specific node.
+func (tr *Peer) ForceSync(ctx context.Context, target string,
+	req *net.EagerSyncRequest, resp *net.EagerSyncResponse) error {
+	if tr.isShutdown() {
+		return ErrTransportStopped
+	}
+
+	tr.wg.Add(1)
+	defer tr.wg.Done()
+
+	return tr.forceSync(ctx, target, req, resp)
+}
+
+func (tr *Peer) forceSync(ctx context.Context, target string,
+	req *net.EagerSyncRequest, resp *net.EagerSyncResponse) error {
+	logger := tr.logger.WithFields(logrus.Fields{"method": "forceSync",
+		"target": target})
+
+	cli, err := tr.clientProducer.Pop(target)
+	if err != nil {
+		logger.Error(err)
+		return err
+	}
+
+	if err := cli.ForceSync(ctx, req, resp); err != nil {
+		logger.Error(err)
+		return err
+	}
+	tr.clientProducer.Pull(target, cli)
+	return nil
+}
+
+// FastForward creates a fast forward request to a specific node.
+func (tr *Peer) FastForward(ctx context.Context, target string,
+	req *net.FastForwardRequest, resp *net.FastForwardResponse) error {
+
+	if tr.isShutdown() {
+		return ErrTransportStopped
+	}
+
+	tr.wg.Add(1)
+	defer tr.wg.Done()
+
+	return tr.fastForward(ctx, target, req, resp)
+}
+
+func (tr *Peer) fastForward(ctx context.Context, target string,
+	req *net.FastForwardRequest, resp *net.FastForwardResponse) error {
+	logger := tr.logger.WithFields(logrus.Fields{"method": "fastForward",
+		"target": target})
+
+	cli, err := tr.clientProducer.Pop(target)
+	if err != nil {
+		logger.Error(err)
+		return err
+	}
+
+	if err := cli.FastForward(ctx, req, resp); err != nil {
+		logger.Error(err)
+		return err
+	}
+	tr.clientProducer.Pull(target, cli)
+	return nil
+}
+
+// Close closes the transport.
+func (tr *Peer) Close() error {
+	logger := tr.logger.WithField("method", "Close")
+
+	tr.mtx.Lock()
+	defer tr.mtx.Unlock()
+
+	if tr.shutdown {
+		return nil
+	}
+	tr.shutdown = true
+
+	// Stop accepting new connections.
+	if tr.server != nil {
+		if err := tr.server.Close(); err != nil {
+			logger.Error(err)
+		}
+	}
+
+	// Stop creating new connections.
+	tr.clientProducer.Close()
+
+	// Waiting for all outgoing connections to complete.
+	tr.wg.Wait()
+	return nil
+}
+
+func (tr *Peer) isShutdown() bool {
+	tr.mtx.Lock()
+	defer tr.mtx.Unlock()
+	return tr.shutdown
+}

--- a/src/net/peer/peer.go
+++ b/src/net/peer/peer.go
@@ -76,7 +76,7 @@ func (tr *Peer) sync(ctx context.Context, target string,
 		logger.Error(err)
 		return err
 	}
-	tr.clientProducer.Pull(target, cli)
+	tr.clientProducer.Push(target, cli)
 
 	return err
 }
@@ -109,7 +109,7 @@ func (tr *Peer) forceSync(ctx context.Context, target string,
 		logger.Error(err)
 		return err
 	}
-	tr.clientProducer.Pull(target, cli)
+	tr.clientProducer.Push(target, cli)
 
 	return nil
 }
@@ -143,7 +143,7 @@ func (tr *Peer) fastForward(ctx context.Context, target string,
 		logger.Error(err)
 		return err
 	}
-	tr.clientProducer.Pull(target, cli)
+	tr.clientProducer.Push(target, cli)
 
 	return nil
 }

--- a/src/net/peer/peer_test.go
+++ b/src/net/peer/peer_test.go
@@ -1,0 +1,200 @@
+package peer_test
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/Fantom-foundation/go-lachesis/src/net"
+	"github.com/Fantom-foundation/go-lachesis/src/net/peer"
+)
+
+var logger logrus.FieldLogger
+
+type node struct {
+	address   string
+	transport *peer.Peer
+}
+
+func TestPeerClient(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	limit := 2
+	target := "1:2"
+	timeout := time.Second
+
+	t.Run("Sync", func(t *testing.T) {
+		createFu := func(target string,
+			timeout time.Duration) (peer.SyncClient, error) {
+			return peer.NewClient(
+				newRPCClient(t, nil, expSyncResponse))
+		}
+
+		producer := peer.NewProducer(limit, timeout, createFu)
+		tr := peer.NewTransport(logger, producer, nil)
+		defer func() {
+			if err := tr.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		resp := &net.SyncResponse{}
+		if err := tr.Sync(
+			ctx, target, expSyncRequest, resp); err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(resp, expSyncResponse) {
+			t.Fatalf("failed to get response, expected: %+v, got: %+v",
+				expSyncResponse, resp)
+		}
+	})
+
+	t.Run("ForceSync", func(t *testing.T) {
+		createFu := func(target string,
+			timeout time.Duration) (peer.SyncClient, error) {
+			return peer.NewClient(
+				newRPCClient(t, nil, expEagerSyncResponse))
+		}
+
+		producer := peer.NewProducer(limit, timeout, createFu)
+		tr := peer.NewTransport(logger, producer, nil)
+		defer func() {
+			if err := tr.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		resp := &net.EagerSyncResponse{}
+		if err := tr.ForceSync(
+			ctx, target, expEagerSyncRequest, resp); err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(resp, expEagerSyncResponse) {
+			t.Fatalf("failed to get response, expected: %+v, got: %+v",
+				expEagerSyncResponse, resp)
+		}
+	})
+
+	t.Run("FastForward", func(t *testing.T) {
+		expResponse := newFastForwardResponse(t)
+
+		createFu := func(target string,
+			timeout time.Duration) (peer.SyncClient, error) {
+			return peer.NewClient(
+				newRPCClient(t, nil, expResponse))
+		}
+
+		producer := peer.NewProducer(limit, timeout, createFu)
+		tr := peer.NewTransport(logger, producer, nil)
+		defer func() {
+			if err := tr.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		resp := &net.FastForwardResponse{}
+		if err := tr.FastForward(
+			ctx, target, expFastForwardRequest, resp); err != nil {
+			t.Fatal(err)
+		}
+
+		checkFastForwardResponse(t, expResponse, resp)
+	})
+}
+
+func TestPeerClose(t *testing.T) {
+	connectLimit := 2
+	netSize := 2
+	timeout := time.Second
+	reqNum := 10
+	done := make(chan struct{})
+	defer close(done)
+
+	network := newNetwork(t, done, logger, connectLimit,
+		expSyncResponse, timeout, timeout, timeout, netSize)
+	defer networkStop(t, network)
+
+	runClient := func(cli, srv *node, errorIsNil bool) {
+		req := expSyncRequest
+		resp := &net.SyncResponse{}
+		err := cli.transport.Sync(context.Background(),
+			srv.address, req, resp)
+		if errorIsNil && err != nil {
+			t.Fatalf("exptected error: nil, got: %v", err)
+		} else if !errorIsNil && err == nil {
+			t.Fatalf("exptected error: not nil, got: %v", err)
+		}
+	}
+
+	// Test normal communication.
+	for i := 0; i < reqNum; i++ {
+		runClient(network[0], network[1], true)
+
+	}
+
+	// Test break connection.
+	if err := network[1].transport.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test after shutdown.
+	for i := 0; i < reqNum; i++ {
+		runClient(network[0], network[1], false)
+
+	}
+}
+
+func newNode(t *testing.T, done chan struct{}, logger logrus.FieldLogger,
+	limit int, resp interface{}, backendTimeout, clientTimeout,
+	idleTimeout time.Duration) *node {
+	createFu := func(target string,
+		timeout time.Duration) (peer.SyncClient, error) {
+		rClient, err := peer.NewRPCClient(peer.TCP, target, timeout)
+		if err != nil {
+			return nil, err
+		}
+		return peer.NewClient(rClient)
+	}
+	producer := peer.NewProducer(limit, clientTimeout, createFu)
+	address := newAddress()
+	backend := newBackend(t, logger, address, done, resp,
+		backendTimeout, backendTimeout, idleTimeout, 0)
+	return &node{address, peer.NewTransport(logger, producer, backend)}
+}
+
+func newNetwork(t *testing.T, done chan struct{}, logger logrus.FieldLogger,
+	limit int, resp interface{}, backendTimeout, dialTimeout,
+	idleTimeout time.Duration, size int) (network []*node) {
+	for i := 0; i < size; i++ {
+		network = append(network, newNode(t, done, logger, limit,
+			resp, backendTimeout, dialTimeout, idleTimeout))
+	}
+	return network
+}
+
+func networkStop(t *testing.T, network []*node) {
+	for k := range network {
+		if err := network[k].transport.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func newTestLogger() *logrus.Logger {
+	logger := logrus.New()
+	logger.Level = logrus.FatalLevel
+	return logger
+}
+
+func TestMain(m *testing.M) {
+	logger = newTestLogger()
+
+	os.Exit(m.Run())
+}

--- a/src/net/peer/producer.go
+++ b/src/net/peer/producer.go
@@ -1,0 +1,106 @@
+package peer
+
+import (
+	"sync"
+	"time"
+)
+
+// ClientProducer is an interface representing methods for producer of sync
+// clients.
+type ClientProducer interface {
+	Pop(target string) (SyncClient, error)
+	Pull(target string, client SyncClient)
+	Close()
+}
+
+// Producer creates new sync clients. Stores a limited number of clients in
+// a pool for reuse.
+type Producer struct {
+	createFunc CreateSyncClientFunc
+	limit      int
+	timeout    time.Duration
+
+	mtx      sync.Mutex
+	pool     map[string][]SyncClient
+	shutdown bool
+}
+
+// NewProducer creates new producer of sync clients.
+func NewProducer(limit int, connectTimeout time.Duration,
+	createClientFunc CreateSyncClientFunc) *Producer {
+	return &Producer{
+		createFunc: createClientFunc,
+		limit:      limit,
+		timeout:    connectTimeout,
+		pool:       make(map[string][]SyncClient),
+	}
+}
+
+// Pop creates a new connection for a target or re-uses an existing connection.
+func (p *Producer) Pop(target string) (SyncClient, error) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	if p.shutdown {
+		return nil, ErrClientProducerStopped
+	}
+
+	clients := p.pool[target]
+	if len(clients) != 0 {
+		var cli SyncClient
+		num := len(clients)
+
+		cli, clients[num-1] = clients[num-1], nil
+		p.pool[target] = clients[:num-1]
+		return cli, nil
+	}
+
+	return p.createFunc(target, p.timeout)
+}
+
+// Pull saves a connection in a pool.
+func (p *Producer) Pull(target string, client SyncClient) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	if p.shutdown || len(p.pool[target]) >= p.limit {
+		return
+	}
+
+	p.pool[target] = append(p.pool[target], client)
+}
+
+// Close closes a producer.
+func (p *Producer) Close() {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	if p.shutdown {
+		return
+	}
+
+	p.shutdown = true
+
+	for target := range p.pool {
+		for k := range p.pool[target] {
+			p.pool[target][k].Close()
+		}
+	}
+	p.pool = nil
+}
+
+// ConnLen returns the number of connections in a pool for a specific target.
+func (p *Producer) ConnLen(target string) int {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	return p.connLen(target)
+}
+
+func (p *Producer) connLen(target string) int {
+	if p.shutdown {
+		return 0
+	}
+
+	return len(p.pool[target])
+}

--- a/src/net/peer/producer_test.go
+++ b/src/net/peer/producer_test.go
@@ -1,0 +1,90 @@
+package peer_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/Fantom-foundation/go-lachesis/src/net"
+	"github.com/Fantom-foundation/go-lachesis/src/net/peer"
+)
+
+func TestProducer(t *testing.T) {
+	ctx := context.Background()
+	target := "1:2"
+	limit := 2
+	createFu := func(target string,
+		timeout time.Duration) (peer.SyncClient, error) {
+		return peer.NewClient(newRPCClient(t, nil, expSyncResponse))
+	}
+	producer := peer.NewProducer(limit, time.Second, createFu)
+
+	// Test new connection.
+	if producer.ConnLen(target) != 0 {
+		t.Fatalf("expected %d, got %d", 0, producer.ConnLen(target))
+	}
+
+	cli, err := producer.Pop(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := &net.SyncResponse{}
+	if err := cli.Sync(ctx, expSyncRequest, resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(resp, expSyncResponse) {
+		t.Fatalf("failed to get response, expected: %+v, got: %+v",
+			expSyncResponse, resp)
+	}
+
+	// Test reuse connection.
+	producer.Pull(target, cli)
+
+	if producer.ConnLen(target) != 1 {
+		t.Fatalf("expected %d, got %d", 1, producer.ConnLen(target))
+	}
+
+	cli, err = producer.Pop(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp = &net.SyncResponse{}
+	if err := cli.Sync(ctx, expSyncRequest, resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(resp, expSyncResponse) {
+		t.Fatalf("failed to get response, expected: %+v, got: %+v",
+			expSyncResponse, resp)
+	}
+
+	if producer.ConnLen(target) != 0 {
+		t.Fatalf("expected %d, got %d", 0, producer.ConnLen(target))
+	}
+
+	// Test full pull.
+	for i := 0; i < limit+1; i++ {
+		producer.Pull(target, cli)
+	}
+
+	if producer.ConnLen(target) != limit {
+		t.Fatalf("expected %d, got %d", limit, producer.ConnLen(target))
+	}
+
+	// Test close producer.
+	producer.Close()
+
+	if _, err := producer.Pop(target); err != peer.ErrClientProducerStopped {
+		t.Fatalf("expected %s, got %s", peer.ErrClientProducerStopped, err)
+	}
+
+	producer.Pull(target, cli)
+
+	if producer.ConnLen(target) != 0 {
+		t.Fatalf("expected %d, got %d", 0, producer.ConnLen(target))
+	}
+}

--- a/src/net/peer/producer_test.go
+++ b/src/net/peer/producer_test.go
@@ -41,7 +41,7 @@ func TestProducer(t *testing.T) {
 	}
 
 	// Test reuse connection.
-	producer.Pull(target, cli)
+	producer.Push(target, cli)
 
 	if producer.ConnLen(target) != 1 {
 		t.Fatalf("expected %d, got %d", 1, producer.ConnLen(target))
@@ -68,7 +68,7 @@ func TestProducer(t *testing.T) {
 
 	// Test full pull.
 	for i := 0; i < limit+1; i++ {
-		producer.Pull(target, cli)
+		producer.Push(target, cli)
 	}
 
 	if producer.ConnLen(target) != limit {
@@ -82,7 +82,7 @@ func TestProducer(t *testing.T) {
 		t.Fatalf("expected %s, got %s", peer.ErrClientProducerStopped, err)
 	}
 
-	producer.Pull(target, cli)
+	producer.Push(target, cli)
 
 	if producer.ConnLen(target) != 0 {
 		t.Fatalf("expected %d, got %d", 0, producer.ConnLen(target))

--- a/src/net/peer/rpc.go
+++ b/src/net/peer/rpc.go
@@ -1,0 +1,122 @@
+package peer
+
+import (
+	"time"
+
+	"github.com/Fantom-foundation/go-lachesis/src/net"
+)
+
+// RPC Methods.
+const (
+	MethodSync        = "Lachesis.Sync"
+	MethodForceSync   = "Lachesis.ForceSync"
+	MethodFastForward = "Lachesis.FastForward"
+)
+
+// Lachesis implements Lachesis synchronization methods.
+type Lachesis struct {
+	done           chan struct{}
+	receiver       chan *net.RPC
+	processTimeout time.Duration
+	receiveTimeout time.Duration
+}
+
+// NewLachesis creates new Lachesis RPC handler.
+func NewLachesis(done chan struct{}, receiver chan *net.RPC,
+	receiveTimeout, processTimeout time.Duration) *Lachesis {
+	return &Lachesis{
+		done:           done,
+		receiver:       receiver,
+		processTimeout: processTimeout,
+		receiveTimeout: receiveTimeout,
+	}
+}
+
+// Sync handles sync requests.
+func (r *Lachesis) Sync(
+	req *net.SyncRequest, resp *net.SyncResponse) error {
+	result, err := r.process(req)
+	if err != nil {
+		return err
+	}
+
+	item, ok := result.(*net.SyncResponse)
+	if !ok {
+		return ErrBadResult
+	}
+	*resp = *item
+	return nil
+}
+
+// ForceSync handles force sync requests.
+func (r *Lachesis) ForceSync(
+	req *net.EagerSyncRequest, resp *net.EagerSyncResponse) error {
+	result, err := r.process(req)
+	if err != nil {
+		return err
+	}
+
+	item, ok := result.(*net.EagerSyncResponse)
+	if !ok {
+		return ErrBadResult
+	}
+	*resp = *item
+	return nil
+}
+
+// FastForward handles fast forward requests.
+func (r *Lachesis) FastForward(
+	req *net.FastForwardRequest, resp *net.FastForwardResponse) error {
+	result, err := r.process(req)
+	if err != nil {
+		return err
+	}
+
+	item, ok := result.(*net.FastForwardResponse)
+	if !ok {
+		return ErrBadResult
+	}
+	*resp = *item
+	return nil
+}
+
+func (r *Lachesis) send(req interface{}) *net.RPCResponse {
+	reply := make(chan *net.RPCResponse, 1) // Buffered.
+	ticket := &net.RPC{
+		Command:  req,
+		RespChan: reply,
+	}
+
+	timer := time.NewTimer(r.receiveTimeout)
+
+	select {
+	case r.receiver <- ticket:
+	case <-timer.C:
+		return &net.RPCResponse{Error: ErrReceiverIsBusy}
+	case <-r.done:
+		return &net.RPCResponse{Error: ErrTransportStopped}
+	}
+
+	var result *net.RPCResponse
+
+	timer.Reset(r.processTimeout)
+
+	select {
+	case result = <-reply:
+	case <-timer.C:
+		result = &net.RPCResponse{Error: ErrProcessingTimeout}
+	case <-r.done:
+		return &net.RPCResponse{Error: ErrTransportStopped}
+	}
+
+	return result
+}
+
+func (r *Lachesis) process(req interface{}) (resp interface{}, err error) {
+	result := r.send(req)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	resp = result.Response
+	return
+}

--- a/src/net/peer/rpc_test.go
+++ b/src/net/peer/rpc_test.go
@@ -1,0 +1,183 @@
+package peer_test
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/Fantom-foundation/go-lachesis/src/net"
+	"github.com/Fantom-foundation/go-lachesis/src/net/peer"
+)
+
+type env struct {
+	shutdown bool
+	done     chan struct{}
+	handler  *peer.Lachesis
+}
+
+func newEnv(t *testing.T, request, response interface{}, err error,
+	delay, timeout time.Duration, receiver chan *net.RPC) *env {
+	done := make(chan struct{})
+	handler := peer.NewLachesis(nil, receiver, timeout, timeout)
+
+	// Processing simulation.
+	go func() {
+		for {
+			var req *net.RPC
+			select {
+			case <-done:
+				return
+			case r, ok := <-receiver:
+				if !ok {
+					return
+				}
+				if !reflect.DeepEqual(r.Command, request) {
+					t.Fatalf("expected request %+v, got %+v",
+						request, r)
+				}
+				req = r
+			}
+
+			time.Sleep(delay)
+
+			select {
+			case <-done:
+				return
+			case req.RespChan <- &net.RPCResponse{
+				Response: response, Error: err}:
+				close(req.RespChan)
+			}
+		}
+	}()
+	return &env{
+		done:    done,
+		handler: handler,
+	}
+}
+
+func (e *env) Close() {
+	if e.shutdown {
+		return
+	}
+	e.shutdown = true
+	close(e.done)
+}
+
+func TestLachesisSync(t *testing.T) {
+	receiver := make(chan *net.RPC)
+	env := newEnv(t, expSyncRequest, expSyncResponse,
+		testError, 0, time.Second, receiver)
+	defer env.Close()
+
+	resp := &net.SyncResponse{}
+	if err := env.handler.Sync(expSyncRequest, resp); err == nil {
+		t.Fatalf("expected error %s, got: error is null", testError)
+	}
+	env.Close()
+
+	receiver = make(chan *net.RPC)
+	env = newEnv(t, expSyncRequest, expSyncResponse,
+		nil, 0, time.Second, receiver)
+	defer env.Close()
+
+	resp = &net.SyncResponse{}
+	if err := env.handler.Sync(expSyncRequest, resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(resp, expSyncResponse) {
+		t.Fatalf("failed to get response, expected: %+v, got: %+v",
+			expSyncResponse, resp)
+	}
+}
+
+func TestLachesisForceSync(t *testing.T) {
+	receiver := make(chan *net.RPC)
+	env := newEnv(t, expEagerSyncRequest, expEagerSyncResponse,
+		testError, 0, time.Second, receiver)
+	defer env.Close()
+
+	resp := &net.EagerSyncResponse{}
+	if err := env.handler.ForceSync(expEagerSyncRequest, resp); err == nil {
+		t.Fatalf("expected error %s, got: error is null", testError)
+	}
+	env.Close()
+
+	receiver = make(chan *net.RPC)
+	env = newEnv(t, expEagerSyncRequest, expEagerSyncResponse,
+		nil, 0, time.Second, receiver)
+	defer env.Close()
+
+	resp = &net.EagerSyncResponse{}
+	if err := env.handler.ForceSync(expEagerSyncRequest, resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(resp, expEagerSyncResponse) {
+		t.Fatalf("failed to get response, expected: %+v, got: %+v",
+			expEagerSyncResponse, resp)
+	}
+}
+
+func TestLachesisFastForward(t *testing.T) {
+	request := &net.FastForwardRequest{
+		FromID: 0,
+	}
+
+	expResponse := newFastForwardResponse(t)
+
+	receiver := make(chan *net.RPC)
+	env := newEnv(t, request, expResponse, testError, 0, time.Second, receiver)
+	defer env.Close()
+
+	resp := &net.FastForwardResponse{}
+	if err := env.handler.FastForward(request, resp); err == nil {
+		t.Fatalf("expected error %s, got: error is null", testError)
+	}
+	env.Close()
+
+	receiver = make(chan *net.RPC)
+	env = newEnv(t, request, expResponse, nil, 0, time.Second, receiver)
+	defer env.Close()
+
+	resp = &net.FastForwardResponse{}
+	if err := env.handler.FastForward(request, resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(resp, expResponse) {
+		t.Fatalf("failed to get response, expected: %+v, got: %+v",
+			expResponse, resp)
+	}
+}
+
+func TestTimeout(t *testing.T) {
+	delay := time.Second
+
+	t.Run("ReceiverIsBusy", func(t *testing.T) {
+		env := newEnv(t, expSyncRequest, expSyncResponse,
+			nil, delay/2, delay/2, nil)
+		defer env.Close()
+
+		resp := &net.SyncResponse{}
+		if err := env.handler.Sync(
+			expSyncRequest, resp); err != peer.ErrReceiverIsBusy {
+			t.Fatalf("expected error %s, got: error is %v",
+				peer.ErrReceiverIsBusy, err)
+		}
+	})
+
+	t.Run("ProcessingTimeout", func(t *testing.T) {
+		receiver := make(chan *net.RPC)
+		env := newEnv(t, expSyncRequest, expSyncResponse,
+			nil, delay, delay/2, receiver)
+		defer env.Close()
+
+		resp := &net.SyncResponse{}
+		if err := env.handler.Sync(
+			expSyncRequest, resp); err != peer.ErrProcessingTimeout {
+			t.Fatalf("expected error %s, got: error is %v",
+				peer.ErrProcessingTimeout, err)
+		}
+	})
+}

--- a/src/net/transport.go
+++ b/src/net/transport.go
@@ -12,12 +12,12 @@ type RPCResponse struct {
 type RPC struct {
 	Command  interface{}
 	Reader   io.Reader
-	RespChan chan<- RPCResponse
+	RespChan chan<- *RPCResponse
 }
 
 // Respond is used to respond with a response, error or both
 func (r *RPC) Respond(resp interface{}, err error) {
-	r.RespChan <- RPCResponse{resp, err}
+	r.RespChan <- &RPCResponse{resp, err}
 }
 
 // Transport provides an interface for network transports
@@ -25,7 +25,7 @@ func (r *RPC) Respond(resp interface{}, err error) {
 type Transport interface {
 	// Consumer returns a channel that can be used to
 	// consume and respond to RPC requests.
-	Consumer() <-chan RPC
+	Consumer() <-chan *RPC
 
 	// LocalAddr is used to return our local address to distinguish from our peers.
 	LocalAddr() string

--- a/src/net/transport_test.go
+++ b/src/net/transport_test.go
@@ -65,7 +65,7 @@ func testTransportImplementation(t *testing.T, trans1, trans2 Transport) {
 		}
 	})
 
-	t.Run("EagerSync", func(t *testing.T) {
+	t.Run("ForceSync", func(t *testing.T) {
 		assert := assert.New(t)
 
 		expectedReq := &EagerSyncRequest{

--- a/src/net/transport_test.go
+++ b/src/net/transport_test.go
@@ -65,7 +65,7 @@ func testTransportImplementation(t *testing.T, trans1, trans2 Transport) {
 		}
 	})
 
-	t.Run("ForceSync", func(t *testing.T) {
+	t.Run("EagerSync", func(t *testing.T) {
 		assert := assert.New(t)
 
 		expectedReq := &EagerSyncRequest{

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -35,7 +35,7 @@ type Node struct {
 	selectorLock sync.Mutex
 
 	trans net.Transport
-	netCh <-chan net.RPC
+	netCh <-chan *net.RPC
 
 	proxy            proxy.AppProxy
 
@@ -253,7 +253,7 @@ func (n *Node) lachesis(gossip bool) {
 	}
 }
 
-func (n *Node) processRPC(rpc net.RPC) {
+func (n *Node) processRPC(rpc *net.RPC) {
 	switch cmd := rpc.Command.(type) {
 	case *net.SyncRequest:
 		n.processSyncRequest(rpc, cmd)
@@ -267,7 +267,7 @@ func (n *Node) processRPC(rpc net.RPC) {
 	}
 }
 
-func (n *Node) processSyncRequest(rpc net.RPC, cmd *net.SyncRequest) {
+func (n *Node) processSyncRequest(rpc *net.RPC, cmd *net.SyncRequest) {
 	n.logger.WithFields(logrus.Fields{
 		"from_id": cmd.FromID,
 		"known":   cmd.Known,
@@ -324,7 +324,7 @@ func (n *Node) processSyncRequest(rpc net.RPC, cmd *net.SyncRequest) {
 	rpc.Respond(resp, respErr)
 }
 
-func (n *Node) processEagerSyncRequest(rpc net.RPC, cmd *net.EagerSyncRequest) {
+func (n *Node) processEagerSyncRequest(rpc *net.RPC, cmd *net.EagerSyncRequest) {
 	n.logger.WithFields(logrus.Fields{
 		"from_id": cmd.FromID,
 		"events":  len(cmd.Events),
@@ -346,7 +346,7 @@ func (n *Node) processEagerSyncRequest(rpc net.RPC, cmd *net.EagerSyncRequest) {
 	rpc.Respond(resp, err)
 }
 
-func (n *Node) processFastForwardRequest(rpc net.RPC, cmd *net.FastForwardRequest) {
+func (n *Node) processFastForwardRequest(rpc *net.RPC, cmd *net.FastForwardRequest) {
 	n.logger.WithFields(logrus.Fields{
 		"from": cmd.FromID,
 	}).Debug("processFastForwardRequest(rpc net.RPC, cmd *net.FastForwardRequest)")

--- a/src/poset/block.go
+++ b/src/poset/block.go
@@ -1,6 +1,7 @@
 package poset
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
@@ -273,6 +274,8 @@ func MapStringsEquals(this map[string]string, that map[string]string) bool {
 func (b *Block) Equals(that *Block) bool {
 	return b.Body.Equals(that.Body) &&
 		MapStringsEquals(b.Signatures, that.Signatures) &&
-		BytesEquals(b.Hash, that.Hash) &&
-		b.Hex == that.Hex
+		b.Hex == that.Hex &&
+		bytes.Equal(b.Hash, that.Hash) &&
+		bytes.Equal(b.FrameHash, that.FrameHash) &&
+		bytes.Equal(b.StateHash, that.StateHash)
 }

--- a/src/utils/util.go
+++ b/src/utils/util.go
@@ -47,3 +47,18 @@ func HashFromHex(s string) []byte {
 	h, _ := hex.DecodeString(s)
 	return h
 }
+
+// FreePort gets free network port on host.
+func FreePort(network string) (port uint16) {
+	addr, err := net.ResolveTCPAddr(network, "localhost:0")
+	if err != nil {
+		panic(err)
+	}
+
+	l, err := net.ListenTCP(network, addr)
+	if err != nil {
+		panic(err)
+	}
+	defer l.Close()
+	return uint16(l.Addr().(*net.TCPAddr).Port)
+}


### PR DESCRIPTION
Features:
- No unprocessed locks;
- Simple fake network for integration tests;
- Graceful shutdown;
- Use `net/rpc` package.
- Slightly changes the current API;
- Good test coverage;
- Custom connection deadline for server side, deadline increases with every read/write operation;
- Not yet integrated with other packages;

Please check if what you want to add to `go-lachesis` list meets [quality standards](https://github.com/Fantom-foundation/go-lachesis/blob/master/CONTRIBUTING.md#quality-standard) before sending pull request.

**Please provide package links to:**

- github.com repo:
- godoc.org:
- goreportcard.com:
- coverage service link ([cover.run](https://cover.run/), [gocover](http://gocover.io/), [coveralls](https://coveralls.io/) etc.), example: `[![cover.run](https://cover.run/go/github.com/user/repository.svg?style=flat&tag=golang-1.10)](https://cover.run/go?tag=golang-1.10&repo=github.com%2Fuser%2Frepository)`

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/Fantom-foundation/go-lachesis/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/Fantom-foundation/go-lachesis/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/Fantom-foundation/go-lachesis/blob/master/CONTRIBUTING.md#quality-standard).
