### PR TITLE
Allow choice of specific peer selector type outside of NewNode function

### DIFF
--- a/src/lachesis/lachesis.go
+++ b/src/lachesis/lachesis.go
@@ -145,14 +145,19 @@ func (l *Lachesis) initNode() error {
 		"id":           nodeID,
 	}).Debug("PARTICIPANTS")
 
+	selectorArgs := node.SelectorCreationFnArgs{
+		Peers: l.Peers,
+		LocalAddr: l.Transport.LocalAddr(),
+	}
 	l.Node = node.NewNode(
 		&l.Config.NodeConfig,
 		nodeID,
 		key,
-		l.Peers,
 		l.Store,
 		l.Transport,
 		l.Config.Proxy,
+		node.NewSmartPeerSelectorFromArgs,
+		selectorArgs,
 	)
 
 	if err := l.Node.Init(); err != nil {

--- a/src/lachesis/lachesis.go
+++ b/src/lachesis/lachesis.go
@@ -145,18 +145,19 @@ func (l *Lachesis) initNode() error {
 		"id":           nodeID,
 	}).Debug("PARTICIPANTS")
 
-	selectorArgs := node.SelectorCreationFnArgs{
-		Peers: l.Peers,
+	selectorArgs := node.SmartPeerSelectorCreationFnArgs{
 		LocalAddr: l.Transport.LocalAddr(),
+		GetFlagTable: nil,
 	}
 	l.Node = node.NewNode(
 		&l.Config.NodeConfig,
 		nodeID,
 		key,
+		l.Peers,
 		l.Store,
 		l.Transport,
 		l.Config.Proxy,
-		node.NewSmartPeerSelectorFromArgs,
+		node.NewSmartPeerSelectorWrapper,
 		selectorArgs,
 	)
 

--- a/src/node/common.go
+++ b/src/node/common.go
@@ -40,18 +40,19 @@ func NewNodeList(count int, logger *logrus.Logger) NodeList {
 	for _, peer := range participants.ToPeerSlice() {
 		key := keys[peer]
 		_, transp := net.NewInmemTransport(peer.GetNetAddr())
-		selectorArgs := SelectorCreationFnArgs{
-			Peers: participants,
+		selectorArgs := SmartPeerSelectorCreationFnArgs{
 			LocalAddr: transp.LocalAddr(),
+			GetFlagTable: nil,
 		}
 		n := NewNode(
 			config,
 			peer.ID,
 			key,
+			participants,
 			poset.NewInmemStore(participants, config.CacheSize, nil),
 			transp,
 			dummy.NewInmemDummyApp(logger),
-			NewSmartPeerSelectorFromArgs,
+			NewSmartPeerSelectorWrapper,
 			selectorArgs,
 			)
 		if err := n.Init(); err != nil {

--- a/src/node/common.go
+++ b/src/node/common.go
@@ -40,14 +40,20 @@ func NewNodeList(count int, logger *logrus.Logger) NodeList {
 	for _, peer := range participants.ToPeerSlice() {
 		key := keys[peer]
 		_, transp := net.NewInmemTransport(peer.GetNetAddr())
+		selectorArgs := SelectorCreationFnArgs{
+			Peers: participants,
+			LocalAddr: transp.LocalAddr(),
+		}
 		n := NewNode(
 			config,
 			peer.ID,
 			key,
-			participants,
 			poset.NewInmemStore(participants, config.CacheSize, nil),
 			transp,
-			dummy.NewInmemDummyApp(logger))
+			dummy.NewInmemDummyApp(logger),
+			NewSmartPeerSelectorFromArgs,
+			selectorArgs,
+			)
 		if err := n.Init(); err != nil {
 			logger.Fatal(err)
 		}

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -59,10 +59,11 @@ type Node struct {
 func NewNode(conf *Config,
 	id uint64,
 	key *ecdsa.PrivateKey,
-	participants *peers.Peers,
 	store poset.Store,
 	trans net.Transport,
-	proxy proxy.AppProxy) *Node {
+	proxy proxy.AppProxy,
+	selectorInitFunc SelectorCreationFn,
+	selectorInitArgs SelectorCreationFnArgs) *Node {
 
 	localAddr := trans.LocalAddr()
 
@@ -73,9 +74,9 @@ func NewNode(conf *Config,
 
 	pubKey := core.HexID()
 
-	// peerSelector := NewRandomPeerSelector(participants, localAddr)
-	peerSelector := NewSmartPeerSelector(participants, pubKey,
-		core.poset.GetPeerFlagTableOfRandomUndeterminedEvent)
+	selectorInitArgs.PubKey = pubKey
+	selectorInitArgs.GetFlagTable = core.poset.GetPeerFlagTableOfRandomUndeterminedEvent
+	peerSelector := selectorInitFunc(selectorInitArgs)
 
 	node := Node{
 		id:               id,

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -59,6 +59,7 @@ type Node struct {
 func NewNode(conf *Config,
 	id uint64,
 	key *ecdsa.PrivateKey,
+	participants *peers.Peers,
 	store poset.Store,
 	trans net.Transport,
 	proxy proxy.AppProxy,
@@ -67,16 +68,18 @@ func NewNode(conf *Config,
 
 	localAddr := trans.LocalAddr()
 
-	pmap, _ := store.Participants()
-
 	commitCh := make(chan poset.Block, 400)
-	core := NewCore(id, key, pmap, store, commitCh, conf.Logger)
+	core := NewCore(id, key, participants, store, commitCh, conf.Logger)
 
 	pubKey := core.HexID()
 
-	selectorInitArgs.PubKey = pubKey
-	selectorInitArgs.GetFlagTable = core.poset.GetPeerFlagTableOfRandomUndeterminedEvent
-	peerSelector := selectorInitFunc(selectorInitArgs)
+	if args, ok := selectorInitArgs.(SmartPeerSelectorCreationFnArgs); ok {
+		args.GetFlagTable = core.poset.GetPeerFlagTableOfRandomUndeterminedEvent
+		args.LocalAddr = pubKey
+		selectorInitArgs = args
+	}
+
+	peerSelector := selectorInitFunc(participants, selectorInitArgs)
 
 	node := Node{
 		id:               id,
@@ -102,7 +105,7 @@ func NewNode(conf *Config,
 
 	signal.Notify(node.signalTERMch, syscall.SIGTERM, os.Kill)
 
-	node.logger.WithField("peers", pmap).Debug("pmap")
+	node.logger.WithField("participants", participants).Debug("participants")
 	node.logger.WithField("pubKey", pubKey).Debug("pubKey")
 
 	node.needBoostrap = store.NeedBootstrap()

--- a/src/node/node_test.go
+++ b/src/node/node_test.go
@@ -59,15 +59,15 @@ func TestProcessSync(t *testing.T) {
 	}
 	defer peer0Trans.Close()
 
-	selector0Args := SelectorCreationFnArgs{
-		Peers: p,
+	selector0Args := SmartPeerSelectorCreationFnArgs{
 		LocalAddr: peer0Trans.LocalAddr(),
+		GetFlagTable: nil,
 	}
-	node0 := NewNode(config, ps[0].ID, keys[0],
+	node0 := NewNode(config, ps[0].ID, keys[0], p,
 		poset.NewInmemStore(p, config.CacheSize, nil),
 		peer0Trans,
 		dummy.NewInmemDummyApp(testLogger),
-		NewSmartPeerSelectorFromArgs,
+		NewSmartPeerSelectorWrapper,
 		selector0Args)
 	if err := node0.Init(); err != nil {
 		t.Fatal(err)
@@ -83,15 +83,15 @@ func TestProcessSync(t *testing.T) {
 	}
 	defer peer1Trans.Close()
 
-	selector1Args := SelectorCreationFnArgs{
-		Peers: p,
+	selector1Args := SmartPeerSelectorCreationFnArgs{
 		LocalAddr: peer1Trans.LocalAddr(),
+		GetFlagTable: nil,
 	}
-	node1 := NewNode(config, ps[1].ID, keys[1],
+	node1 := NewNode(config, ps[1].ID, keys[1], p,
 		poset.NewInmemStore(p, config.CacheSize, nil),
 		peer1Trans,
 		dummy.NewInmemDummyApp(testLogger),
-		NewSmartPeerSelectorFromArgs,
+		NewSmartPeerSelectorWrapper,
 		selector1Args)
 	if err := node1.Init(); err != nil {
 		t.Fatal(err)
@@ -176,15 +176,15 @@ func TestProcessEagerSync(t *testing.T) {
 	}
 	defer peer0Trans.Close()
 
-	selector0Args := SelectorCreationFnArgs{
-		Peers: p,
+	selector0Args := SmartPeerSelectorCreationFnArgs{
 		LocalAddr: peer0Trans.LocalAddr(),
+		GetFlagTable: nil,
 	}
-	node0 := NewNode(config, ps[0].ID, keys[0],
+	node0 := NewNode(config, ps[0].ID, keys[0], p,
 		poset.NewInmemStore(p, config.CacheSize, nil),
 		peer0Trans,
 		dummy.NewInmemDummyApp(testLogger),
-		NewSmartPeerSelectorFromArgs,
+		NewSmartPeerSelectorWrapper,
 		selector0Args)
 	if err := node0.Init(); err != nil {
 		t.Fatal(err)
@@ -200,15 +200,15 @@ func TestProcessEagerSync(t *testing.T) {
 	}
 	defer peer1Trans.Close()
 
-	selector1Args := SelectorCreationFnArgs{
-		Peers: p,
+	selector1Args := SmartPeerSelectorCreationFnArgs{
 		LocalAddr: peer1Trans.LocalAddr(),
+		GetFlagTable: nil,
 	}
-	node1 := NewNode(config, ps[1].ID, keys[1],
+	node1 := NewNode(config, ps[1].ID, keys[1], p,
 		poset.NewInmemStore(p, config.CacheSize, nil),
 		peer1Trans,
 		dummy.NewInmemDummyApp(testLogger),
-		NewSmartPeerSelectorFromArgs,
+		NewSmartPeerSelectorWrapper,
 		selector1Args)
 	if err := node1.Init(); err != nil {
 		t.Fatal(err)
@@ -272,15 +272,15 @@ func TestAddTransaction(t *testing.T) {
 	peer0Proxy := dummy.NewInmemDummyApp(testLogger)
 	defer peer0Trans.Close()
 
-	selector0Args := SelectorCreationFnArgs{
-		Peers: p,
+	selector0Args := SmartPeerSelectorCreationFnArgs{
 		LocalAddr: peer0Trans.LocalAddr(),
+		GetFlagTable: nil,
 	}
-	node0 := NewNode(TestConfig(t), ps[0].ID, keys[0],
+	node0 := NewNode(TestConfig(t), ps[0].ID, keys[0], p,
 		poset.NewInmemStore(p, config.CacheSize, nil),
 		peer0Trans,
 		peer0Proxy,
-		NewSmartPeerSelectorFromArgs,
+		NewSmartPeerSelectorWrapper,
 		selector0Args)
 	if err := node0.Init(); err != nil {
 		t.Fatal(err)
@@ -297,15 +297,15 @@ func TestAddTransaction(t *testing.T) {
 	peer1Proxy := dummy.NewInmemDummyApp(testLogger)
 	defer peer1Trans.Close()
 
-	selector1Args := SelectorCreationFnArgs{
-		Peers: p,
+	selector1Args := SmartPeerSelectorCreationFnArgs{
 		LocalAddr: peer1Trans.LocalAddr(),
+		GetFlagTable: nil,
 	}
-	node1 := NewNode(TestConfig(t), ps[1].ID, keys[1],
+	node1 := NewNode(TestConfig(t), ps[1].ID, keys[1], p,
 		poset.NewInmemStore(p, config.CacheSize, nil),
 		peer1Trans,
 		peer1Proxy,
-		NewSmartPeerSelectorFromArgs,
+		NewSmartPeerSelectorWrapper,
 		selector1Args)
 	if err := node1.Init(); err != nil {
 		t.Fatal(err)
@@ -406,17 +406,18 @@ func initNodes(keys []*ecdsa.PrivateKey,
 		}
 		prox := dummy.NewInmemDummyApp(logger)
 
-		selectorArgs := SelectorCreationFnArgs{
-			Peers: peers,
+		selectorArgs := SmartPeerSelectorCreationFnArgs{
 			LocalAddr: trans.LocalAddr(),
+			GetFlagTable: nil,
 		}
 		node := NewNode(conf,
 			id,
 			k,
+			peers,
 			store,
 			trans,
 			prox,
-			NewSmartPeerSelectorFromArgs,
+			NewSmartPeerSelectorWrapper,
 			selectorArgs)
 
 		if err := node.Init(); err != nil {
@@ -462,12 +463,12 @@ func recycleNode(oldNode *Node, logger *logrus.Logger, t *testing.T) *Node {
 	}
 	prox := dummy.NewInmemDummyApp(logger)
 
-	selectorArgs := SelectorCreationFnArgs{
-		Peers: ps,
+	selectorArgs := SmartPeerSelectorCreationFnArgs{
 		LocalAddr: trans.LocalAddr(),
+		GetFlagTable: nil,
 	}
-	newNode := NewNode(conf, id, key, store, trans, prox,
-		NewSmartPeerSelectorFromArgs, selectorArgs)
+	newNode := NewNode(conf, id, key, ps, store, trans, prox,
+		NewSmartPeerSelectorWrapper, selectorArgs)
 
 	if err := newNode.Init(); err != nil {
 		t.Fatal(err)

--- a/src/node/node_test.go
+++ b/src/node/node_test.go
@@ -59,10 +59,16 @@ func TestProcessSync(t *testing.T) {
 	}
 	defer peer0Trans.Close()
 
-	node0 := NewNode(config, ps[0].ID, keys[0], p,
+	selector0Args := SelectorCreationFnArgs{
+		Peers: p,
+		LocalAddr: peer0Trans.LocalAddr(),
+	}
+	node0 := NewNode(config, ps[0].ID, keys[0],
 		poset.NewInmemStore(p, config.CacheSize, nil),
 		peer0Trans,
-		dummy.NewInmemDummyApp(testLogger))
+		dummy.NewInmemDummyApp(testLogger),
+		NewSmartPeerSelectorFromArgs,
+		selector0Args)
 	if err := node0.Init(); err != nil {
 		t.Fatal(err)
 	}
@@ -77,10 +83,16 @@ func TestProcessSync(t *testing.T) {
 	}
 	defer peer1Trans.Close()
 
-	node1 := NewNode(config, ps[1].ID, keys[1], p,
+	selector1Args := SelectorCreationFnArgs{
+		Peers: p,
+		LocalAddr: peer1Trans.LocalAddr(),
+	}
+	node1 := NewNode(config, ps[1].ID, keys[1],
 		poset.NewInmemStore(p, config.CacheSize, nil),
 		peer1Trans,
-		dummy.NewInmemDummyApp(testLogger))
+		dummy.NewInmemDummyApp(testLogger),
+		NewSmartPeerSelectorFromArgs,
+		selector1Args)
 	if err := node1.Init(); err != nil {
 		t.Fatal(err)
 	}
@@ -164,10 +176,16 @@ func TestProcessEagerSync(t *testing.T) {
 	}
 	defer peer0Trans.Close()
 
-	node0 := NewNode(config, ps[0].ID, keys[0], p,
+	selector0Args := SelectorCreationFnArgs{
+		Peers: p,
+		LocalAddr: peer0Trans.LocalAddr(),
+	}
+	node0 := NewNode(config, ps[0].ID, keys[0],
 		poset.NewInmemStore(p, config.CacheSize, nil),
 		peer0Trans,
-		dummy.NewInmemDummyApp(testLogger))
+		dummy.NewInmemDummyApp(testLogger),
+		NewSmartPeerSelectorFromArgs,
+		selector0Args)
 	if err := node0.Init(); err != nil {
 		t.Fatal(err)
 	}
@@ -182,10 +200,16 @@ func TestProcessEagerSync(t *testing.T) {
 	}
 	defer peer1Trans.Close()
 
-	node1 := NewNode(config, ps[1].ID, keys[1], p,
+	selector1Args := SelectorCreationFnArgs{
+		Peers: p,
+		LocalAddr: peer1Trans.LocalAddr(),
+	}
+	node1 := NewNode(config, ps[1].ID, keys[1],
 		poset.NewInmemStore(p, config.CacheSize, nil),
 		peer1Trans,
-		dummy.NewInmemDummyApp(testLogger))
+		dummy.NewInmemDummyApp(testLogger),
+		NewSmartPeerSelectorFromArgs,
+		selector1Args)
 	if err := node1.Init(); err != nil {
 		t.Fatal(err)
 	}
@@ -248,10 +272,16 @@ func TestAddTransaction(t *testing.T) {
 	peer0Proxy := dummy.NewInmemDummyApp(testLogger)
 	defer peer0Trans.Close()
 
-	node0 := NewNode(TestConfig(t), ps[0].ID, keys[0], p,
+	selector0Args := SelectorCreationFnArgs{
+		Peers: p,
+		LocalAddr: peer0Trans.LocalAddr(),
+	}
+	node0 := NewNode(TestConfig(t), ps[0].ID, keys[0],
 		poset.NewInmemStore(p, config.CacheSize, nil),
 		peer0Trans,
-		peer0Proxy)
+		peer0Proxy,
+		NewSmartPeerSelectorFromArgs,
+		selector0Args)
 	if err := node0.Init(); err != nil {
 		t.Fatal(err)
 	}
@@ -267,10 +297,16 @@ func TestAddTransaction(t *testing.T) {
 	peer1Proxy := dummy.NewInmemDummyApp(testLogger)
 	defer peer1Trans.Close()
 
-	node1 := NewNode(TestConfig(t), ps[1].ID, keys[1], p,
+	selector1Args := SelectorCreationFnArgs{
+		Peers: p,
+		LocalAddr: peer1Trans.LocalAddr(),
+	}
+	node1 := NewNode(TestConfig(t), ps[1].ID, keys[1],
 		poset.NewInmemStore(p, config.CacheSize, nil),
 		peer1Trans,
-		peer1Proxy)
+		peer1Proxy,
+		NewSmartPeerSelectorFromArgs,
+		selector1Args)
 	if err := node1.Init(); err != nil {
 		t.Fatal(err)
 	}
@@ -370,13 +406,18 @@ func initNodes(keys []*ecdsa.PrivateKey,
 		}
 		prox := dummy.NewInmemDummyApp(logger)
 
+		selectorArgs := SelectorCreationFnArgs{
+			Peers: peers,
+			LocalAddr: trans.LocalAddr(),
+		}
 		node := NewNode(conf,
 			id,
 			k,
-			peers,
 			store,
 			trans,
-			prox)
+			prox,
+			NewSmartPeerSelectorFromArgs,
+			selectorArgs)
 
 		if err := node.Init(); err != nil {
 			t.Fatalf("failed to initialize node%d: %s", id, err)
@@ -421,7 +462,12 @@ func recycleNode(oldNode *Node, logger *logrus.Logger, t *testing.T) *Node {
 	}
 	prox := dummy.NewInmemDummyApp(logger)
 
-	newNode := NewNode(conf, id, key, ps, store, trans, prox)
+	selectorArgs := SelectorCreationFnArgs{
+		Peers: ps,
+		LocalAddr: trans.LocalAddr(),
+	}
+	newNode := NewNode(conf, id, key, store, trans, prox,
+		NewSmartPeerSelectorFromArgs, selectorArgs)
 
 	if err := newNode.Init(); err != nil {
 		t.Fatal(err)

--- a/src/node/peer_selector.go
+++ b/src/node/peer_selector.go
@@ -23,29 +23,27 @@ type RandomPeerSelector struct {
 }
 
 // SelectorCreationFnArgs specifies the union of possible arguments that can be extracted to create a variant of PeerSelector
-type SelectorCreationFnArgs struct {
-	GetFlagTable GetFlagTableFn
-	LocalAddr    string
-	Peers        *peers.Peers
-	PubKey       string
-}
+type SelectorCreationFnArgs interface {}
 
 // SelectorCreationFn declares the function signature to create variants of PeerSelector
-type SelectorCreationFn func(SelectorCreationFnArgs) PeerSelector
+type SelectorCreationFn func(*peers.Peers, interface{}) PeerSelector
+
+// RandomPeerSelectorCreationFnArgs arguments for RandomPeerSelector
+type RandomPeerSelectorCreationFnArgs struct {
+	LocalAddr    string
+}
 
 // NewRandomPeerSelector creates a new random peer selector
-func NewRandomPeerSelector(participants *peers.Peers, localAddr string) *RandomPeerSelector {
+func NewRandomPeerSelector(participants *peers.Peers, args RandomPeerSelectorCreationFnArgs) *RandomPeerSelector {
 	return &RandomPeerSelector{
-		localAddr: localAddr,
+		localAddr: args.LocalAddr,
 		peers:     participants,
 	}
 }
 
-// NewSmartPeerSelectorFromArgs creates RandomPeerSelector from SelectorCreationFnArgs
-func NewRandomPeerSelectorFromArgs(args SelectorCreationFnArgs) PeerSelector {
-	return NewRandomPeerSelector(
-		args.Peers,
-		args.LocalAddr)
+// NewRandomPeerSelectorWrapper implements SelectorCreationFn to allow dynamic creation of RandomPeerSelector ie NewNode
+func NewRandomPeerSelectorWrapper(participants *peers.Peers, args interface{}) PeerSelector {
+	return NewRandomPeerSelector(participants, args.(RandomPeerSelectorCreationFnArgs))
 }
 
 // Peers returns all known peers

--- a/src/node/peer_selector.go
+++ b/src/node/peer_selector.go
@@ -22,12 +22,30 @@ type RandomPeerSelector struct {
 	last      string
 }
 
+// SelectorCreationFnArgs specifies the union of possible arguments that can be extracted to create a variant of PeerSelector
+type SelectorCreationFnArgs struct {
+	GetFlagTable GetFlagTableFn
+	LocalAddr    string
+	Peers        *peers.Peers
+	PubKey       string
+}
+
+// SelectorCreationFn declares the function signature to create variants of PeerSelector
+type SelectorCreationFn func(SelectorCreationFnArgs) PeerSelector
+
 // NewRandomPeerSelector creates a new random peer selector
 func NewRandomPeerSelector(participants *peers.Peers, localAddr string) *RandomPeerSelector {
 	return &RandomPeerSelector{
 		localAddr: localAddr,
 		peers:     participants,
 	}
+}
+
+// NewSmartPeerSelectorFromArgs creates RandomPeerSelector from SelectorCreationFnArgs
+func NewRandomPeerSelectorFromArgs(args SelectorCreationFnArgs) PeerSelector {
+	return NewRandomPeerSelector(
+		args.Peers,
+		args.LocalAddr)
 }
 
 // Peers returns all known peers

--- a/src/node/peer_selector2.go
+++ b/src/node/peer_selector2.go
@@ -18,24 +18,25 @@ type SmartPeerSelector struct {
 	GetFlagTable GetFlagTableFn
 }
 
+// SmartPeerSelectorCreationFnArgs specifies the union of possible arguments that can be extracted to create a variant of PeerSelector
+type SmartPeerSelectorCreationFnArgs struct {
+	GetFlagTable GetFlagTableFn
+	LocalAddr    string
+}
+
 // NewSmartPeerSelector creates a new smart peer selection struct
-func NewSmartPeerSelector(participants *peers.Peers,
-	localAddr string,
-	GetFlagTable GetFlagTableFn) *SmartPeerSelector {
+func NewSmartPeerSelector(participants *peers.Peers, args SmartPeerSelectorCreationFnArgs) *SmartPeerSelector {
 
 	return &SmartPeerSelector{
-		localAddr:    localAddr,
+		localAddr:    args.LocalAddr,
 		peers:        participants,
-		GetFlagTable: GetFlagTable,
+		GetFlagTable: args.GetFlagTable,
 	}
 }
 
-// NewSmartPeerSelectorFromArgs creates SmartPeerSelector from SelectorCreationFnArgs
-func NewSmartPeerSelectorFromArgs(args SelectorCreationFnArgs) PeerSelector {
-	return NewSmartPeerSelector(
-		args.Peers,
-		args.PubKey,
-		args.GetFlagTable)
+// NewSmartPeerSelectorWrapper implements SelectorCreationFn to allow dynamic creation of SmartPeerSelector ie NewNode
+func NewSmartPeerSelectorWrapper(participants *peers.Peers, args interface{}) PeerSelector {
+	return NewSmartPeerSelector(participants, args.(SmartPeerSelectorCreationFnArgs))
 }
 
 // Peers returns all known peers

--- a/src/node/peer_selector2.go
+++ b/src/node/peer_selector2.go
@@ -7,24 +7,35 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/src/peers"
 )
 
+// GetFlagTableFn declares flag table function signature
+type GetFlagTableFn func() (map[string]int64, error)
+
 // SmartPeerSelector provides selection based on FlagTable of a randomly chosen undermined event
 type SmartPeerSelector struct {
 	peers        *peers.Peers
 	localAddr    string
 	last         string
-	GetFlagTable func() (map[string]int64, error)
+	GetFlagTable GetFlagTableFn
 }
 
 // NewSmartPeerSelector creates a new smart peer selection struct
 func NewSmartPeerSelector(participants *peers.Peers,
 	localAddr string,
-	GetFlagTable func() (map[string]int64, error)) *SmartPeerSelector {
+	GetFlagTable GetFlagTableFn) *SmartPeerSelector {
 
 	return &SmartPeerSelector{
 		localAddr:    localAddr,
 		peers:        participants,
 		GetFlagTable: GetFlagTable,
 	}
+}
+
+// NewSmartPeerSelectorFromArgs creates SmartPeerSelector from SelectorCreationFnArgs
+func NewSmartPeerSelectorFromArgs(args SelectorCreationFnArgs) PeerSelector {
+	return NewSmartPeerSelector(
+		args.Peers,
+		args.PubKey,
+		args.GetFlagTable)
 }
 
 // Peers returns all known peers

--- a/src/node/peer_selector2_test.go
+++ b/src/node/peer_selector2_test.go
@@ -16,9 +16,11 @@ func TestSmartSelectorEmpty(t *testing.T) {
 
 	ss := NewSmartPeerSelector(
 		fp,
-		"",
-		func() (map[string]int64, error) {
-			return nil, nil
+		SmartPeerSelectorCreationFnArgs{
+			LocalAddr: "",
+			GetFlagTable: func() (map[string]int64, error) {
+				return nil, nil
+			},
 		},
 	)
 
@@ -33,9 +35,11 @@ func TestSmartSelectorLocalAddrOnly(t *testing.T) {
 
 	ss := NewSmartPeerSelector(
 		fp,
-		fps[0].NetAddr,
-		func() (map[string]int64, error) {
-			return nil, nil
+		SmartPeerSelectorCreationFnArgs{
+			LocalAddr: fps[0].NetAddr,
+			GetFlagTable: func() (map[string]int64, error) {
+				return nil, nil
+			},
 		},
 	)
 
@@ -50,9 +54,11 @@ func TestSmartSelectorUsed(t *testing.T) {
 
 	ss := NewSmartPeerSelector(
 		fp,
-		fps[0].NetAddr,
-		func() (map[string]int64, error) {
-			return nil, nil
+		SmartPeerSelectorCreationFnArgs{
+			LocalAddr: fps[0].NetAddr,
+			GetFlagTable: func() (map[string]int64, error) {
+				return nil, nil
+			},
 		},
 	)
 
@@ -69,11 +75,13 @@ func TestSmartSelectorFlagged(t *testing.T) {
 
 	ss := NewSmartPeerSelector(
 		fp,
-		fps[0].NetAddr,
-		func() (map[string]int64, error) {
-			return map[string]int64{
-				fps[2].PubKeyHex: 1,
-			}, nil
+		SmartPeerSelectorCreationFnArgs{
+			LocalAddr: fps[0].NetAddr,
+			GetFlagTable: func() (map[string]int64, error) {
+				return map[string]int64{
+					fps[2].PubKeyHex: 1,
+				}, nil
+			},
 		},
 	)
 
@@ -90,14 +98,16 @@ func TestSmartSelectorGeneral(t *testing.T) {
 
 	ss := NewSmartPeerSelector(
 		fp,
-		fps[3].NetAddr,
-		func() (map[string]int64, error) {
-			return map[string]int64{
-				fps[0].PubKeyHex: 0,
-				fps[1].PubKeyHex: 0,
-				fps[2].PubKeyHex: 1,
-				fps[3].PubKeyHex: 0,
-			}, nil
+		SmartPeerSelectorCreationFnArgs{
+			LocalAddr: fps[3].NetAddr,
+			GetFlagTable: func() (map[string]int64, error) {
+				return map[string]int64{
+					fps[0].PubKeyHex: 0,
+					fps[1].PubKeyHex: 0,
+					fps[2].PubKeyHex: 1,
+					fps[3].PubKeyHex: 0,
+				}, nil
+			},
 		},
 	)
 
@@ -122,14 +132,18 @@ func BenchmarkSmartSelectorNext(b *testing.B) {
 
 	ss1 := NewSmartPeerSelector(
 		participants1,
-		fakeAddr(0),
-		func() (map[string]int64, error) {
-			return flagTable1, nil
+		SmartPeerSelectorCreationFnArgs{
+			LocalAddr: fakeAddr(0),
+			GetFlagTable: func() (map[string]int64, error) {
+				return flagTable1, nil
+			},
 		},
 	)
 	rnd := NewRandomPeerSelector(
 		participants2,
-		fakeAddr(0),
+		RandomPeerSelectorCreationFnArgs{
+			LocalAddr: fakeAddr(0),
+		},
 	)
 
 	b.ResetTimer()


### PR DESCRIPTION
Allow choosing specific peer selector type, like Smart/RandomPeerSelector, outside of NewNode function

Please check if what you want to add to `go-lachesis` list meets [quality standards](https://github.com/Fantom-foundation/go-lachesis/blob/master/CONTRIBUTING.md#quality-standard) before sending pull request.

**Please provide package links to:**

- github.com repo:
- godoc.org:
- goreportcard.com:
- coverage service link ([cover.run](https://cover.run/), [gocover](http://gocover.io/), [coveralls](https://coveralls.io/) etc.), example: `[![cover.run](https://cover.run/go/github.com/user/repository.svg?style=flat&tag=golang-1.10)](https://cover.run/go?tag=golang-1.10&repo=github.com%2Fuser%2Frepository)`

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order.
- [x] I have an appropriate description with correct grammar.
- [x] I know that this package was not listed before.
- [x] I have added godoc link to the repo and to my pull request.
- [x] I have added coverage service link to the repo and to my pull request.
- [x] I have added goreportcard link to the repo and to my pull request.
- [x] I have read [Contribution guidelines](https://github.com/Fantom-foundation/go-lachesis/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/Fantom-foundation/go-lachesis/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/Fantom-foundation/go-lachesis/blob/master/CONTRIBUTING.md#quality-standard).
