### PR TITLE
[*.go] Lint fixes; gofmt -s -w

### DIFF
--- a/cmd/dummy/commands/root.go
+++ b/cmd/dummy/commands/root.go
@@ -42,7 +42,7 @@ func runDummy(cmd *cobra.Command, args []string) error {
 	name := config.Name
 	address := config.ProxyAddr
 	//Create and run Dummy Socket Client
-	client, err := dummy.NewDummySocketClient(address, logger)
+	client, err := dummy.NewSocketClient(address, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/dummy_client/main.go
+++ b/cmd/dummy_client/main.go
@@ -68,7 +68,7 @@ func run(c *cli.Context) error {
 	}).Debug("RUN")
 
 	//Create and run Dummy Socket Client
-	client, err := dummy.NewDummySocketClient(address, logger)
+	client, err := dummy.NewSocketClient(address, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/lachesis/commands/config.go
+++ b/cmd/lachesis/commands/config.go
@@ -8,13 +8,13 @@ import (
 
 //CLIConfig contains configuration for the Run command
 type CLIConfig struct {
-	Lachesis   lachesis.LachesisConfig `mapstructure:",squash"`
-	ProxyAddr  string                  `mapstructure:"proxy-listen"`
-	ClientAddr string                  `mapstructure:"client-connect"`
-	Standalone bool                    `mapstructure:"standalone"`
-	Log2file   bool                    `mapstructure:"log2file"`
-	Pidfile    string                  `mapstructure:"pidfile"`
-	Syslog     bool                    `mapstructure:"syslog"`
+	Lachesis   lachesis.Config `mapstructure:",squash"`
+	ProxyAddr  string          `mapstructure:"proxy-listen"`
+	ClientAddr string          `mapstructure:"client-connect"`
+	Standalone bool            `mapstructure:"standalone"`
+	Log2file   bool            `mapstructure:"log2file"`
+	Pidfile    string          `mapstructure:"pidfile"`
+	Syslog     bool            `mapstructure:"syslog"`
 }
 
 //NewDefaultCLIConfig creates a CLIConfig with default values

--- a/cmd/lachesis/commands/run.go
+++ b/cmd/lachesis/commands/run.go
@@ -86,7 +86,7 @@ func runSingleLachesis(config *CLIConfig) error {
 		}
 		config.Lachesis.Proxy = p
 	} else {
-		p := dummy.NewInmemDummyApp(config.Lachesis.Logger)
+		p := dummy.NewInmemApp(config.Lachesis.Logger)
 		config.Lachesis.Proxy = p
 	}
 

--- a/cmd/network/commands/config.go
+++ b/cmd/network/commands/config.go
@@ -4,11 +4,11 @@ import "github.com/Fantom-foundation/go-lachesis/src/lachesis"
 
 //CLIConfig contains configuration for the Run command
 type CLIConfig struct {
-	Lachesis lachesis.LachesisConfig `mapstructure:",squash"`
-	NbNodes  int                     `mapstructure:"nodes"`
-	SendTxs  int                     `mapstructure:"send-txs"`
-	Stdin    bool                    `mapstructure:"stdin"`
-	Node     int                     `mapstructure:"node"`
+	Lachesis lachesis.Config `mapstructure:",squash"`
+	NbNodes  int             `mapstructure:"nodes"`
+	SendTxs  int             `mapstructure:"send-txs"`
+	Stdin    bool            `mapstructure:"stdin"`
+	Node     int             `mapstructure:"node"`
 }
 
 //NewDefaultCLIConfig creates a CLIConfig with default values

--- a/src/crypto/keys_test.go
+++ b/src/crypto/keys_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestFakeKeyGeneration(t *testing.T) {
-	assert := assert.New(t)
+	assertar := assert.New(t)
 
 	prev := make([]*common.PrivateKey, 10)
 	for i := 0; i < len(prev); i++ {
@@ -18,7 +18,7 @@ func TestFakeKeyGeneration(t *testing.T) {
 
 	for i := 0; i < len(prev); i++ {
 		again := GenerateFakeKey(i)
-		if !assert.Equal(prev[i], again) {
+		if !assertar.Equal(prev[i], again) {
 			return
 		}
 	}

--- a/src/dummy/client.go
+++ b/src/dummy/client.go
@@ -6,35 +6,35 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/src/proxy"
 )
 
-// DummyClient is a implementation of the dummy app. Lachesis and the
+// Client is a implementation of the dummy app. Lachesis and the
 // app run in separate processes and communicate through proxy
-type DummyClient struct {
+type Client struct {
 	logger        *logrus.Logger
 	state         proxy.App
 	lachesisProxy proxy.LachesisProxy
 }
 
-// NewInmemDummyApp constructor
-func NewInmemDummyApp(logger *logrus.Logger) proxy.AppProxy {
+// NewInmemApp constructor
+func NewInmemApp(logger *logrus.Logger) proxy.AppProxy {
 	state := NewState(logger)
 	return proxy.NewInmemAppProxy(state, logger)
 }
 
-// NewDummySocketClient constructor
-func NewDummySocketClient(addr string, logger *logrus.Logger) (*DummyClient, error) {
+// NewSocketClient constructor
+func NewSocketClient(addr string, logger *logrus.Logger) (*Client, error) {
 	lachesisProxy, err := proxy.NewGrpcLachesisProxy(addr, logger)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewDummyClient(lachesisProxy, nil, logger)
+	return NewClient(lachesisProxy, nil, logger)
 }
 
-// NewDummyClient instantiates an implementation of the dummy app
-func NewDummyClient(lachesisProxy proxy.LachesisProxy, handler proxy.App, logger *logrus.Logger) (c *DummyClient, err error) {
+// NewClient instantiates an implementation of the dummy app
+func NewClient(lachesisProxy proxy.LachesisProxy, handler proxy.App, logger *logrus.Logger) (c *Client, err error) {
 	// state := NewState(logger)
 
-	c = &DummyClient{
+	c = &Client{
 		logger:        logger,
 		state:         handler,
 		lachesisProxy: lachesisProxy,
@@ -79,6 +79,6 @@ func NewDummyClient(lachesisProxy proxy.LachesisProxy, handler proxy.App, logger
 }
 
 // SubmitTx sends a transaction to node via proxy
-func (c *DummyClient) SubmitTx(tx []byte) error {
+func (c *Client) SubmitTx(tx []byte) error {
 	return c.lachesisProxy.SubmitTx(tx)
 }

--- a/src/hash/hash.go
+++ b/src/hash/hash.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	// HashLength is the expected length of the hash
-	HashLength = sha256.Size
+	// Size is the expected length of the hash
+	Size = sha256.Size
 )
 
 var (
@@ -22,7 +22,7 @@ var (
 )
 
 // Hash represents the 32 byte Keccak256 hash of arbitrary data.
-type Hash [HashLength]byte
+type Hash [Size]byte
 
 func Of(data ...[]byte) (hash Hash) {
 	d := sha3.NewKeccak256()
@@ -125,8 +125,8 @@ func (h *Hash) Scan(src interface{}) error {
 	if !ok {
 		return fmt.Errorf("can't scan %T into Hash", src)
 	}
-	if len(srcB) != HashLength {
-		return fmt.Errorf("can't scan []byte of len %d into Hash, want %d", len(srcB), HashLength)
+	if len(srcB) != Size {
+		return fmt.Errorf("can't scan []byte of len %d into Hash, want %d", len(srcB), Size)
 	}
 	copy(h[:], srcB)
 	return nil

--- a/src/inter/common_test.go
+++ b/src/inter/common_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestASCIIschemeToDAG(t *testing.T) {
-	assert := assert.New(t)
+	assertar := assert.New(t)
 
 	nodes, events, names := ASCIIschemeToDAG(`
 a00 b00   c00 d00
@@ -55,10 +55,10 @@ a04 ╫ ─ ─ ╬  ╝║   ║
 		"e00": {"", "d02"},
 	}
 
-	if !assert.Equal(5, len(nodes), "node count") {
+	if !assertar.Equal(5, len(nodes), "node count") {
 		return
 	}
-	if !assert.Equal(len(expected), len(names), "event count") {
+	if !assertar.Equal(len(expected), len(names), "event count") {
 		return
 	}
 
@@ -71,15 +71,15 @@ a04 ╫ ─ ─ ╬  ╝║   ║
 
 	for eName, e := range names {
 		parents := expected[eName]
-		if !assert.Equal(len(parents), len(e.Parents), "at event "+eName) {
+		if !assertar.Equal(len(parents), len(e.Parents), "at event "+eName) {
 			return
 		}
 		for _, pName := range parents {
-			hash := hash.ZeroEvent
+			zeroEvent := hash.ZeroEvent
 			if pName != "" {
-				hash = names[pName].Hash()
+				zeroEvent = names[pName].Hash()
 			}
-			if !e.Parents.Contains(hash) {
+			if !e.Parents.Contains(zeroEvent) {
 				t.Fatalf("%s has no parent %s", eName, pName)
 			}
 		}

--- a/src/inter/event.go
+++ b/src/inter/event.go
@@ -30,9 +30,9 @@ type Event struct {
 
 // SignBy signs event by private key.
 func (e *Event) SignBy(priv *common.PrivateKey) error {
-	hash := e.Hash()
+	eventHash := e.Hash()
 
-	R, S, err := priv.Sign(hash.Bytes())
+	R, S, err := priv.Sign(eventHash.Bytes())
 	if err != nil {
 		return err
 	}
@@ -51,13 +51,13 @@ func (e *Event) Verify(pubKey *common.PublicKey) bool {
 		return false
 	}
 
-	hash := e.Hash()
+	eventHash := e.Hash()
 	r, s, err := crypto.DecodeSignature(string(e.Sign))
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	return pubKey.Verify(hash.Bytes(), r, s)
+	return pubKey.Verify(eventHash.Bytes(), r, s)
 }
 
 // Hash calcs hash of event.

--- a/src/inter/event_test.go
+++ b/src/inter/event_test.go
@@ -11,21 +11,21 @@ import (
 )
 
 func TestEventSerialization(t *testing.T) {
-	assert := assert.New(t)
+	assertar := assert.New(t)
 
 	events := FakeFuzzingEvents()
 	for _, e0 := range events {
 		buf, err := proto.Marshal(e0.ToWire())
-		assert.NoError(err)
+		assertar.NoError(err)
 
 		w := &wire.Event{}
 		err = proto.Unmarshal(buf, w)
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			break
 		}
 		e1 := WireToEvent(w)
 
-		if !assert.Equal(e0, e1) {
+		if !assertar.Equal(e0, e1) {
 			break
 		}
 	}

--- a/src/inter/ordering/event_buffer.go
+++ b/src/inter/ordering/event_buffer.go
@@ -77,10 +77,10 @@ func EventBuffer(
 		process(e.Event)
 
 		// now child events may become complete, check it again
-		for hash, child := range incompletes {
+		for hash_, child := range incompletes {
 			if parent, ok := child.parents[e.Hash()]; ok && parent == nil {
 				child.parents[e.Hash()] = e.Event
-				delete(incompletes, hash)
+				delete(incompletes, hash_)
 				onNewEvent(child)
 			}
 		}
@@ -96,8 +96,8 @@ func EventBuffer(
 			Event:   e,
 			parents: make(map[hash.Event]*inter.Event, len(e.Parents)),
 		}
-		for hash := range e.Parents {
-			w.parents[hash] = nil
+		for parentHash := range e.Parents {
+			w.parents[parentHash] = nil
 		}
 		onNewEvent(w)
 	}

--- a/src/lachesis/lachesis.go
+++ b/src/lachesis/lachesis.go
@@ -20,7 +20,7 @@ import (
 
 // Lachesis struct
 type Lachesis struct {
-	Config    *LachesisConfig
+	Config    *Config
 	Node      *node.Node
 	Transport peer.SyncPeer
 	Store     poset.Store
@@ -29,7 +29,7 @@ type Lachesis struct {
 }
 
 // NewLachesis constructor
-func NewLachesis(config *LachesisConfig) *Lachesis {
+func NewLachesis(config *Config) *Lachesis {
 	engine := &Lachesis{
 		Config: config,
 	}

--- a/src/lachesis/lachesis_config.go
+++ b/src/lachesis/lachesis_config.go
@@ -17,7 +17,7 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/src/proxy"
 )
 
-type LachesisConfig struct {
+type Config struct {
 	DataDir     string `mapstructure:"datadir"`
 	BindAddr    string `mapstructure:"listen"`
 	ServiceAddr string `mapstructure:"service-listen"`
@@ -41,8 +41,8 @@ type LachesisConfig struct {
 	TestDelay uint64 `mapstructure:"test_delay"`
 }
 
-func NewDefaultConfig() *LachesisConfig {
-	config := &LachesisConfig{
+func NewDefaultConfig() *Config {
+	config := &Config{
 		DataDir:     DefaultDataDir(),
 		BindAddr:    ":1337",
 		ServiceAddr: ":8000",
@@ -80,7 +80,7 @@ func DefaultBadgerDir() string {
 	return ""
 }
 
-func (c *LachesisConfig) BadgerDir() string {
+func (c *Config) BadgerDir() string {
 	return filepath.Join(c.DataDir, "badger_db")
 }
 

--- a/src/logger/logger.go
+++ b/src/logger/logger.go
@@ -2,7 +2,7 @@ package logger
 
 import (
 	"sync"
-	
+
 	"github.com/evalphobia/logrus_sentry"
 	"github.com/sirupsen/logrus"
 )
@@ -14,29 +14,29 @@ var (
 
 // SetDSN for sentry logger
 func SetDSN(value string) {
-		// If DSN is empty, we don't create new hook.
-		// Otherwise we'll the same error message for each new log.
-		if value == "" {
-			log.Warn("Sentry client DSN is empty")
-			return
-		}
+	// If DSN is empty, we don't create new hook.
+	// Otherwise we'll the same error message for each new log.
+	if value == "" {
+		log.Warn("Sentry client DSN is empty")
+		return
+	}
 
-		hook, err := logrus_sentry.NewSentryHook(value, []logrus.Level{
-			logrus.PanicLevel,
-			logrus.FatalLevel,
-			logrus.ErrorLevel,
-			logrus.WarnLevel,
-			logrus.InfoLevel,
-			logrus.DebugLevel,
-			logrus.TraceLevel,
-		})
+	hook, err := logrus_sentry.NewSentryHook(value, []logrus.Level{
+		logrus.PanicLevel,
+		logrus.FatalLevel,
+		logrus.ErrorLevel,
+		logrus.WarnLevel,
+		logrus.InfoLevel,
+		logrus.DebugLevel,
+		logrus.TraceLevel,
+	})
 
-		if err != nil {
-			log.Warn("Probably Sentry host is not running.", err)
-			return
-		}
+	if err != nil {
+		log.Warn("Probably Sentry host is not running.", err)
+		return
+	}
 
-		log.Hooks.Add(hook)
+	log.Hooks.Add(hook)
 }
 
 // Init sets or creates logger instance.

--- a/src/mobile/mobile_config.go
+++ b/src/mobile/mobile_config.go
@@ -1,7 +1,7 @@
 package mobile
 
-// MobileConfig stores all the configuration information for a mobile node
-type MobileConfig struct {
+// Config stores all the configuration information for a mobile node
+type Config struct {
 	Heartbeat  int    //heartbeat timeout in milliseconds
 	TCPTimeout int    //TCP timeout in milliseconds
 	MaxPool    int    //Max number of pooled connections
@@ -18,9 +18,9 @@ func NewMobileConfig(heartbeat int,
 	cacheSize int,
 	syncLimit int,
 	storeType string,
-	storePath string) *MobileConfig {
+	storePath string) *Config {
 
-	return &MobileConfig{
+	return &Config{
 		Heartbeat:  heartbeat,
 		TCPTimeout: tcpTimeout,
 		MaxPool:    maxPool,
@@ -31,9 +31,9 @@ func NewMobileConfig(heartbeat int,
 	}
 }
 
-// DefaultMobileConfig sets the default config
-func DefaultMobileConfig() *MobileConfig {
-	return &MobileConfig{
+// DefaultConfig sets the default config
+func DefaultConfig() *Config {
+	return &Config{
 		Heartbeat:  1000,
 		TCPTimeout: 1000,
 		MaxPool:    2,

--- a/src/mobile/node.go
+++ b/src/mobile/node.go
@@ -27,7 +27,7 @@ func New(privKey string,
 	participants *peers.Peers,
 	commitHandler CommitHandler,
 	exceptionHandler ExceptionHandler,
-	config *MobileConfig) *Node {
+	config *Config) *Node {
 
 	lachesisConfig := lachesis.NewDefaultConfig()
 

--- a/src/node/node_test.go
+++ b/src/node/node_test.go
@@ -123,7 +123,7 @@ func createNode(t *testing.T, logger *logrus.Logger, config *Config,
 	trans peer.SyncPeer, localAddr string, run bool) *Node {
 
 	db := poset.NewInmemStore(participants, config.CacheSize, nil)
-	app := dummy.NewInmemDummyApp(logger)
+	app := dummy.NewInmemApp(logger)
 
 	selectorArgs := SmartPeerSelectorCreationFnArgs{
 		LocalAddr:    localAddr,
@@ -260,7 +260,7 @@ func recycleNode(oldNode *Node, logger *logrus.Logger, t *testing.T) *Node {
 		2, createFu, network.CreateListener)
 	defer transportClose(t, trans)
 
-	prox := dummy.NewInmemDummyApp(logger)
+	prox := dummy.NewInmemApp(logger)
 
 	selectorArgs := SmartPeerSelectorCreationFnArgs{
 		LocalAddr:    p[0].NetAddr,

--- a/src/poset/badger_store.go
+++ b/src/poset/badger_store.go
@@ -531,9 +531,9 @@ func (s *BadgerStore) dbParticipantEvents(participant string, skip int64) (res E
 		item, errr := txn.Get(key)
 		for errr == nil {
 			errrr := item.Value(func(v []byte) error {
-				var hash EventHash
-				hash.Set(v)
-				res = append(res, hash)
+				var eventHash EventHash
+				eventHash.Set(v)
+				res = append(res, eventHash)
 				return nil
 			})
 			if errrr != nil {

--- a/src/poset/inmem_store.go
+++ b/src/poset/inmem_store.go
@@ -143,9 +143,9 @@ func (s *InmemStore) RootsBySelfParent() map[EventHash]Root {
 	if s.rootsBySelfParent == nil {
 		s.rootsBySelfParent = make(map[EventHash]Root)
 		for _, root := range s.rootsByParticipant {
-			var hash EventHash
-			hash.Set(root.SelfParent.Hash)
-			s.rootsBySelfParent[hash] = root
+			var eventHash EventHash
+			eventHash.Set(root.SelfParent.Hash)
+			s.rootsBySelfParent[eventHash] = root
 		}
 	}
 	return s.rootsBySelfParent

--- a/src/poslachesis/cli/command/common.go
+++ b/src/poslachesis/cli/command/common.go
@@ -15,10 +15,10 @@ func makeCtrlProxy(cmd *cobra.Command) (proxy.NodeProxy, error) {
 		return nil, err
 	}
 
-	proxy, err := proxy.NewGrpcNodeProxy(addr, nil)
+	grpcProxy, err := proxy.NewGrpcNodeProxy(addr, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return proxy, nil
+	return grpcProxy, nil
 }

--- a/src/poslachesis/cli/main_test.go
+++ b/src/poslachesis/cli/main_test.go
@@ -35,7 +35,7 @@ func TestApp(t *testing.T) {
 	peer := hash.FakePeer()
 
 	t.Run("id", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		node.EXPECT().
 			GetID().
@@ -45,15 +45,15 @@ func TestApp(t *testing.T) {
 		defer out.Reset()
 
 		err := app.Execute()
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			return
 		}
 
-		assert.Contains(out.String(), peer.Hex())
+		assertar.Contains(out.String(), peer.Hex())
 	})
 
 	t.Run("balance", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		amount := rand.Uint64()
 
@@ -68,16 +68,16 @@ func TestApp(t *testing.T) {
 		defer out.Reset()
 
 		err := app.Execute()
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			return
 		}
 
 		expect := fmt.Sprintf("balance of %s == %d", peer.Hex(), amount)
-		assert.Contains(out.String(), expect)
+		assertar.Contains(out.String(), expect)
 	})
 
 	t.Run("balance with peer flag", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		amount := rand.Uint64()
 
@@ -93,16 +93,16 @@ func TestApp(t *testing.T) {
 		defer out.Reset()
 
 		err := app.Execute()
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			return
 		}
 
 		expect := fmt.Sprintf("balance of %s == %d", otherPeer.Hex(), amount)
-		assert.Contains(out.String(), expect)
+		assertar.Contains(out.String(), expect)
 	})
 
 	t.Run("info not found", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		hex := "0x00000"
 		consensus.EXPECT().
@@ -116,15 +116,15 @@ func TestApp(t *testing.T) {
 		defer out.Reset()
 
 		err := app.Execute()
-		if !assert.Error(err) {
+		if !assertar.Error(err) {
 			return
 		}
 
-		assert.Contains(out.String(), "transaction not found")
+		assertar.Contains(out.String(), "transaction not found")
 	})
 
 	t.Run("info ok", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		h := hash.FakeTransaction()
 		amount := rand.Uint64()
@@ -146,11 +146,11 @@ func TestApp(t *testing.T) {
 		defer out.Reset()
 
 		err := app.Execute()
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			return
 		}
 
-		assert.Contains(
+		assertar.Contains(
 			out.String(),
 			fmt.Sprintf(
 				"transfer %d to %s",
@@ -161,21 +161,21 @@ func TestApp(t *testing.T) {
 	})
 
 	t.Run("transfer missing flags", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		app.SetArgs([]string{"transfer"})
 		defer out.Reset()
 
 		err := app.Execute()
-		if !assert.Error(err) {
+		if !assertar.Error(err) {
 			return
 		}
 
-		assert.Contains(out.String(), "required flag(s) \"amount\", \"index\", \"receiver\" not set")
+		assertar.Contains(out.String(), "required flag(s) \"amount\", \"index\", \"receiver\" not set")
 	})
 
 	t.Run("transfer", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		amount := rand.Uint64()
 
@@ -198,15 +198,15 @@ func TestApp(t *testing.T) {
 		defer out.Reset()
 
 		err := app.Execute()
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			return
 		}
 
-		assert.Contains(out.String(), h.Hex())
+		assertar.Contains(out.String(), h.Hex())
 	})
 
 	t.Run("log-level one argument", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		app.SetArgs([]string{
 			"log-level",
@@ -214,15 +214,15 @@ func TestApp(t *testing.T) {
 		defer out.Reset()
 
 		err := app.Execute()
-		if !assert.Error(err) {
+		if !assertar.Error(err) {
 			return
 		}
 
-		assert.Contains(out.String(), "expected exactly one argument")
+		assertar.Contains(out.String(), "expected exactly one argument")
 	})
 
 	t.Run("log-level ok", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		app.SetArgs([]string{
 			"log-level",
@@ -231,10 +231,10 @@ func TestApp(t *testing.T) {
 		defer out.Reset()
 
 		err := app.Execute()
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			return
 		}
 
-		assert.Contains(out.String(), "ok")
+		assertar.Contains(out.String(), "ok")
 	})
 }

--- a/src/posnode/api/wire_test.go
+++ b/src/posnode/api/wire_test.go
@@ -72,7 +72,7 @@ func testGRPC(t *testing.T, bind, from string, listen network.ListenFunc, opts .
 	defer server.Stop()
 
 	t.Run("authorized", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		opts := append(opts,
 			grpc.WithInsecure(),
@@ -87,36 +87,36 @@ func testGRPC(t *testing.T, bind, from string, listen network.ListenFunc, opts .
 		// SyncEvents() rpc
 		id1, ctx1 := ServerPeerID(nil)
 		_, err = client.SyncEvents(ctx1, &KnownEvents{})
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			return
 		}
-		if !assert.Equal(serverID, *id1) {
+		if !assertar.Equal(serverID, *id1) {
 			return
 		}
 
 		// GetEvent() rpc
 		id2, ctx2 := ServerPeerID(nil)
 		_, err = client.GetEvent(ctx2, &EventRequest{})
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			return
 		}
-		if !assert.Equal(serverID, *id2) {
+		if !assertar.Equal(serverID, *id2) {
 			return
 		}
 
 		// GetPeerInfo() rpc
 		id3, ctx3 := ServerPeerID(nil)
 		_, err = client.GetPeerInfo(ctx3, &PeerRequest{})
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			return
 		}
-		if !assert.Equal(serverID, *id3) {
+		if !assertar.Equal(serverID, *id3) {
 			return
 		}
 	})
 
 	t.Run("unauthorized client", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		opts := append(opts,
 			grpc.WithInsecure(),
@@ -130,30 +130,30 @@ func testGRPC(t *testing.T, bind, from string, listen network.ListenFunc, opts .
 		// SyncEvents() rpc
 		id1, ctx1 := ServerPeerID(nil)
 		_, err = client.SyncEvents(ctx1, &KnownEvents{})
-		if !assert.Error(err) {
+		if !assertar.Error(err) {
 			return
 		}
-		if !assert.Equal(hash.EmptyPeer, *id1) {
+		if !assertar.Equal(hash.EmptyPeer, *id1) {
 			return
 		}
 
 		// GetEvent() rpc
 		id2, ctx2 := ServerPeerID(nil)
 		_, err = client.GetEvent(ctx2, &EventRequest{})
-		if !assert.Error(err) {
+		if !assertar.Error(err) {
 			return
 		}
-		if !assert.Equal(hash.EmptyPeer, *id2) {
+		if !assertar.Equal(hash.EmptyPeer, *id2) {
 			return
 		}
 
 		// GetPeerInfo() rpc
 		id3, ctx3 := ServerPeerID(nil)
 		_, err = client.GetPeerInfo(ctx3, &PeerRequest{})
-		if !assert.Error(err) {
+		if !assertar.Error(err) {
 			return
 		}
-		if !assert.Equal(hash.EmptyPeer, *id3) {
+		if !assertar.Equal(hash.EmptyPeer, *id3) {
 			return
 		}
 	})

--- a/src/posnode/client_test.go
+++ b/src/posnode/client_test.go
@@ -42,34 +42,34 @@ func TestClient(t *testing.T) {
 	}
 
 	t.Run("1st-connection", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		pong, err := ping(t)
-		_ = assert.NoError(err) && assert.NotNil(pong)
+		_ = assertar.NoError(err) && assertar.NotNil(pong)
 	})
 
 	t.Run("2nd-connection", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		pong, err := ping(t)
-		_ = assert.NoError(err) && assert.NotNil(pong)
+		_ = assertar.NoError(err) && assertar.NotNil(pong)
 	})
 
 	t.Run("Re-connection 1", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		server.StopService()
 		server.StartService()
 		pong, err := ping(t)
 		// both results (err or not) are acceptable here
-		_ = assert.NotEqual(err == nil, api.IsProtoEmpty(&pong), "inconsistent result")
+		_ = assertar.NotEqual(err == nil, api.IsProtoEmpty(&pong), "inconsistent result")
 	})
 
 	t.Run("Re-connection 2", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		pong, err := ping(t)
-		_ = assert.NoError(err) && assert.NotNil(pong)
+		_ = assertar.NoError(err) && assertar.NotNil(pong)
 	})
 
 	// TODO: test the all situations.

--- a/src/posnode/discovery_test.go
+++ b/src/posnode/discovery_test.go
@@ -27,27 +27,27 @@ func TestDiscoveryPeer(t *testing.T) {
 	node2.initPeers()
 
 	t.Run("ask for unknown", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		unknown := hash.FakePeer()
 		node2.AskPeerInfo(node1.host, &unknown)
 
 		peer := store2.GetPeer(unknown)
-		assert.Nil(peer)
+		assertar.Nil(peer)
 	})
 
 	t.Run("ask for himself", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		unknown := node1.ID
 		node2.AskPeerInfo(node1.host, &unknown)
 
 		peer := store2.GetPeer(unknown)
-		assert.Equal(node1.AsPeer(), peer)
+		assertar.Equal(node1.AsPeer(), peer)
 	})
 
 	t.Run("ask for known unreachable", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		known := FakePeer("unreachable")
 		store1.SetPeer(known)
@@ -55,11 +55,11 @@ func TestDiscoveryPeer(t *testing.T) {
 		node2.AskPeerInfo(node1.host, &known.ID)
 
 		peer := store2.GetPeer(known.ID)
-		assert.Nil(peer)
+		assertar.Nil(peer)
 	})
 
 	t.Run("ask for known invalid", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		known := InvalidPeer("invalid")
 		store1.SetPeer(known)
@@ -67,12 +67,12 @@ func TestDiscoveryPeer(t *testing.T) {
 		node2.AskPeerInfo(node1.host, &known.ID)
 
 		peer := store2.GetPeer(known.ID)
-		assert.Nil(peer)
+		assertar.Nil(peer)
 	})
 }
 
 func TestDiscoveryHost(t *testing.T) {
-	assert := assert.New(t)
+	assertar := assert.New(t)
 
 	// node 1
 	store1 := NewMemStore()
@@ -91,7 +91,7 @@ func TestDiscoveryHost(t *testing.T) {
 
 	node1.AskPeerInfo(node2.Host(), nil)
 
-	assert.Equal(
+	assertar.Equal(
 		node2.ID,
 		node1.peers.Snapshot()[0])
 
@@ -99,7 +99,7 @@ func TestDiscoveryHost(t *testing.T) {
 	case <-nodeDiscoveryFinish(node2):
 	case <-time.After(time.Second):
 	}
-	assert.Equal(
+	assertar.Equal(
 		node1.ID,
 		node2.peers.Snapshot()[0])
 }

--- a/src/posnode/emitter_test.go
+++ b/src/posnode/emitter_test.go
@@ -24,7 +24,7 @@ func TestAddInternalTxn(t *testing.T) {
 	peer := hash.FakePeer()
 
 	t.Run("very 1st add", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		tx := inter.InternalTransaction{
 			Index:    1,
@@ -33,15 +33,15 @@ func TestAddInternalTxn(t *testing.T) {
 		}
 
 		_, err := node.AddInternalTxn(tx)
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			return
 		}
 		// TODO: check when implemented
-		//assert.Equal(expect, h.Hex())
+		//assertar.Equal(expect, h.Hex())
 	})
 
 	t.Run("very 2nd add", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		tx := inter.InternalTransaction{
 			Index:    2,
@@ -50,7 +50,7 @@ func TestAddInternalTxn(t *testing.T) {
 		}
 
 		_, err := node.AddInternalTxn(tx)
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			return
 		}
 		// TODO: check when implemented
@@ -72,77 +72,77 @@ func TestEmit(t *testing.T) {
 	events := make([]*inter.Event, 4)
 
 	t.Run("very 1st event", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 		// node1 has no candidates to parent
 		tx := []byte("12345")
 		node1.AddExternalTxn(tx)
 
 		events[0] = node1.EmitEvent()
 
-		assert.Equal(
+		assertar.Equal(
 			uint64(1),
 			events[0].Index)
-		assert.Equal(
+		assertar.Equal(
 			inter.Timestamp(1),
 			events[0].LamportTime)
-		assert.Equal(
+		assertar.Equal(
 			hash.NewEvents(hash.ZeroEvent),
 			events[0].Parents)
-		assert.Equal(
+		assertar.Equal(
 			[][]byte{tx},
 			events[0].ExternalTransactions)
 	})
 
 	t.Run("1st event", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 		// node2 got event0
 		node2.onNewEvent(events[0])
 
 		events[1] = node2.EmitEvent()
 
-		assert.Equal(
+		assertar.Equal(
 			uint64(1),
 			events[1].Index)
-		assert.Equal(
+		assertar.Equal(
 			inter.Timestamp(2),
 			events[1].LamportTime)
-		assert.Equal(
+		assertar.Equal(
 			hash.NewEvents(hash.ZeroEvent, events[0].Hash()),
 			events[1].Parents)
 	})
 
 	t.Run("2nd event", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 		// node1 got event1
 		node1.onNewEvent(events[1])
 
 		events[2] = node1.EmitEvent()
 
-		assert.Equal(
+		assertar.Equal(
 			uint64(2),
 			events[2].Index)
-		assert.Equal(
+		assertar.Equal(
 			inter.Timestamp(3),
 			events[2].LamportTime)
-		assert.Equal(
+		assertar.Equal(
 			hash.NewEvents(events[0].Hash(), events[1].Hash()),
 			events[2].Parents)
 	})
 
 	t.Run("3rd event", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 		// node1 has no new parents
 		// TODO: what about skip event creation?
 
 		events[3] = node1.EmitEvent()
 
-		assert.Equal(
+		assertar.Equal(
 			uint64(3),
 			events[3].Index)
-		assert.Equal(
+		assertar.Equal(
 			inter.Timestamp(4),
 			events[3].LamportTime)
-		assert.Equal(
+		assertar.Equal(
 			hash.NewEvents(events[2].Hash()),
 			events[3].Parents)
 	})

--- a/src/posnode/gossip_test.go
+++ b/src/posnode/gossip_test.go
@@ -33,9 +33,9 @@ func TestGossip(t *testing.T) {
 	node2.EmitEvent()
 
 	t.Run("before", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
-		assert.Equal(
+		assertar.Equal(
 			map[hash.Peer]uint64{
 				node1.ID: 1,
 				node2.ID: 0,
@@ -43,7 +43,7 @@ func TestGossip(t *testing.T) {
 			node1.knownEvents(),
 			"node1 knows their event only")
 
-		assert.Equal(
+		assertar.Equal(
 			map[hash.Peer]uint64{
 				node1.ID: 0,
 				node2.ID: 1,
@@ -53,10 +53,10 @@ func TestGossip(t *testing.T) {
 	})
 
 	t.Run("after 1-2", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 		node1.syncWithPeer(node2.AsPeer())
 
-		assert.Equal(
+		assertar.Equal(
 			map[hash.Peer]uint64{
 				node1.ID: 1,
 				node2.ID: 1,
@@ -64,7 +64,7 @@ func TestGossip(t *testing.T) {
 			node1.knownEvents(),
 			"node1 knows last event of node2")
 
-		assert.Equal(
+		assertar.Equal(
 			map[hash.Peer]uint64{
 				node1.ID: 0,
 				node2.ID: 1,
@@ -73,14 +73,14 @@ func TestGossip(t *testing.T) {
 			"node2 still knows their event only")
 
 		e2 := node1.store.GetEventHash(node2.ID, 1)
-		assert.NotNil(e2, "event of node2 is in db")
+		assertar.NotNil(e2, "event of node2 is in db")
 	})
 
 	t.Run("after 2-1", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 		node2.syncWithPeer(node1.AsPeer())
 
-		assert.Equal(
+		assertar.Equal(
 			map[hash.Peer]uint64{
 				node1.ID: 1,
 				node2.ID: 1,
@@ -88,7 +88,7 @@ func TestGossip(t *testing.T) {
 			node1.knownEvents(),
 			"node1 still knows event of node2")
 
-		assert.Equal(
+		assertar.Equal(
 			map[hash.Peer]uint64{
 				node1.ID: 1,
 				node2.ID: 1,
@@ -97,7 +97,7 @@ func TestGossip(t *testing.T) {
 			"node2 knows last event of node1")
 
 		e1 := node2.store.GetEventHash(node1.ID, 1)
-		assert.NotNil(e1, "event of node1 is in db")
+		assertar.NotNil(e1, "event of node1 is in db")
 	})
 
 }
@@ -127,9 +127,9 @@ func TestMissingParents(t *testing.T) {
 	node1.EmitEvent()
 
 	t.Run("before sync", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
-		assert.Equal(
+		assertar.Equal(
 			map[hash.Peer]uint64{
 				node1.ID: 3,
 				node2.ID: 0,
@@ -137,7 +137,7 @@ func TestMissingParents(t *testing.T) {
 			node1.knownEvents(),
 			"node1 knows their event only")
 
-		assert.Equal(
+		assertar.Equal(
 			map[hash.Peer]uint64{
 				node1.ID: 0,
 				node2.ID: 0,
@@ -148,7 +148,7 @@ func TestMissingParents(t *testing.T) {
 
 	// Note: we cannot use syncWithPeer here because we need custom iterator for missing some events.
 	t.Run("sync", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		peer := node1.AsPeer()
 		client, _, _, err := node2.ConnectTo(peer)
@@ -190,7 +190,7 @@ func TestMissingParents(t *testing.T) {
 		// Download missings
 		node2.checkParents(client, peer, parents)
 
-		assert.Equal(
+		assertar.Equal(
 			map[hash.Peer]uint64{
 				node1.ID: 3,
 				node2.ID: 0,
@@ -198,7 +198,7 @@ func TestMissingParents(t *testing.T) {
 			node1.knownEvents(),
 			"node1 still knows their event only")
 
-		assert.Equal(
+		assertar.Equal(
 			map[hash.Peer]uint64{
 				node1.ID: 3,
 				node2.ID: 0,
@@ -207,13 +207,13 @@ func TestMissingParents(t *testing.T) {
 			"node2 knows last event of node1")
 
 		e1 := node2.store.GetEventHash(node1.ID, 1)
-		assert.NotNil(e1, "event of node1 is in db")
+		assertar.NotNil(e1, "event of node1 is in db")
 
 		e2 := node2.store.GetEventHash(node1.ID, 2)
-		assert.NotNil(e2, "event of node1 is in db")
+		assertar.NotNil(e2, "event of node1 is in db")
 
 		e3 := node2.store.GetEventHash(node1.ID, 3)
-		assert.NotNil(e3, "event of node1 is in db")
+		assertar.NotNil(e3, "event of node1 is in db")
 	})
 }
 
@@ -232,19 +232,19 @@ func TestPeerPriority(t *testing.T) {
 	node.initPeers()
 
 	t.Run("First selection after bootstrap", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		peer := node.NextForGossip()
 		defer node.FreePeer(peer)
 
-		assert.Equal(
+		assertar.Equal(
 			peer1.Host,
 			peer.Host,
 			"node1 should select first top node without sort")
 	})
 
 	t.Run("Select last successful peer", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		node.ConnectOK(peer1)
 		store.SetPeer(peer2)
@@ -253,28 +253,28 @@ func TestPeerPriority(t *testing.T) {
 		peer := node.NextForGossip()
 		defer node.FreePeer(peer)
 
-		assert.Equal(
+		assertar.Equal(
 			peer2,
 			peer,
 			"node1 should select peer2 as first successful peer")
 	})
 
 	t.Run("Select last but one successful peer", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		node.ConnectFail(peer2, nil)
 
 		peer := node.NextForGossip()
 		defer node.FreePeer(peer)
 
-		assert.Equal(
+		assertar.Equal(
 			peer1,
 			peer,
 			"should select peer1 as last successful peer")
 	})
 
 	t.Run("If all connection was failed -> select with earliest timestamp", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		node.ConnectOK(peer1)
 		node.ConnectFail(peer1, nil)
@@ -283,14 +283,14 @@ func TestPeerPriority(t *testing.T) {
 		peer := node.NextForGossip()
 		defer node.FreePeer(peer)
 
-		assert.Equal(
+		assertar.Equal(
 			peer1,
 			peer,
 			"should select peer1 as last failed peer")
 	})
 
 	t.Run("If all connection was successful -> select first in top without sort", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		node.ConnectOK(peer1)
 		node.ConnectOK(peer2)
@@ -298,7 +298,7 @@ func TestPeerPriority(t *testing.T) {
 		peer := node.NextForGossip()
 		defer node.FreePeer(peer)
 
-		assert.Equal(
+		assertar.Equal(
 			peer1,
 			peer,
 			"should select peer1 as first not busy in top peer")

--- a/src/posnode/parents_test.go
+++ b/src/posnode/parents_test.go
@@ -40,7 +40,7 @@ func TestParentSelection(t *testing.T) {
 // testParentSelection uses special event name format: <creator weight>:<uppercase if expected|lowercase><expected ordering num>
 func testParentSelection(t *testing.T, dsc, schema string) {
 	t.Run(dsc, func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -53,15 +53,15 @@ func testParentSelection(t *testing.T, dsc, schema string) {
 		expected := ASCIIschemeToDAG(node, consensus, schema)
 		for n, expect := range expected {
 			parent := node.popBestParent()
-			if !assert.NotNil(parent, "step %d", n) {
+			if !assertar.NotNil(parent, "step %d", n) {
 				break
 			}
-			if !assert.Equal(expect, parent.String(), "step %d", n) {
+			if !assertar.Equal(expect, parent.String(), "step %d", n) {
 				break
 			}
 		}
 
-		assert.Nil(node.popBestParent(), "last step")
+		assertar.Nil(node.popBestParent(), "last step")
 
 	})
 }

--- a/src/posnode/peers_test.go
+++ b/src/posnode/peers_test.go
@@ -14,13 +14,13 @@ func TestPeerReadyForReq(t *testing.T) {
 	node.initPeers()
 
 	t.Run("new host", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
-		assert.True(node.PeerReadyForReq("new_host"))
+		assertar.True(node.PeerReadyForReq("new_host"))
 	})
 
 	t.Run("last success", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		host := &hostAttr{
 			Name:        "success",
@@ -29,11 +29,11 @@ func TestPeerReadyForReq(t *testing.T) {
 		}
 		node.peers.hosts[host.Name] = host
 
-		assert.True(node.PeerReadyForReq(host.Name))
+		assertar.True(node.PeerReadyForReq(host.Name))
 	})
 
 	t.Run("last fail timeouted", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		host := &hostAttr{
 			Name:        "fail",
@@ -42,7 +42,7 @@ func TestPeerReadyForReq(t *testing.T) {
 		}
 		node.peers.hosts[host.Name] = host
 
-		assert.True(node.PeerReadyForReq(host.Name))
+		assertar.True(node.PeerReadyForReq(host.Name))
 	})
 }
 
@@ -52,7 +52,7 @@ func TestPeerUnknown(t *testing.T) {
 	node.initPeers()
 
 	t.Run("last success", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		peer := &peerAttr{
 			ID: hash.FakePeer(),
@@ -62,11 +62,11 @@ func TestPeerUnknown(t *testing.T) {
 		}
 		node.peers.ids[peer.ID] = peer
 
-		assert.False(node.PeerUnknown(&peer.ID))
+		assertar.False(node.PeerUnknown(&peer.ID))
 	})
 
 	t.Run("peer known", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		peer := &peerAttr{
 			ID: hash.FakePeer(),
@@ -76,20 +76,20 @@ func TestPeerUnknown(t *testing.T) {
 		}
 		node.peers.ids[peer.ID] = peer
 
-		assert.False(node.PeerUnknown(&peer.ID))
+		assertar.False(node.PeerUnknown(&peer.ID))
 	})
 
 	t.Run("peer unknown", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		unknown := hash.FakePeer()
-		assert.True(node.PeerUnknown(&unknown))
+		assertar.True(node.PeerUnknown(&unknown))
 	})
 
 	t.Run("nil peer", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
-		assert.True(node.PeerUnknown(nil))
+		assertar.True(node.PeerUnknown(nil))
 	})
 }
 
@@ -111,28 +111,28 @@ func TestCleanPeers(t *testing.T) {
 	node.initPeers()
 
 	t.Run("leave hosts as is", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		node.PeerReadyForReq(peer1.Host)
 		node.PeerReadyForReq(peer2.Host)
 
 		node.trimHosts(2, 2)
 
-		assert.Equal(len(node.peers.hosts), len(peers))
+		assertar.Equal(len(node.peers.hosts), len(peers))
 	})
 
 	t.Run("clean expired hosts", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		// We already have info about 2 hosts but limit is 1
 		// Clean all expired hosts
 		node.trimHosts(1, 1)
 
-		assert.Equal(len(node.peers.hosts), 1)
+		assertar.Equal(len(node.peers.hosts), 1)
 	})
 
 	t.Run("clean extra hosts", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		node.PeerReadyForReq(peer1.Host)
 		node.PeerReadyForReq(peer2.Host)
@@ -143,6 +143,6 @@ func TestCleanPeers(t *testing.T) {
 		// Clean extra
 		node.trimHosts(1, 1)
 
-		assert.Equal(len(node.peers.hosts), 1)
+		assertar.Equal(len(node.peers.hosts), 1)
 	})
 }

--- a/src/posnode/service_test.go
+++ b/src/posnode/service_test.go
@@ -27,7 +27,7 @@ func TestGetPeerInfo(t *testing.T) {
 	defer free()
 
 	t.Run("existing peer", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		peer := FakePeer("unreachable")
 		store.SetPeer(peer)
@@ -38,16 +38,16 @@ func TestGetPeerInfo(t *testing.T) {
 		got, err := client.GetPeerInfo(ctx, &api.PeerRequest{
 			PeerID: peer.ID.Hex(),
 		})
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			fail(err)
 			return
 		}
 
-		assert.Equal(peer, WireToPeer(got))
+		assertar.Equal(peer, WireToPeer(got))
 	})
 
 	t.Run("no existing peer", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		ctx, cancel := context.WithTimeout(context.Background(), n.conf.ClientTimeout)
 		defer cancel()
@@ -56,21 +56,21 @@ func TestGetPeerInfo(t *testing.T) {
 			PeerID: "unknown",
 		})
 
-		if !assert.Nil(resp) {
+		if !assertar.Nil(resp) {
 			return
 		}
 
-		if !assert.Error(err) {
+		if !assertar.Error(err) {
 			return
 		} else {
 			fail(err)
 		}
 
 		s := status.Convert(err)
-		if !assert.NotNil(s) {
+		if !assertar.NotNil(s) {
 			return
 		}
-		assert.Equal(codes.NotFound, s.Code())
+		assertar.Equal(codes.NotFound, s.Code())
 	})
 
 }

--- a/src/posnode/store_test.go
+++ b/src/posnode/store_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Test_IntToBytes(t *testing.T) {
-	assert := assert.New(t)
+	assertar := assert.New(t)
 
 	for _, n1 := range []uint64{
 		0,
@@ -17,6 +17,6 @@ func Test_IntToBytes(t *testing.T) {
 	} {
 		b := intToBytes(n1)
 		n2 := bytesToInt(b)
-		assert.Equal(n1, n2)
+		assertar.Equal(n1, n2)
 	}
 }

--- a/src/posposet/event_test.go
+++ b/src/posposet/event_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestEventsSort(t *testing.T) {
-	assert := assert.New(t)
+	assertar := assert.New(t)
 
 	expected := Events{
 		&Event{consensusTime: 1, Event: &inter.Event{LamportTime: 7}},
@@ -33,7 +33,7 @@ func TestEventsSort(t *testing.T) {
 		}
 		sort.Sort(ordered)
 
-		if !assert.Equal(expected, ordered, fmt.Sprintf("perms: %v", perms)) {
+		if !assertar.Equal(expected, ordered, fmt.Sprintf("perms: %v", perms)) {
 			break
 		}
 	}

--- a/src/posposet/flag_table.go
+++ b/src/posposet/flag_table.go
@@ -139,10 +139,10 @@ func (ee EventsByPeer) String() string {
 func (ee EventsByPeer) ToWire() []*wire.EventDescr {
 	var arr []*wire.EventDescr
 	for creator, hh := range ee {
-		for hash := range hh {
+		for hash_ := range hh {
 			arr = append(arr, &wire.EventDescr{
 				Creator: creator.Bytes(),
-				Hash:    hash.Bytes(),
+				Hash:    hash_.Bytes(),
 			})
 		}
 	}

--- a/src/posposet/frame_test.go
+++ b/src/posposet/frame_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestFrameSerialization(t *testing.T) {
-	assert := assert.New(t)
+	assertar := assert.New(t)
 	// fake random data
 	nodes, events := GenEventsByNode(4, 10, 3)
 
@@ -43,13 +43,13 @@ func TestFrameSerialization(t *testing.T) {
 		Balances:         hash.FakeHash(),
 	}
 	buf, err := proto.Marshal(f0.ToWire())
-	assert.NoError(err)
+	assertar.NoError(err)
 
 	w := &wire.Frame{}
 	err = proto.Unmarshal(buf, w)
-	assert.NoError(err)
+	assertar.NoError(err)
 
 	f1 := WireToFrame(w)
 
-	assert.EqualValues(f0, f1)
+	assertar.EqualValues(f0, f1)
 }

--- a/src/posposet/input_test.go
+++ b/src/posposet/input_test.go
@@ -92,25 +92,25 @@ func TestEventStore(t *testing.T) {
 	store := NewEventStore(nil, false)
 
 	t.Run("NotExisting", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		h := hash.FakeEvent()
 		e1 := store.GetEvent(h)
-		assert.Nil(e1)
+		assertar.Nil(e1)
 	})
 
 	t.Run("Events", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		events := inter.FakeFuzzingEvents()
 		for _, e0 := range events {
 			store.SetEvent(e0)
 			e1 := store.GetEvent(e0.Hash())
 
-			if !assert.Equal(e0.Hash(), e1.Hash()) {
+			if !assertar.Equal(e0.Hash(), e1.Hash()) {
 				break
 			}
-			if !assert.Equal(e0, e1) {
+			if !assertar.Equal(e0, e1) {
 				break
 			}
 		}

--- a/src/posposet/poset.go
+++ b/src/posposet/poset.go
@@ -333,22 +333,22 @@ func (p *Poset) topologicalOrdered(frameNum uint64) (chain Events) {
 
 // collectParents recursive collects Events of Atropos.
 func (p *Poset) collectParents(a *Event, res *Events, already hash.Events) {
-	for hash := range a.Parents {
-		if hash.IsZero() {
+	for hash_ := range a.Parents {
+		if hash_.IsZero() {
 			continue
 		}
-		if already.Contains(hash) {
+		if already.Contains(hash_) {
 			continue
 		}
-		f, _ := p.FrameOfEvent(hash)
-		if _, ok := f.Atroposes[hash]; ok {
+		f, _ := p.FrameOfEvent(hash_)
+		if _, ok := f.Atroposes[hash_]; ok {
 			continue
 		}
 
-		e := p.GetEvent(hash)
+		e := p.GetEvent(hash_)
 		e.consensusTime = a.consensusTime
 		*res = append(*res, e)
-		already.Add(hash)
+		already.Add(hash_)
 		p.collectParents(e, res, already)
 	}
 }

--- a/src/posposet/poset_atropos_test.go
+++ b/src/posposet/poset_atropos_test.go
@@ -92,7 +92,7 @@ func TestPosetSimpleAtropos(t *testing.T) {
 // - 3rd number - frame where node should be in;
 // - last "+T" - means Atropos and its consensus time;
 func testSpecialNamedAtropos(t *testing.T, tryRestoring bool, asciiScheme string) {
-	assert := assert.New(t)
+	assertar := assert.New(t)
 	// init
 	nodes, _, names := inter.ASCIIschemeToDAG(asciiScheme)
 	p, store, input := FakePoset(nodes)
@@ -120,32 +120,32 @@ func testSpecialNamedAtropos(t *testing.T, tryRestoring bool, asciiScheme string
 		// check root
 		mustBeRoot := name == strings.ToUpper(name)
 		frame, isRoot := p.FrameOfEvent(event.Hash())
-		if !assert.Equal(mustBeRoot, isRoot, name+" is root") {
+		if !assertar.Equal(mustBeRoot, isRoot, name+" is root") {
 			t.Log(event.String())
 			break
 		}
 		// check frame
 		mustBeFrame, err := strconv.ParseUint(name[2:3], 10, 64)
-		if !assert.NoError(err, "name the nodes properly: <UpperCaseForRoot><Index><FrameN>") {
+		if !assertar.NoError(err, "name the nodes properly: <UpperCaseForRoot><Index><FrameN>") {
 			return
 		}
-		if !assert.Equal(mustBeFrame, frame.Index, "frame of "+name) {
+		if !assertar.Equal(mustBeFrame, frame.Index, "frame of "+name) {
 			break
 		}
 		// check Atropos time
 		mustBeAtropos := len(name) > 4 && name[3:4] == "+"
 		consensusTime, isAtropos := frame.Atroposes[event.Hash()]
-		if !assert.Equal(mustBeAtropos, isAtropos, "Atropos "+name) {
+		if !assertar.Equal(mustBeAtropos, isAtropos, "Atropos "+name) {
 			break
 		}
 		if !isAtropos {
 			continue
 		}
 		expectedTime, err := strconv.ParseUint(name[4:5], 10, 64)
-		if !assert.NoError(err, "name the Atropos properly: <UpperCaseForRoot><Index><FrameN>+<ConsensusTime>") {
+		if !assertar.NoError(err, "name the Atropos properly: <UpperCaseForRoot><Index><FrameN>+<ConsensusTime>") {
 			return
 		}
-		if !assert.Equal(inter.Timestamp(expectedTime), consensusTime, "Atropos "+name+" consensus time") {
+		if !assertar.Equal(inter.Timestamp(expectedTime), consensusTime, "Atropos "+name+" consensus time") {
 			break
 		}
 	}

--- a/src/posposet/poset_clotho_test.go
+++ b/src/posposet/poset_clotho_test.go
@@ -68,7 +68,7 @@ A54 ─ ─ ╫ ─ ─ ─ ╬ ─ ─ ─ ╣       ║
 // - 3rd number - frame where node should be in;
 // - last "+" - ClothoCandidate;
 func testSpecialNamedClotho(t *testing.T, asciiScheme string) {
-	assert := assert.New(t)
+	assertar := assert.New(t)
 	// init
 	nodes, _, names := inter.ASCIIschemeToDAG(asciiScheme)
 	p, _, input := FakePoset(nodes)
@@ -82,21 +82,21 @@ func testSpecialNamedClotho(t *testing.T, asciiScheme string) {
 		// check root
 		mustBeRoot := name == strings.ToUpper(name)
 		frame, isRoot := p.FrameOfEvent(event.Hash())
-		if !assert.Equal(mustBeRoot, isRoot, name+" is root") {
+		if !assertar.Equal(mustBeRoot, isRoot, name+" is root") {
 			break
 		}
 		// check frame
 		mustBeFrame, err := strconv.ParseUint(name[2:3], 10, 64)
-		if !assert.NoError(err, "name the nodes properly: <UpperCaseForRoot><Index><FrameN>") {
+		if !assertar.NoError(err, "name the nodes properly: <UpperCaseForRoot><Index><FrameN>") {
 			return
 		}
-		if !assert.Equal(mustBeFrame, frame.Index, "frame of "+name) {
+		if !assertar.Equal(mustBeFrame, frame.Index, "frame of "+name) {
 			break
 		}
 		// check Clotho Candidate
 		mustBeCC := len(name) > 3 && name[3:4] == "+"
 		isCC := frame.ClothoCandidates[event.Creator].Contains(event.Hash())
-		if !assert.Equal(mustBeCC, isCC, name+" is Clotho Candidate") {
+		if !assertar.Equal(mustBeCC, isCC, name+" is Clotho Candidate") {
 			break
 		}
 	}

--- a/src/posposet/poset_root_test.go
+++ b/src/posposet/poset_root_test.go
@@ -114,7 +114,7 @@ A54 ─ ╫ ─ ─ ╬ ─ ─ ╣     ║
 // - 2nd number - index by node;
 // - 3rd number - frame where node should be in;
 func testSpecialNamedRoots(t *testing.T, asciiScheme string) {
-	assert := assert.New(t)
+	assertar := assert.New(t)
 	// init
 	nodes, _, names := inter.ASCIIschemeToDAG(asciiScheme)
 	p, _, input := FakePoset(nodes)
@@ -128,15 +128,15 @@ func testSpecialNamedRoots(t *testing.T, asciiScheme string) {
 		// check root
 		mustBeRoot := name == strings.ToUpper(name)
 		frame, isRoot := p.FrameOfEvent(event.Hash())
-		if !assert.Equal(mustBeRoot, isRoot, name+" is root") {
+		if !assertar.Equal(mustBeRoot, isRoot, name+" is root") {
 			break
 		}
 		// check frame
 		mustBeFrame, err := strconv.ParseUint(name[2:3], 10, 64)
-		if !assert.NoError(err, "name the nodes properly: <UpperCaseForRoot><Index><FrameN>") {
+		if !assertar.NoError(err, "name the nodes properly: <UpperCaseForRoot><Index><FrameN>") {
 			return
 		}
-		if !assert.Equal(mustBeFrame, frame.Index, "frame of "+name) {
+		if !assertar.Equal(mustBeFrame, frame.Index, "frame of "+name) {
 			break
 		}
 	}

--- a/src/posposet/poset_test.go
+++ b/src/posposet/poset_test.go
@@ -49,11 +49,11 @@ func TestPoset(t *testing.T) {
 	})
 
 	t.Run("All events in Store", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 		for _, events := range nodesEvents {
 			for _, e0 := range events {
 				frame := posets[0].store.GetEventFrame(e0.Hash())
-				if !assert.NotNil(frame, "Event is not in poset store") {
+				if !assertar.NotNil(frame, "Event is not in poset store") {
 					return
 				}
 			}
@@ -61,16 +61,16 @@ func TestPoset(t *testing.T) {
 	})
 
 	t.Run("Check consensus", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 		for i := 0; i < len(posets)-1; i++ {
 			for j := i + 1; j < len(posets); j++ {
 				p0, p1 := posets[i], posets[j]
 				// compare blockchain
-				if !assert.Equal(p0.state.LastBlockN, p1.state.LastBlockN, "blocks count") {
+				if !assertar.Equal(p0.state.LastBlockN, p1.state.LastBlockN, "blocks count") {
 					return
 				}
 				for b := uint64(1); b <= p0.state.LastBlockN; b++ {
-					if !assert.Equal(p0.store.GetBlock(b), p1.store.GetBlock(b), "block") {
+					if !assertar.Equal(p0.store.GetBlock(b), p1.store.GetBlock(b), "block") {
 						return
 					}
 				}

--- a/src/posposet/store_test.go
+++ b/src/posposet/store_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Test_IntToBytes(t *testing.T) {
-	assert := assert.New(t)
+	assertar := assert.New(t)
 
 	for _, n1 := range []uint64{
 		0,
@@ -23,7 +23,7 @@ func Test_IntToBytes(t *testing.T) {
 	} {
 		b := intToBytes(n1)
 		n2 := bytesToInt(b)
-		assert.Equal(n1, n2)
+		assertar.Equal(n1, n2)
 	}
 }
 

--- a/src/posposet/time.go
+++ b/src/posposet/time.go
@@ -28,8 +28,8 @@ func WireToTimestampsByEvent(arr map[string]uint64) TimestampsByEvent {
 	res := make(TimestampsByEvent, len(arr))
 
 	for hex, t := range arr {
-		hash := hash.HexToEventHash(hex)
-		res[hash] = inter.Timestamp(t)
+		hash_ := hash.HexToEventHash(hex)
+		res[hash_] = inter.Timestamp(t)
 	}
 
 	return res

--- a/src/posposet/time_test.go
+++ b/src/posposet/time_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestLamportTimeCounter(t *testing.T) {
-	assert := assert.New(t)
+	assertar := assert.New(t)
 
 	data := map[inter.Timestamp][]inter.Timestamp{
 		math.MaxUint64: {},
@@ -26,7 +26,7 @@ func TestLamportTimeCounter(t *testing.T) {
 		}
 
 		actual := counter.MaxMin()
-		if !assert.Equal(expected, actual, "max-min time") {
+		if !assertar.Equal(expected, actual, "max-min time") {
 			break
 		}
 	}

--- a/src/proxy/grpc_app_test.go
+++ b/src/proxy/grpc_app_test.go
@@ -56,87 +56,87 @@ func testGrpcAppCalls(t *testing.T, listen network.ListenFunc, opts ...grpc.Dial
 	defer c.Close()
 
 	t.Run("#1 Send tx", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 		gold := []byte("123456")
 
 		err := c.SubmitTx(gold)
-		assert.NoError(err)
+		assertar.NoError(err)
 
 		select {
 		case tx := <-s.SubmitCh():
-			assert.Equal(gold, tx)
+			assertar.Equal(gold, tx)
 		case <-time.After(timeout):
-			assert.Fail(errTimeout)
+			assertar.Fail(errTimeout)
 		}
 	})
 
 	t.Run("#2 Receive block", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 		block := poset.Block{}
 		gold := []byte("123456")
 
 		go func() {
 			select {
 			case event := <-c.CommitCh():
-				assert.Equal(block, event.Block)
+				assertar.Equal(block, event.Block)
 				event.RespChan <- proto.CommitResponse{
 					StateHash: gold,
 					Error:     nil,
 				}
 			case <-time.After(timeout):
-				assert.Fail(errTimeout)
+				assertar.Fail(errTimeout)
 			}
 		}()
 
 		answer, err := s.CommitBlock(block)
-		if assert.NoError(err) {
-			assert.Equal(gold, answer)
+		if assertar.NoError(err) {
+			assertar.Equal(gold, answer)
 		}
 	})
 
 	t.Run("#3 Receive snapshot query", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 		index := int64(1)
 		gold := []byte("123456")
 
 		go func() {
 			select {
 			case event := <-c.SnapshotRequestCh():
-				assert.Equal(index, event.BlockIndex)
+				assertar.Equal(index, event.BlockIndex)
 				event.RespChan <- proto.SnapshotResponse{
 					Snapshot: gold,
 					Error:    nil,
 				}
 			case <-time.After(timeout):
-				assert.Fail(errTimeout)
+				assertar.Fail(errTimeout)
 			}
 		}()
 
 		answer, err := s.GetSnapshot(index)
-		if assert.NoError(err) {
-			assert.Equal(gold, answer)
+		if assertar.NoError(err) {
+			assertar.Equal(gold, answer)
 		}
 	})
 
 	t.Run("#4 Receive restore command", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 		gold := []byte("123456")
 
 		go func() {
 			select {
 			case event := <-c.RestoreCh():
-				assert.Equal(gold, event.Snapshot)
+				assertar.Equal(gold, event.Snapshot)
 				event.RespChan <- proto.RestoreResponse{
 					StateHash: gold,
 					Error:     nil,
 				}
 			case <-time.After(timeout):
-				assert.Fail(errTimeout)
+				assertar.Fail(errTimeout)
 			}
 		}()
 
 		err := s.Restore(gold)
-		assert.NoError(err)
+		assertar.NoError(err)
 	})
 }
 
@@ -160,17 +160,17 @@ func testGrpcAppReconnect(t *testing.T, listen network.ListenFunc, opts ...grpc.
 	defer c.Close()
 
 	checkConn := func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 		gold := []byte("123456")
 
 		err := c.SubmitTx(gold)
-		assert.NoError(err)
+		assertar.NoError(err)
 
 		select {
 		case tx := <-s.SubmitCh():
-			assert.Equal(gold, tx)
+			assertar.Equal(gold, tx)
 		case <-time.After(timeout):
-			assert.Fail(errTimeout)
+			assertar.Fail(errTimeout)
 		}
 	}
 

--- a/src/proxy/grpc_ctrl_test.go
+++ b/src/proxy/grpc_ctrl_test.go
@@ -53,16 +53,16 @@ func testGrpcCtrlCalls(t *testing.T, listen network.ListenFunc, opts ...grpc.Dia
 	peer := hash.FakePeer()
 
 	t.Run("get self id", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		got, err := client.GetSelfID()
 
-		assert.NoError(err)
-		assert.Equal(id, got)
+		assertar.NoError(err)
+		assertar.Equal(id, got)
 	})
 
 	t.Run("get balance of", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		expect := rand.Uint64()
 
@@ -71,15 +71,15 @@ func testGrpcCtrlCalls(t *testing.T, listen network.ListenFunc, opts ...grpc.Dia
 			Return(expect)
 
 		got, err := client.StakeOf(peer)
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			return
 		}
 
-		assert.Equal(expect, got)
+		assertar.Equal(expect, got)
 	})
 
 	t.Run("transaction not found", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		h := hash.FakeTransaction()
 
@@ -88,11 +88,11 @@ func testGrpcCtrlCalls(t *testing.T, listen network.ListenFunc, opts ...grpc.Dia
 			Return(nil)
 
 		_, err := client.GetTransaction(h)
-		assert.Error(err)
+		assertar.Error(err)
 	})
 
 	t.Run("transaction", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		h := hash.FakeTransaction()
 		expect := &inter.InternalTransaction{
@@ -106,15 +106,15 @@ func testGrpcCtrlCalls(t *testing.T, listen network.ListenFunc, opts ...grpc.Dia
 			Return(expect)
 
 		got, err := client.GetTransaction(h)
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			return
 		}
 
-		assert.Equal(expect, got)
+		assertar.Equal(expect, got)
 	})
 
 	t.Run("get balance of self", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		expect := rand.Uint64()
 
@@ -123,15 +123,15 @@ func testGrpcCtrlCalls(t *testing.T, listen network.ListenFunc, opts ...grpc.Dia
 			Return(expect)
 
 		got, err := client.StakeOf(peer)
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			return
 		}
 
-		assert.Equal(expect, got)
+		assertar.Equal(expect, got)
 	})
 
 	t.Run("send to", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		amount := rand.Uint64()
 		tx := inter.InternalTransaction{
@@ -144,15 +144,15 @@ func testGrpcCtrlCalls(t *testing.T, listen network.ListenFunc, opts ...grpc.Dia
 			AddInternalTxn(tx)
 
 		_, err := client.SendTo(tx.Receiver, tx.Index, tx.Amount, tx.UntilBlock)
-		assert.NoError(err)
+		assertar.NoError(err)
 	})
 
 	t.Run("set log level", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 
 		l := "info"
 		err := client.SetLogLevel(l)
-		assert.NoError(err)
-		assert.Equal(logger.Get().GetLevel(), logger.GetLevel(l))
+		assertar.NoError(err)
+		assertar.Equal(logger.Get().GetLevel(), logger.GetLevel(l))
 	})
 }

--- a/src/proxy/inmem_app_test.go
+++ b/src/proxy/inmem_app_test.go
@@ -21,7 +21,7 @@ func TestInmemAppCalls(t *testing.T) {
 	defer s.Close()
 
 	t.Run("#2 Receive block", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 		block := poset.Block{
 			Body: &poset.BlockBody{},
 		}
@@ -32,13 +32,13 @@ func TestInmemAppCalls(t *testing.T) {
 			Return(gold, nil)
 
 		answer, err := s.CommitBlock(block)
-		if assert.NoError(err) {
-			assert.Equal(gold, answer)
+		if assertar.NoError(err) {
+			assertar.Equal(gold, answer)
 		}
 	})
 
 	t.Run("#3 Receive snapshot query", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 		index := int64(1)
 		gold := []byte("123456")
 
@@ -47,13 +47,13 @@ func TestInmemAppCalls(t *testing.T) {
 			Return(gold, nil)
 
 		answer, err := s.GetSnapshot(index)
-		if assert.NoError(err) {
-			assert.Equal(gold, answer)
+		if assertar.NoError(err) {
+			assertar.Equal(gold, answer)
 		}
 	})
 
 	t.Run("#4 Receive restore command", func(t *testing.T) {
-		assert := assert.New(t)
+		assertar := assert.New(t)
 		gold := []byte("123456")
 
 		handler.EXPECT().
@@ -61,6 +61,6 @@ func TestInmemAppCalls(t *testing.T) {
 			Return([]byte("state_hash"), nil)
 
 		err := s.Restore(gold)
-		assert.NoError(err)
+		assertar.NoError(err)
 	})
 }

--- a/src/state/statedb.go
+++ b/src/state/statedb.go
@@ -428,8 +428,8 @@ func (s *DB) Copy() *DB {
 			state.stateObjectsDirty[addr] = struct{}{}
 		}
 	}
-	for hash, preimage := range s.preimages {
-		state.preimages[hash] = preimage
+	for hash_, preimage := range s.preimages {
+		state.preimages[hash_] = preimage
 	}
 	return state
 }

--- a/src/state/statedb_test.go
+++ b/src/state/statedb_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestBalanceState(t *testing.T) {
-	assert := assert.New(t)
+	assertar := assert.New(t)
 
 	var aa = []hash.Peer{
 		hash.FakePeer(),
@@ -23,7 +23,7 @@ func TestBalanceState(t *testing.T) {
 
 	stateAt := func(point hash.Hash) *DB {
 		db, err := New(point, store)
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			t.FailNow()
 		}
 		return db
@@ -32,14 +32,14 @@ func TestBalanceState(t *testing.T) {
 	checkBalance := func(point hash.Hash, addr hash.Peer, balance uint64) {
 		db := stateAt(point)
 		got := db.FreeBalance(addr)
-		if !assert.Equalf(balance, got, "unexpected balance") {
+		if !assertar.Equalf(balance, got, "unexpected balance") {
 			t.FailNow()
 		}
 	}
 
 	commit := func(db *DB) hash.Hash {
 		root, err := db.Commit(true)
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			t.FailNow()
 		}
 		return root
@@ -64,8 +64,8 @@ func TestBalanceState(t *testing.T) {
 	// fork 1
 	db = stateAt(root)
 	db.Transfer(aa[0], aa[1], 1)
-	if !assert.Equalf(uint64(9), db.FreeBalance(aa[0]), "before commit") ||
-		!assert.Equalf(uint64(11), db.FreeBalance(aa[1]), "before commit") {
+	if !assertar.Equalf(uint64(9), db.FreeBalance(aa[0]), "before commit") ||
+		!assertar.Equalf(uint64(11), db.FreeBalance(aa[1]), "before commit") {
 		return
 	}
 	fork1 := commit(db)
@@ -85,7 +85,7 @@ func TestBalanceState(t *testing.T) {
 }
 
 func TestDelegationState(t *testing.T) {
-	assert := assert.New(t)
+	assertar := assert.New(t)
 
 	const __ uint64 = 0
 
@@ -100,7 +100,7 @@ func TestDelegationState(t *testing.T) {
 
 	stateAt := func(point hash.Hash) *DB {
 		db, err := New(point, store)
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			t.FailNow()
 		}
 		return db
@@ -129,7 +129,7 @@ func TestDelegationState(t *testing.T) {
 				continue
 			}
 			got := db.GetDelegations(addr)[x][p]
-			if !assert.Equalf(exp, got, "unexpected delegation amount: aa[%d] %s aa[%d]", j, dir, i) {
+			if !assertar.Equalf(exp, got, "unexpected delegation amount: aa[%d] %s aa[%d]", j, dir, i) {
 				t.FailNow()
 			}
 		}
@@ -137,7 +137,7 @@ func TestDelegationState(t *testing.T) {
 
 	commit := func(db *DB) hash.Hash {
 		root, err := db.Commit(true)
-		if !assert.NoError(err) {
+		if !assertar.NoError(err) {
 			t.FailNow()
 		}
 		return root

--- a/src/trie/proof.go
+++ b/src/trie/proof.go
@@ -57,17 +57,17 @@ func (t *Trie) Prove(key []byte, fromLevel uint, proofDb kvdb.Putter) error {
 		// if encoding doesn't work and we're not writing to any database.
 		n, _, _ = hasher.hashChildren(n, nil)
 		hn, _ := hasher.store(n, nil, false)
-		if hash, ok := hn.(hashNode); ok || i == 0 {
-			// If the node's database encoding is a hash (or is the
+		if hash_, ok := hn.(hashNode); ok || i == 0 {
+			// If the node's database encoding is a hash_ (or is the
 			// root node), it becomes a proof element.
 			if fromLevel > 0 {
 				fromLevel--
 			} else {
 				enc, _ := EncodeToBytes(n)
 				if !ok {
-					hash = crypto.Keccak256(enc)
+					hash_ = crypto.Keccak256(enc)
 				}
-				err := proofDb.Put(hash, enc)
+				err := proofDb.Put(hash_, enc)
 				if err != nil {
 					return err
 				}

--- a/src/trie/secure_trie.go
+++ b/src/trie/secure_trie.go
@@ -21,7 +21,7 @@ import (
 // SecureTrie is not safe for concurrent use.
 type SecureTrie struct {
 	trie             Trie
-	hashKeyBuf       [hash.HashLength]byte
+	hashKeyBuf       [hash.Size]byte
 	secKeyCache      map[string][]byte
 	secKeyCacheOwner *SecureTrie // Pointer to self, replace the key cache on mismatch
 }

--- a/src/trie/sync_test.go
+++ b/src/trie/sync_test.go
@@ -108,12 +108,12 @@ func testIterativeSync(t *testing.T, batch int) {
 	queue := append([]hash.Hash{}, sched.Missing(batch)...)
 	for len(queue) > 0 {
 		results := make([]SyncResult, len(queue))
-		for i, hash := range queue {
-			data, err := srcDb.Node(hash)
+		for i, hash_ := range queue {
+			data, err := srcDb.Node(hash_)
 			if err != nil {
-				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
+				t.Fatalf("failed to retrieve node data for %x: %v", hash_, err)
 			}
-			results[i] = SyncResult{hash, data}
+			results[i] = SyncResult{hash_, data}
 		}
 		if _, index, err := sched.Process(results); err != nil {
 			t.Fatalf("failed to process result #%d: %v", index, err)
@@ -142,12 +142,12 @@ func TestIterativeDelayedSync(t *testing.T) {
 	for len(queue) > 0 {
 		// Sync only half of the scheduled nodes
 		results := make([]SyncResult, len(queue)/2+1)
-		for i, hash := range queue[:len(results)] {
-			data, err := srcDb.Node(hash)
+		for i, hash_ := range queue[:len(results)] {
+			data, err := srcDb.Node(hash_)
 			if err != nil {
-				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
+				t.Fatalf("failed to retrieve node data for %x: %v", hash_, err)
 			}
-			results[i] = SyncResult{hash, data}
+			results[i] = SyncResult{hash_, data}
 		}
 		if _, index, err := sched.Process(results); err != nil {
 			t.Fatalf("failed to process result #%d: %v", index, err)
@@ -177,18 +177,18 @@ func testIterativeRandomSync(t *testing.T, batch int) {
 	sched := NewSync(srcTrie.Hash(), diskdb, nil)
 
 	queue := make(map[hash.Hash]struct{})
-	for _, hash := range sched.Missing(batch) {
-		queue[hash] = struct{}{}
+	for _, hash_ := range sched.Missing(batch) {
+		queue[hash_] = struct{}{}
 	}
 	for len(queue) > 0 {
 		// Fetch all the queued nodes in a random order
 		results := make([]SyncResult, 0, len(queue))
-		for hash := range queue {
-			data, err := srcDb.Node(hash)
+		for hash_ := range queue {
+			data, err := srcDb.Node(hash_)
 			if err != nil {
-				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
+				t.Fatalf("failed to retrieve node data for %x: %v", hash_, err)
 			}
-			results = append(results, SyncResult{hash, data})
+			results = append(results, SyncResult{hash_, data})
 		}
 		// Feed the retrieved results back and queue new tasks
 		if _, index, err := sched.Process(results); err != nil {
@@ -198,8 +198,8 @@ func testIterativeRandomSync(t *testing.T, batch int) {
 			t.Fatalf("failed to commit data #%d: %v", index, err)
 		}
 		queue = make(map[hash.Hash]struct{})
-		for _, hash := range sched.Missing(batch) {
-			queue[hash] = struct{}{}
+		for _, hash_ := range sched.Missing(batch) {
+			queue[hash_] = struct{}{}
 		}
 	}
 	// Cross check that the two tries are in sync
@@ -218,18 +218,18 @@ func TestIterativeRandomDelayedSync(t *testing.T) {
 	sched := NewSync(srcTrie.Hash(), diskdb, nil)
 
 	queue := make(map[hash.Hash]struct{})
-	for _, hash := range sched.Missing(10000) {
-		queue[hash] = struct{}{}
+	for _, hash_ := range sched.Missing(10000) {
+		queue[hash_] = struct{}{}
 	}
 	for len(queue) > 0 {
 		// Sync only half of the scheduled nodes, even those in random order
 		results := make([]SyncResult, 0, len(queue)/2+1)
-		for hash := range queue {
-			data, err := srcDb.Node(hash)
+		for hash_ := range queue {
+			data, err := srcDb.Node(hash_)
 			if err != nil {
-				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
+				t.Fatalf("failed to retrieve node data for %x: %v", hash_, err)
 			}
-			results = append(results, SyncResult{hash, data})
+			results = append(results, SyncResult{hash_, data})
 
 			if len(results) >= cap(results) {
 				break
@@ -245,8 +245,8 @@ func TestIterativeRandomDelayedSync(t *testing.T) {
 		for _, result := range results {
 			delete(queue, result.Hash)
 		}
-		for _, hash := range sched.Missing(10000) {
-			queue[hash] = struct{}{}
+		for _, hash_ := range sched.Missing(10000) {
+			queue[hash_] = struct{}{}
 		}
 	}
 	// Cross check that the two tries are in sync
@@ -269,17 +269,17 @@ func TestDuplicateAvoidanceSync(t *testing.T) {
 
 	for len(queue) > 0 {
 		results := make([]SyncResult, len(queue))
-		for i, hash := range queue {
-			data, err := srcDb.Node(hash)
+		for i, hash_ := range queue {
+			data, err := srcDb.Node(hash_)
 			if err != nil {
-				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
+				t.Fatalf("failed to retrieve node data for %x: %v", hash_, err)
 			}
-			if _, ok := requested[hash]; ok {
-				t.Errorf("hash %x already requested once", hash)
+			if _, ok := requested[hash_]; ok {
+				t.Errorf("hash_ %x already requested once", hash_)
 			}
-			requested[hash] = struct{}{}
+			requested[hash_] = struct{}{}
 
-			results[i] = SyncResult{hash, data}
+			results[i] = SyncResult{hash_, data}
 		}
 		if _, index, err := sched.Process(results); err != nil {
 			t.Fatalf("failed to process result #%d: %v", index, err)
@@ -309,12 +309,12 @@ func TestIncompleteSync(t *testing.T) {
 	for len(queue) > 0 {
 		// Fetch a batch of trie nodes
 		results := make([]SyncResult, len(queue))
-		for i, hash := range queue {
-			data, err := srcDb.Node(hash)
+		for i, hash_ := range queue {
+			data, err := srcDb.Node(hash_)
 			if err != nil {
-				t.Fatalf("failed to retrieve node data for %x: %v", hash, err)
+				t.Fatalf("failed to retrieve node data for %x: %v", hash_, err)
 			}
-			results[i] = SyncResult{hash, data}
+			results[i] = SyncResult{hash_, data}
 		}
 		// Process each of the trie nodes
 		if _, index, err := sched.Process(results); err != nil {

--- a/src/trie/trie_test.go
+++ b/src/trie/trie_test.go
@@ -102,12 +102,12 @@ func testMissingNode(t *testing.T, memonly bool) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	hash := hash.HexToHash("2db7571d4823d62e2897c63e29e8360954fa43808feba89e85470fe9b2c10f83")
+	hash_ := hash.HexToHash("2db7571d4823d62e2897c63e29e8360954fa43808feba89e85470fe9b2c10f83")
 
 	if memonly {
-		delete(triedb.dirties, hash)
+		delete(triedb.dirties, hash_)
 	} else {
-		err = diskdb.Delete(hash[:])
+		err = diskdb.Delete(hash_[:])
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -273,12 +273,12 @@ func TestReplication(t *testing.T) {
 			t.Errorf("trie2 doesn't have %q => %q", kv.k, kv.v)
 		}
 	}
-	hash, err := trie2.Commit(nil)
+	trie2CommittedHash, err := trie2.Commit(nil)
 	if err != nil {
 		t.Fatalf("commit error: %v", err)
 	}
-	if hash != exp {
-		t.Errorf("root failure. expected %x got %x", exp, hash)
+	if trie2CommittedHash != exp {
+		t.Errorf("root failure. expected %x got %x", exp, trie2CommittedHash)
 	}
 
 	// perform some insertions on the new trie.
@@ -296,8 +296,8 @@ func TestReplication(t *testing.T) {
 	for _, val := range vals2 {
 		updateString(trie2, val.k, val.v)
 	}
-	if hash := trie2.Hash(); hash != exp {
-		t.Errorf("root failure. expected %x got %x", exp, hash)
+	if trie2Hash := trie2.Hash(); trie2Hash != exp {
+		t.Errorf("root failure. expected %x got %x", exp, trie2Hash)
 	}
 }
 
@@ -437,12 +437,12 @@ func runRandTest(rt randTest) bool {
 		case opHash:
 			tr.Hash()
 		case opReset:
-			hash, err := tr.Commit(nil)
+			hash_, err := tr.Commit(nil)
 			if err != nil {
 				rt[i].err = err
 				return false
 			}
-			newtr, err := New(hash, triedb)
+			newtr, err := New(hash_, triedb)
 			if err != nil {
 				rt[i].err = err
 				return false
@@ -455,7 +455,7 @@ func runRandTest(rt randTest) bool {
 				checktr.Update(it.Key, it.Value)
 			}
 			if tr.Hash() != checktr.Hash() {
-				rt[i].err = fmt.Errorf("hash mismatch in opItercheckhash")
+				rt[i].err = fmt.Errorf("hash_ mismatch in opItercheckhash")
 			}
 		case opCheckCacheInvariant:
 			rt[i].err = checkCacheInvariant(tr.root, nil, tr.cachegen, false, 0)

--- a/src/utils/util.go
+++ b/src/utils/util.go
@@ -27,16 +27,21 @@ func GetUnusedNetAddr(n int, t testing.TB) []string {
 		if err != nil {
 			continue
 		}
-		defer func() {
-			if err := l.Close(); err != nil {
-				t.Fatal(err)
+		if res := func() []string {
+			defer func() {
+				if err := l.Close(); err != nil {
+					t.Fatal(err)
+				}
+			}()
+			t.Logf("Unused port %s is chosen", addrStr)
+			addresses[idx] = addrStr
+			idx++
+			if idx == n {
+				return addresses
 			}
-		}()
-		t.Logf("Unused port %s is chosen", addrStr)
-		addresses[idx] = addrStr
-		idx++
-		if idx == n {
-			return addresses
+			return nil
+		}(); res != nil {
+			return res
 		}
 	}
 	t.Fatalf("No free port left!!!")


### PR DESCRIPTION
Mostly fixes for this warning:
> Variable collides with imported package name