### PR TITLE
Proposal implementation of independent nonce accounting for each node

### DIFF
--- a/src/posnode/node.go
+++ b/src/posnode/node.go
@@ -98,6 +98,10 @@ func (n *Node) saveNewEvent(e *inter.Event) {
 	n.store.SetEventHash(e.Creator, e.Index, e.Hash())
 	n.store.SetPeerHeight(e.Creator, e.Index)
 
+	from, _ := n.store.IncreaseNonce(e.Creator, e.InternalTransactions)
+	n.store.SetBatchNonceEvent(from, e)
+	n.store.SetBatchNonceTx(from, e.Creator, e.InternalTransactions)
+
 	n.pushPotentialParent(e)
 
 	if n.consensus != nil {

--- a/src/posnode/store.go
+++ b/src/posnode/store.go
@@ -3,24 +3,24 @@ package posnode
 import (
 	"github.com/golang/protobuf/proto"
 
-	"github.com/Fantom-foundation/go-lachesis/src/hash"
-	"github.com/Fantom-foundation/go-lachesis/src/inter"
-	"github.com/Fantom-foundation/go-lachesis/src/inter/wire"
 	"github.com/Fantom-foundation/go-lachesis/src/kvdb"
 	"github.com/Fantom-foundation/go-lachesis/src/logger"
-	"github.com/Fantom-foundation/go-lachesis/src/posnode/api"
 )
 
 // Store is a node persistent storage working over physical key-value database.
 type Store struct {
-	physicalDB kvdb.Database
+	PhysicalDB kvdb.Database `store:"-"`
 
-	peers       kvdb.Database
-	peersTop    kvdb.Database
-	peerHeights kvdb.Database
+	Peers       kvdb.Database `table:"peer_"`
+	PeersTop    kvdb.Database `table:"top_peers_"`
+	PeerHeights kvdb.Database `table:"peer_height_"`
 
-	events kvdb.Database
-	hashes kvdb.Database
+	Events kvdb.Database `table:"event_"`
+	Hashes kvdb.Database `table:"hash_"`
+
+	Nonce       kvdb.Database `table:"nonce_"`
+	NonceTxs    kvdb.Database `table:"nonce_tx_"`
+	NonceEvents kvdb.Database `table:"nonce_event_"`
 
 	logger.Instance
 }
@@ -28,10 +28,10 @@ type Store struct {
 // NewStore creates store over key-value db.
 func NewStore(db kvdb.Database) *Store {
 	s := &Store{
-		physicalDB: db,
+		PhysicalDB: db,
 		Instance:   logger.MakeInstance(),
 	}
-	s.init()
+	s.Open()
 	return s
 }
 
@@ -41,164 +41,17 @@ func NewMemStore() *Store {
 	return NewStore(db)
 }
 
-func (s *Store) init() {
-	s.peers = kvdb.NewTable(s.physicalDB, "peer_")
-	s.peersTop = kvdb.NewTable(s.physicalDB, "top_peers_")
-	s.peerHeights = kvdb.NewTable(s.physicalDB, "peer_height_")
-
-	s.events = kvdb.NewTable(s.physicalDB, "event_")
-	s.hashes = kvdb.NewTable(s.physicalDB, "hash_")
+// Open populate underlying database.
+// Open() receiver type method satisfies an abstract database interface
+func (s *Store) Open() {
+	kvdb.MigrateTables(s, s.PhysicalDB, true)
 }
 
 // Close leaves underlying database.
+// Close() receiver type method satisfies the abstract database interface
 func (s *Store) Close() {
-	s.peerHeights = nil
-	s.peersTop = nil
-	s.peers = nil
-	s.events = nil
-	s.hashes = nil
-	s.physicalDB.Close()
-}
-
-// SetEvent stores event.
-func (s *Store) SetEvent(e *inter.Event) {
-	s.set(s.events, e.Hash().Bytes(), e.ToWire())
-}
-
-// GetWireEvent returns stored event.
-// Result is a ready gRPC message.
-func (s *Store) GetWireEvent(h hash.Event) *wire.Event {
-	w, _ := s.get(s.events, h.Bytes(), &wire.Event{}).(*wire.Event)
-	return w
-}
-
-// GetEvent returns stored event.
-func (s *Store) GetEvent(h hash.Event) *inter.Event {
-	w := s.GetWireEvent(h)
-	return inter.WireToEvent(w)
-}
-
-// SetEventHash stores hash.
-func (s *Store) SetEventHash(creator hash.Peer, index uint64, hash hash.Event) {
-	key := append(creator.Bytes(), intToBytes(index)...)
-
-	if err := s.hashes.Put(key, hash.Bytes()); err != nil {
-		s.Fatal(err)
-	}
-}
-
-// GetEventHash returns stored event hash.
-func (s *Store) GetEventHash(creator hash.Peer, index uint64) *hash.Event {
-	key := append(creator.Bytes(), intToBytes(index)...)
-
-	buf, err := s.hashes.Get(key)
-	if err != nil {
-		s.Fatal(err)
-	}
-	if buf == nil {
-		return nil
-	}
-
-	e := hash.BytesToEventHash(buf)
-	return &e
-}
-
-// HasEvent returns true if event exists.
-func (s *Store) HasEvent(h hash.Event) bool {
-	return s.has(s.events, h.Bytes())
-}
-
-// SetWirePeer stores peer info.
-func (s *Store) SetWirePeer(id hash.Peer, info *api.PeerInfo) {
-	s.set(s.peers, id.Bytes(), info)
-}
-
-// SetPeer stores peer.
-func (s *Store) SetPeer(peer *Peer) {
-	info := peer.ToWire()
-	s.SetWirePeer(peer.ID, info)
-}
-
-// GetWirePeer returns stored peer info.
-// Result is a ready gRPC message.
-func (s *Store) GetWirePeer(id hash.Peer) *api.PeerInfo {
-	w, _ := s.get(s.peers, id.Bytes(), &api.PeerInfo{}).(*api.PeerInfo)
-	return w
-}
-
-// GetPeer returns stored peer.
-func (s *Store) GetPeer(id hash.Peer) *Peer {
-	w := s.GetWirePeer(id)
-	return WireToPeer(w)
-}
-
-// BootstrapPeers stores peer list.
-func (s *Store) BootstrapPeers(peers ...*Peer) {
-	if len(peers) < 1 {
-		return
-	}
-
-	// save peers
-	batch := s.peers.NewBatch()
-	defer batch.Reset()
-
-	ids := make([]hash.Peer, 0, len(peers))
-	for _, peer := range peers {
-		// skip empty
-		if peer == nil || peer.PubKey == nil || peer.ID.IsEmpty() || peer.Host == "" {
-			continue
-		}
-
-		var pbf proto.Buffer
-		w := peer.ToWire()
-		if err := pbf.Marshal(w); err != nil {
-			s.Fatal(err)
-		}
-		if err := batch.Put(peer.ID.Bytes(), pbf.Bytes()); err != nil {
-			s.Fatal(err)
-		}
-		ids = append(ids, peer.ID)
-	}
-
-	if err := batch.Write(); err != nil {
-		s.Fatal(err)
-	}
-
-	s.SetTopPeers(ids)
-}
-
-// SetTopPeers stores peers.top.
-func (s *Store) SetTopPeers(ids []hash.Peer) {
-	var key = []byte("current")
-	w := IDsToWire(ids)
-	s.set(s.peersTop, key, w)
-}
-
-// GetTopPeers returns peers.top.
-func (s *Store) GetTopPeers() []hash.Peer {
-	var key = []byte("current")
-	w, _ := s.get(s.peersTop, key, &api.PeerIDs{}).(*api.PeerIDs)
-	return WireToIDs(w)
-}
-
-// SetPeerHeight stores last event index of peer.
-func (s *Store) SetPeerHeight(id hash.Peer, height uint64) {
-	if err := s.peerHeights.Put(id.Bytes(), intToBytes(height)); err != nil {
-		s.Fatal(err)
-	}
-}
-
-// GetPeerHeight returns last event index of peer.
-func (s *Store) GetPeerHeight(id hash.Peer) uint64 {
-	buf, err := s.peerHeights.Get(id.Bytes())
-	if err != nil {
-		s.Fatal(err)
-	}
-	if buf == nil {
-		return 0
-	}
-
-	return bytesToInt(buf)
+	kvdb.MigrateTables(s, s.PhysicalDB, false)
+	s.PhysicalDB.Close()
 }
 
 /*

--- a/src/posnode/store_event.go
+++ b/src/posnode/store_event.go
@@ -1,0 +1,55 @@
+package posnode
+
+import (
+	"github.com/Fantom-foundation/go-lachesis/src/hash"
+	"github.com/Fantom-foundation/go-lachesis/src/inter"
+	"github.com/Fantom-foundation/go-lachesis/src/inter/wire"
+)
+
+// SetEvent stores event.
+func (s *Store) SetEvent(e *inter.Event) {
+	s.set(s.Events, e.Hash().Bytes(), e.ToWire())
+}
+
+// GetEvent returns stored event.
+func (s *Store) GetEvent(h hash.Event) *inter.Event {
+	w := s.GetWireEvent(h)
+	return inter.WireToEvent(w)
+}
+
+// HasEvent returns true if event exists.
+func (s *Store) HasEvent(h hash.Event) bool {
+	return s.has(s.Events, h.Bytes())
+}
+
+// GetWireEvent returns stored event.
+// Result is a ready gRPC message.
+func (s *Store) GetWireEvent(h hash.Event) *wire.Event {
+	w, _ := s.get(s.Events, h.Bytes(), &wire.Event{}).(*wire.Event)
+	return w
+}
+
+// SetEventHash stores hash.
+func (s *Store) SetEventHash(creator hash.Peer, index uint64, hash hash.Event) {
+	key := append(creator.Bytes(), intToBytes(index)...)
+
+	if err := s.Hashes.Put(key, hash.Bytes()); err != nil {
+		s.Fatal(err)
+	}
+}
+
+// GetEventHash returns stored event hash.
+func (s *Store) GetEventHash(creator hash.Peer, index uint64) *hash.Event {
+	key := append(creator.Bytes(), intToBytes(index)...)
+
+	buf, err := s.Hashes.Get(key)
+	if err != nil {
+		s.Fatal(err)
+	}
+	if buf == nil {
+		return nil
+	}
+
+	e := hash.BytesToEventHash(buf)
+	return &e
+}

--- a/src/posnode/store_nonce.go
+++ b/src/posnode/store_nonce.go
@@ -1,0 +1,166 @@
+package posnode
+
+import (
+	"github.com/golang/protobuf/proto"
+
+	"github.com/Fantom-foundation/go-lachesis/src/hash"
+	"github.com/Fantom-foundation/go-lachesis/src/inter"
+	"github.com/Fantom-foundation/go-lachesis/src/inter/wire"
+)
+
+// SetNonce stores nonce for the specified node.
+func (s *Store) SetNonce(index uint64, creator hash.Peer) {
+	if err := s.Nonce.Put(creator.Bytes(), intToBytes(index)); err != nil {
+		panic(err)
+	}
+}
+
+// GetNonce returns nonce for the specified node.
+func (s *Store) GetNonce(creator hash.Peer) uint64 {
+	buf, err := s.Nonce.Get(creator.Bytes())
+	if err != nil {
+		panic(err)
+	}
+	if buf == nil {
+		return 0
+	}
+
+	return bytesToInt(buf)
+}
+
+// IncreaseNonce increases nonce value for the specified node depending on the number of transactions.
+func (s *Store) IncreaseNonce(creator hash.Peer, txs []*inter.InternalTransaction) (fromIndex uint64, toIndex uint64) {
+	txCount := uint64(len(txs))
+	fromIndex = s.GetNonce(creator)
+	toIndex = fromIndex + txCount
+	if txCount < 1 {
+		return
+	}
+
+	s.SetNonce(toIndex, creator)
+	return
+}
+
+// SetNonceEvent accepts transaction and stores the event
+// for the specified node, depending on the nonce value and creator.
+func (s *Store) SetNonceEvent(index uint64, e *inter.Event) {
+	if e == nil {
+		return
+	}
+	key := append(e.Creator.Bytes(), intToBytes(index)...)
+	s.set(s.NonceEvents, key, e.ToWire())
+}
+
+// SetBatchNonceEvent accepts multiple transactions and batch stores the event
+// for the specified node, depending on the nonce values and creator.
+func (s *Store) SetBatchNonceEvent(fromIndex uint64, e *inter.Event) {
+	txs := e.InternalTransactions
+	if e == nil || len(txs) < 1 {
+		return
+	}
+
+	batch := s.NonceEvents.NewBatch()
+	defer batch.Reset()
+
+	w := e.ToWire()
+	for i, tx := range txs {
+		if tx == nil {
+			continue
+		}
+
+		var pbf proto.Buffer
+		if err := pbf.Marshal(w); err != nil {
+			panic(err)
+		}
+		key := append(e.Creator.Bytes(), intToBytes(fromIndex+uint64(i))...)
+		if err := batch.Put(key, pbf.Bytes()); err != nil {
+			panic(err)
+		}
+	}
+
+	if err := batch.Write(); err != nil {
+		panic(err)
+	}
+}
+
+// GetNonceEvent returns the event
+// for the specified node, depending on the nonce value and creator.
+func (s *Store) GetNonceEvent(index uint64, creator hash.Peer) (e *inter.Event) {
+	w := s.GetNonceWireEvent(index, creator)
+	if w != nil {
+		e = inter.WireToEvent(w)
+	}
+	return
+}
+
+// GetNonceEvent returns the wire event
+// for the specified node, depending on the nonce value and creator.
+// As a result, this function returns a serialized protobuf message.
+func (s *Store) GetNonceWireEvent(index uint64, creator hash.Peer) (w *wire.Event) {
+	key := append(creator.Bytes(), intToBytes(index)...)
+	if s.has(s.NonceEvents, key) {
+		w = s.get(s.NonceEvents, key, &wire.Event{}).(*wire.Event)
+	}
+	return
+}
+
+// SetNonceTx accepts the transaction and stores it,
+// as a key are used the nonce value and creator.
+func (s *Store) SetNonceTx(index uint64, creator hash.Peer, tx *inter.InternalTransaction) {
+	if tx == nil {
+		return
+	}
+	key := append(creator.Bytes(), intToBytes(index)...)
+	s.set(s.NonceTxs, key, tx.ToWire())
+}
+
+// SetBatchNonceTx accepts multiple transactions and batch stores them,
+// as a key are used the nonce values and creator.
+func (s *Store) SetBatchNonceTx(fromIndex uint64, creator hash.Peer, txs []*inter.InternalTransaction) {
+	if len(txs) < 1 {
+		return
+	}
+
+	batch := s.NonceTxs.NewBatch()
+	defer batch.Reset()
+
+	for i, tx := range txs {
+		if tx == nil {
+			continue
+		}
+		var pbf proto.Buffer
+		w := tx.ToWire()
+		if err := pbf.Marshal(w); err != nil {
+			panic(err)
+		}
+		key := append(creator.Bytes(), intToBytes(fromIndex+uint64(i))...)
+		if err := batch.Put(key, pbf.Bytes()); err != nil {
+			panic(err)
+		}
+	}
+
+	if err := batch.Write(); err != nil {
+		panic(err)
+	}
+}
+
+// GetNonceTx returns the transaction
+// for the specified node, depending on the nonce value and creator.
+func (s *Store) GetNonceTx(index uint64, creator hash.Peer) (tx *inter.InternalTransaction) {
+	w := s.GetNonceWireTx(index, creator)
+	if w != nil {
+		tx = inter.WireToInternalTransaction(w)
+	}
+	return
+}
+
+// GetNonceWireTx returns the wire transaction
+// for the specified node, depending on the nonce value and creator.
+// As a result, this function returns a serialized protobuf message.
+func (s *Store) GetNonceWireTx(index uint64, creator hash.Peer) (tx *wire.InternalTransaction) {
+	key := append(creator.Bytes(), intToBytes(index)...)
+	if s.has(s.NonceTxs, key) {
+		tx = s.get(s.NonceTxs, key, &wire.InternalTransaction{}).(*wire.InternalTransaction)
+	}
+	return
+}

--- a/src/posnode/store_peer.go
+++ b/src/posnode/store_peer.go
@@ -1,0 +1,101 @@
+package posnode
+
+import (
+	"github.com/golang/protobuf/proto"
+
+	"github.com/Fantom-foundation/go-lachesis/src/hash"
+	"github.com/Fantom-foundation/go-lachesis/src/posnode/api"
+)
+
+// BootstrapPeers stores peer list.
+func (s *Store) BootstrapPeers(peers ...*Peer) {
+	if len(peers) < 1 {
+		return
+	}
+
+	// save peers
+	batch := s.Peers.NewBatch()
+	defer batch.Reset()
+
+	ids := make([]hash.Peer, 0, len(peers))
+	for _, peer := range peers {
+		// skip empty
+		if peer == nil || peer.PubKey == nil || peer.ID.IsEmpty() || peer.Host == "" {
+			continue
+		}
+
+		var pbf proto.Buffer
+		w := peer.ToWire()
+		if err := pbf.Marshal(w); err != nil {
+			s.Fatal(err)
+		}
+		if err := batch.Put(peer.ID.Bytes(), pbf.Bytes()); err != nil {
+			s.Fatal(err)
+		}
+		ids = append(ids, peer.ID)
+	}
+
+	if err := batch.Write(); err != nil {
+		s.Fatal(err)
+	}
+
+	s.SetTopPeers(ids)
+}
+
+// SetPeer stores peer.
+func (s *Store) SetPeer(peer *Peer) {
+	info := peer.ToWire()
+	s.SetWirePeer(peer.ID, info)
+}
+
+// GetPeer returns stored peer.
+func (s *Store) GetPeer(id hash.Peer) *Peer {
+	w := s.GetWirePeer(id)
+	return WireToPeer(w)
+}
+
+// SetWirePeer stores peer info.
+func (s *Store) SetWirePeer(id hash.Peer, info *api.PeerInfo) {
+	s.set(s.Peers, id.Bytes(), info)
+}
+
+// GetWirePeer returns stored peer info.
+// Result is a ready gRPC message.
+func (s *Store) GetWirePeer(id hash.Peer) *api.PeerInfo {
+	w, _ := s.get(s.Peers, id.Bytes(), &api.PeerInfo{}).(*api.PeerInfo)
+	return w
+}
+
+// SetTopPeers stores peers.top.
+func (s *Store) SetTopPeers(ids []hash.Peer) {
+	var key = []byte("current")
+	w := IDsToWire(ids)
+	s.set(s.PeersTop, key, w)
+}
+
+// GetTopPeers returns peers.top.
+func (s *Store) GetTopPeers() []hash.Peer {
+	var key = []byte("current")
+	w, _ := s.get(s.PeersTop, key, &api.PeerIDs{}).(*api.PeerIDs)
+	return WireToIDs(w)
+}
+
+// SetPeerHeight stores last event index of peer.
+func (s *Store) SetPeerHeight(id hash.Peer, height uint64) {
+	if err := s.PeerHeights.Put(id.Bytes(), intToBytes(height)); err != nil {
+		s.Fatal(err)
+	}
+}
+
+// GetPeerHeight returns last event index of peer.
+func (s *Store) GetPeerHeight(id hash.Peer) uint64 {
+	buf, err := s.PeerHeights.Get(id.Bytes())
+	if err != nil {
+		s.Fatal(err)
+	}
+	if buf == nil {
+		return 0
+	}
+
+	return bytesToInt(buf)
+}

--- a/src/posposet/store.go
+++ b/src/posposet/store.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/src/hash"
 	"github.com/Fantom-foundation/go-lachesis/src/kvdb"
 	"github.com/Fantom-foundation/go-lachesis/src/logger"
-	"github.com/Fantom-foundation/go-lachesis/src/posposet/wire"
 	"github.com/Fantom-foundation/go-lachesis/src/state"
 )
 
@@ -18,17 +17,17 @@ const cacheSize = 500 // TODO: Move it to config later
 // Store is a poset persistent storage working over physical key-value database.
 // TODO: cache tables with LRU.
 type Store struct {
-	physicalDB kvdb.Database
+	PhysicalDB kvdb.Database `store:"-"`
 
-	states      kvdb.Database
-	frames      kvdb.Database
-	blocks      kvdb.Database
-	event2frame kvdb.Database
+	States      kvdb.Database `table:"state_"`
+	Frames      kvdb.Database `table:"frame_"`
+	Blocks      kvdb.Database `table:"block_"`
+	Event2frame kvdb.Database `table:"event2frame_"`
 
 	framesCache      *lru.Cache
 	event2frameCache *lru.Cache
 
-	balances state.Database // trie
+	balances state.Database `store:"-"` // trie
 
 	logger.Instance
 }
@@ -36,11 +35,11 @@ type Store struct {
 // NewStore creates store over key-value db.
 func NewStore(db kvdb.Database, cached bool) *Store {
 	s := &Store{
-		physicalDB: db,
+		PhysicalDB: db,
 		Instance:   logger.MakeInstance(),
 	}
 
-	s.init()
+	s.Open()
 	if cached {
 		s.initCache()
 	}
@@ -52,16 +51,6 @@ func NewStore(db kvdb.Database, cached bool) *Store {
 func NewMemStore() *Store {
 	db := kvdb.NewMemDatabase()
 	return NewStore(db, false)
-}
-
-func (s *Store) init() {
-	s.states = kvdb.NewTable(s.physicalDB, "state_")
-	s.frames = kvdb.NewTable(s.physicalDB, "frame_")
-	s.blocks = kvdb.NewTable(s.physicalDB, "block_")
-	s.event2frame = kvdb.NewTable(s.physicalDB, "event2frame_")
-
-	s.balances = state.NewDatabase(
-		kvdb.NewTable(s.physicalDB, "balance_"))
 }
 
 func (s *Store) initCache() {
@@ -77,13 +66,18 @@ func (s *Store) initCache() {
 	s.event2frameCache = cache()
 }
 
+// Open populate underlying database.
+// Open() receiver type method satisfies an abstract database interface
+func (s *Store) Open() {
+	kvdb.MigrateTables(s, s.PhysicalDB, true)
+	s.balances = state.NewDatabase(kvdb.NewTable(s.PhysicalDB, "balance_"))
+}
+
 // Close leaves underlying database.
+// Close() receiver type method satisfies the abstract database interface
 func (s *Store) Close() {
-	s.event2frame = nil
-	s.balances = nil
-	s.frames = nil
-	s.states = nil
-	s.physicalDB.Close()
+	kvdb.MigrateTables(s, nil, false)
+	s.PhysicalDB.Close()
 
 	s.framesCache.Purge()
 	s.event2frameCache.Purge()
@@ -128,102 +122,6 @@ func (s *Store) ApplyGenesis(balances map[hash.Peer]uint64) error {
 	return nil
 }
 
-// SetEventFrame stores frame num of event.
-func (s *Store) SetEventFrame(e hash.Event, frame uint64) {
-	key := e.Bytes()
-	val := intToBytes(frame)
-	if err := s.event2frame.Put(key, val); err != nil {
-		s.Fatal(err)
-	}
-
-	if s.event2frameCache != nil {
-		s.event2frameCache.Add(e, frame)
-	}
-}
-
-// GetEventFrame returns frame num of event.
-func (s *Store) GetEventFrame(e hash.Event) *uint64 {
-	if s.event2frameCache != nil {
-		if n, ok := s.event2frameCache.Get(e); ok {
-			num := n.(uint64)
-			return &num
-		}
-	}
-
-	key := e.Bytes()
-	buf, err := s.event2frame.Get(key)
-	if err != nil {
-		s.Fatal(err)
-	}
-	if buf == nil {
-		return nil
-	}
-
-	val := bytesToInt(buf)
-	return &val
-}
-
-// SetState stores state.
-// State is seldom read; so no cache.
-func (s *Store) SetState(st *State) {
-	const key = "current"
-	s.set(s.states, []byte(key), st.ToWire())
-
-}
-
-// GetState returns stored state.
-// State is seldom read; so no cache.
-func (s *Store) GetState() *State {
-	const key = "current"
-	w, _ := s.get(s.states, []byte(key), &wire.State{}).(*wire.State)
-	return WireToState(w)
-}
-
-// SetFrame stores event.
-func (s *Store) SetFrame(f *Frame) {
-	w := f.ToWire()
-	s.set(s.frames, intToBytes(f.Index), w)
-
-	if s.framesCache != nil {
-		s.framesCache.Add(f.Index, w)
-	}
-}
-
-// GetFrame returns stored frame.
-func (s *Store) GetFrame(n uint64) *Frame {
-	if s.framesCache != nil {
-		if f, ok := s.framesCache.Get(n); ok {
-			w := f.(*wire.Frame)
-			return WireToFrame(w)
-		}
-	}
-
-	w, _ := s.get(s.frames, intToBytes(n), &wire.Frame{}).(*wire.Frame)
-	return WireToFrame(w)
-}
-
-// SetBlock stores chain block.
-// State is seldom read; so no cache.
-func (s *Store) SetBlock(b *Block) {
-	s.set(s.blocks, intToBytes(b.Index), b.ToWire())
-}
-
-// GetBlock returns stored block.
-// State is seldom read; so no cache.
-func (s *Store) GetBlock(n uint64) *Block {
-	w, _ := s.get(s.blocks, intToBytes(n), &wire.Block{}).(*wire.Block)
-	return WireToBlock(w)
-}
-
-// StateDB returns state database.
-func (s *Store) StateDB(from hash.Hash) *state.DB {
-	db, err := state.New(from, s.balances)
-	if err != nil {
-		s.Fatal(err)
-	}
-	return db
-}
-
 /*
  * Utils:
  */
@@ -232,18 +130,18 @@ func (s *Store) set(table kvdb.Database, key []byte, val proto.Message) {
 	var pbf proto.Buffer
 
 	if err := pbf.Marshal(val); err != nil {
-		s.Fatal(err)
+		panic(err)
 	}
 
 	if err := table.Put(key, pbf.Bytes()); err != nil {
-		s.Fatal(err)
+		panic(err)
 	}
 }
 
 func (s *Store) get(table kvdb.Database, key []byte, to proto.Message) proto.Message {
 	buf, err := table.Get(key)
 	if err != nil {
-		s.Fatal(err)
+		panic(err)
 	}
 	if buf == nil {
 		return nil
@@ -251,7 +149,7 @@ func (s *Store) get(table kvdb.Database, key []byte, to proto.Message) proto.Mes
 
 	err = proto.Unmarshal(buf, to)
 	if err != nil {
-		s.Fatal(err)
+		panic(err)
 	}
 	return to
 }
@@ -259,7 +157,7 @@ func (s *Store) get(table kvdb.Database, key []byte, to proto.Message) proto.Mes
 func (s *Store) has(table kvdb.Database, key []byte) bool {
 	res, err := table.Has(key)
 	if err != nil {
-		s.Fatal(err)
+		panic(err)
 	}
 	return res
 }

--- a/src/posposet/store_block.go
+++ b/src/posposet/store_block.go
@@ -1,0 +1,16 @@
+package posposet
+
+import "github.com/Fantom-foundation/go-lachesis/src/posposet/wire"
+
+// SetBlock stores chain block.
+// State is seldom read; so no cache.
+func (s *Store) SetBlock(b *Block) {
+	s.set(s.Blocks, intToBytes(b.Index), b.ToWire())
+}
+
+// GetBlock returns stored block.
+// State is seldom read; so no cache.
+func (s *Store) GetBlock(n uint64) *Block {
+	w, _ := s.get(s.Blocks, intToBytes(n), &wire.Block{}).(*wire.Block)
+	return WireToBlock(w)
+}

--- a/src/posposet/store_frame.go
+++ b/src/posposet/store_frame.go
@@ -1,0 +1,64 @@
+package posposet
+
+import (
+	"github.com/Fantom-foundation/go-lachesis/src/hash"
+	"github.com/Fantom-foundation/go-lachesis/src/posposet/wire"
+)
+
+// SetFrame stores event.
+func (s *Store) SetFrame(f *Frame) {
+	w := f.ToWire()
+	s.set(s.Frames, intToBytes(f.Index), w)
+
+	if s.framesCache != nil {
+		s.framesCache.Add(f.Index, w)
+	}
+}
+
+// GetFrame returns stored frame.
+func (s *Store) GetFrame(n uint64) *Frame {
+	if s.framesCache != nil {
+		if f, ok := s.framesCache.Get(n); ok {
+			w := f.(*wire.Frame)
+			return WireToFrame(w)
+		}
+	}
+
+	w, _ := s.get(s.Frames, intToBytes(n), &wire.Frame{}).(*wire.Frame)
+	return WireToFrame(w)
+}
+
+// SetEventFrame stores frame num of event.
+func (s *Store) SetEventFrame(e hash.Event, frame uint64) {
+	key := e.Bytes()
+	val := intToBytes(frame)
+	if err := s.Event2frame.Put(key, val); err != nil {
+		s.Fatal(err)
+	}
+
+	if s.event2frameCache != nil {
+		s.event2frameCache.Add(e, frame)
+	}
+}
+
+// GetEventFrame returns frame num of event.
+func (s *Store) GetEventFrame(e hash.Event) *uint64 {
+	if s.event2frameCache != nil {
+		if n, ok := s.event2frameCache.Get(e); ok {
+			num := n.(uint64)
+			return &num
+		}
+	}
+
+	key := e.Bytes()
+	buf, err := s.Event2frame.Get(key)
+	if err != nil {
+		s.Fatal(err)
+	}
+	if buf == nil {
+		return nil
+	}
+
+	val := bytesToInt(buf)
+	return &val
+}

--- a/src/posposet/store_state.go
+++ b/src/posposet/store_state.go
@@ -1,0 +1,32 @@
+package posposet
+
+import (
+	"github.com/Fantom-foundation/go-lachesis/src/hash"
+	"github.com/Fantom-foundation/go-lachesis/src/posposet/wire"
+	"github.com/Fantom-foundation/go-lachesis/src/state"
+)
+
+// StateDB returns state database.
+func (s *Store) StateDB(from hash.Hash) *state.DB {
+	db, err := state.New(from, s.balances)
+	if err != nil {
+		panic(err)
+	}
+	return db
+}
+
+// SetState stores state.
+// State is seldom read; so no cache.
+func (s *Store) SetState(st *State) {
+	const key = "current"
+	s.set(s.States, []byte(key), st.ToWire())
+
+}
+
+// GetState returns stored state.
+// State is seldom read; so no cache.
+func (s *Store) GetState() *State {
+	const key = "current"
+	w, _ := s.get(s.States, []byte(key), &wire.State{}).(*wire.State)
+	return WireToState(w)
+}


### PR DESCRIPTION
Proposal for solving the problem of collisions and transactions idempotency:

* Nonce counts on the side of each node and counts on its own.
* Each public key counts its Nonce on the side of each node
* Added `nonce_`,` nonce_event_`, `nonce_tx_` tables
* Added methods for getting data such as Event and transaction data using public + key.
* Since the tables were created by calling the same code via kvdb.NewTable (db, tableName), and then reset by assignment - therefore, the function for generating migration was added, which also serves to assign nil values ​​for tables using reflect using tags