### PR TITLE
 src/posnode: fix api/wire_test.go for travis

### DIFF
--- a/src/posnode/api/wire_test.go
+++ b/src/posnode/api/wire_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -14,15 +15,17 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/src/hash"
 	"github.com/Fantom-foundation/go-lachesis/src/inter/wire"
 	"github.com/Fantom-foundation/go-lachesis/src/network"
+	"github.com/Fantom-foundation/go-lachesis/src/utils"
 )
 
 // gen is an empty genesis hash.
 var gen hash.Hash
 
 func TestGRPC(t *testing.T) {
+	bind_addr := fmt.Sprintf("127.0.0.1:%d", utils.FreePort("tcp4"))
 
 	t.Run("over TCP", func(t *testing.T) {
-		testGRPC(t, "", "::1", network.TCPListener)
+		testGRPC(t, bind_addr, "127.0.0.1", network.TCPListener)
 	})
 
 	t.Run("over Fake", func(t *testing.T) {


### PR DESCRIPTION
Travis uses IPv4 when empty bind address is specified, thus we need explicitly specify IPv4 loopback to have the test stable across all platforms.