### PR TITLE
Refactor the way new block subscription works by using a callback

### DIFF
--- a/src/posposet/poset_test.go
+++ b/src/posposet/poset_test.go
@@ -18,6 +18,7 @@ func TestPoset(t *testing.T) {
 		posets[i], _, inputs[i] = FakePoset(nodes)
 		posets[i].SetName(nodes[i].String())
 		posets[i].store.SetName(nodes[i].String())
+		posets[i].Start()
 	}
 
 	t.Run("Multiple start", func(t *testing.T) {
@@ -87,6 +88,10 @@ func TestPoset(t *testing.T) {
 		posets[0].Stop()
 		posets[0].Stop()
 	})
+
+	for i := 0; i < len(nodes); i++ {
+		posets[i].Stop()
+	}
 }
 
 /*

--- a/src/posposet/transaction_test.go
+++ b/src/posposet/transaction_test.go
@@ -38,6 +38,7 @@ func TestPosetTxn(t *testing.T) {
 		uint64(1), p.StakeOf(nodes[1]),
 		"balance of %s", nodes[1].String())
 
+	p.Start()
 	for _, n := range nodes {
 		for _, e := range events[n] {
 			x.SetEvent(e)
@@ -54,5 +55,5 @@ func TestPosetTxn(t *testing.T) {
 	assert.Equal(t,
 		uint64(2), p.StakeOf(nodes[1]),
 		"balance of %s", nodes[1].String())
-
+	p.Stop()
 }


### PR DESCRIPTION
Make a public channel private, add a callback in its stead that doesn't block consensus if it's not used and cannot be accidentally overwritten