### PR TITLE
Reduce peer connection noise. 

### DIFF
--- a/src/posnode/discovery.go
+++ b/src/posnode/discovery.go
@@ -98,6 +98,9 @@ func (n *Node) AskPeerInfo(host string, id *hash.Peer) {
 	if !n.PeerReadyForReq(host) {
 		return
 	}
+	if !n.HostUnknown(&host) {
+		return
+	}
 	if !n.PeerUnknown(id) {
 		return
 	}
@@ -144,7 +147,11 @@ func (n *Node) AskPeerInfo(host string, id *hash.Peer) {
 	info.Host = host
 	peer = WireToPeer(info)
 	n.store.SetWirePeer(peer.ID, info)
-	n.Debugf("discovered new peer %s with host %s", info.ID, info.Host)
+	if n.PeerUnknown(&peer.ID) {
+		n.Infof("discovered new peer %s with host %s", info.ID, info.Host)
+	} else {
+		n.Debugf("discovered peer %s with host %s", info.ID, info.Host)
+	}
 	n.ConnectOK(peer)
 }
 

--- a/src/posnode/peers.go
+++ b/src/posnode/peers.go
@@ -157,6 +157,23 @@ func (n *Node) PeerReadyForReq(host string) bool {
 			attr.LastSuccess.Before(timeout))
 }
 
+// HostUnknown returns true if peer should be discovered.
+func (n *Node) HostUnknown(address *string) bool {
+	if nil == address {
+		return true
+	}
+
+	n.peers.RLock()
+	defer n.peers.RUnlock()
+
+	attr := n.peers.attrByHost(*address)
+
+	timeout := time.Now().Add(-n.conf.DiscoveryTimeout)
+
+	return attr == nil ||
+		(attr.LastSuccess.Before(timeout) && attr.LastFail.Before(timeout))
+}
+
 // PeerUnknown returns true if peer should be discovered.
 func (n *Node) PeerUnknown(id *hash.Peer) bool {
 	if id.IsEmpty() {

--- a/src/posnode/peers_test.go
+++ b/src/posnode/peers_test.go
@@ -36,7 +36,7 @@ func TestPeerReadyForReq(t *testing.T) {
 		assertar.False(node.PeerReadyForReq(host.Name))
 	})
 
-	t.Run("last fail timeouted", func(t *testing.T) {
+	t.Run("last fail timed out", func(t *testing.T) {
 		assertar := assert.New(t)
 
 		host := &hostAttr{
@@ -97,6 +97,52 @@ func TestPeerUnknown(t *testing.T) {
 		assertar := assert.New(t)
 
 		assertar.True(node.PeerUnknown(nil))
+	})
+}
+
+func TestHostUnknown(t *testing.T) {
+	logger.SetTestMode(t)
+
+	store := NewMemStore()
+	node := NewForTests("node03", store, nil)
+	node.initPeers()
+	defer node.Stop()
+
+	t.Run("last success", func(t *testing.T) {
+		is := assert.New(t)
+
+		host := &hostAttr{
+			Name:        "last-success",
+			LastSuccess: time.Now().Truncate(node.conf.DiscoveryTimeout),
+		}
+		node.peers.hosts[host.Name] = host
+
+		is.False(node.HostUnknown(&host.Name))
+	})
+
+	t.Run("host known", func(t *testing.T) {
+		is := assert.New(t)
+
+		host := &hostAttr{
+			Name:        "known",
+			LastSuccess: time.Now(),
+		}
+		node.peers.hosts[host.Name] = host
+
+		is.False(node.HostUnknown(&host.Name))
+	})
+
+	t.Run("host unknown", func(t *testing.T) {
+		is := assert.New(t)
+
+		unknown := "unknown"
+		is.True(node.HostUnknown(&unknown))
+	})
+
+	t.Run("nil host", func(t *testing.T) {
+		is := assert.New(t)
+
+		is.True(node.HostUnknown(nil))
 	})
 }
 


### PR DESCRIPTION
There were too many "discovered new peer" messages when they aren't actually new peers