### PR TITLE
Migrate POS codebase to BoltDB

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 2c3d4e35b6d8fc3458a8634142f5660a3500b6412432c9351867f4ccc468043d
-updated: 2019-06-10T08:01:35.474316455+07:00
+hash: 944ff49dfde2eb4fb59089039c11034736c5fb77f3c43942f3d1cfcee21f397f
+updated: 2019-06-17T11:02:50.186914+07:00
 imports:
 - name: github.com/allegro/bigcache
   version: 84a0ff3f153cbd7e280a19029a864bb04b504e62
@@ -89,7 +89,6 @@ imports:
   subpackages:
   - prometheus
   - prometheus/internal
-  - prometheus/promauto
   - prometheus/promhttp
 - name: github.com/prometheus/client_model
   version: fd36f4220a901265f90734c3183c5f0c91daa0b8
@@ -102,7 +101,7 @@ imports:
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: 1de2bc567d78f4ff415fd103412f7e5ec9e8876b
+  version: 90b65b6334013b0a1cfce27ce5c79feb7da2f77a
   subpackages:
   - internal/fs
 - name: github.com/rifflock/lfshook
@@ -129,8 +128,10 @@ imports:
   version: 246bd1df1758fe9df5a88fc3e0f6e77271e97e55
 - name: github.com/urfave/cli
   version: cfb38830724cc34fedffe9a2a29fb54fa9169cd1
+- name: go.etcd.io/bbolt
+  version: a0458a2b35708eef59eb5f620ceb3cd1c01a824d
 - name: golang.org/x/crypto
-  version: f99c8df09eb5bff426315721bfa5f16a99cad32c
+  version: 5c40567a22f818bd14a1ea7245dad9f8ef0691aa
   subpackages:
   - sha3
 - name: golang.org/x/net

--- a/glide.yaml
+++ b/glide.yaml
@@ -56,6 +56,8 @@ import:
   - sha3
 - package: github.com/prometheus/client_golang
   version: ^0.9.4
+- package: go.etcd.io/bbolt
+  version: ^1.3.3
 testImport:
 - package: github.com/davecgh/go-spew
   version: ^1.1.1

--- a/src/kvdb/bolt_database.go
+++ b/src/kvdb/bolt_database.go
@@ -1,0 +1,144 @@
+package kvdb
+
+import (
+	"github.com/Fantom-foundation/go-lachesis/src/common"
+	"go.etcd.io/bbolt"
+)
+
+const defaultBucketName = "default_bucket"
+
+// BoltDatabase is a kvbd.Database wrapper of *bbolt.DB
+type BoltDatabase struct {
+	db                *bbolt.DB
+	defaultBucketName []byte
+}
+
+// NewBoltDatabase wraps *bbolt.DB
+func NewBoltDatabase(db *bbolt.DB) *BoltDatabase {
+	bucketName := []byte(defaultBucketName)
+
+	// Won't return an error since bucketName is not blank or too long
+	_ = db.Update(func(tx *bbolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(bucketName)
+
+		return err
+	})
+
+	return &BoltDatabase{
+		db:                db,
+		defaultBucketName: bucketName,
+	}
+}
+
+/*
+ * Database interface implementation
+ */
+
+// Put puts key-value pair into batch.
+func (w *BoltDatabase) Put(key []byte, value []byte) error {
+	return w.db.Update(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket(w.defaultBucketName)
+
+		return bucket.Put(key, value)
+	})
+}
+
+// Has checks if key is in the db.
+func (w *BoltDatabase) Has(key []byte) (exists bool, err error) {
+	err = w.db.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket(w.defaultBucketName)
+		exists = bucket.Get(key) != nil
+
+		return nil
+	})
+
+	return
+}
+
+// Get returns key-value pair by key.
+func (w *BoltDatabase) Get(key []byte) (val []byte, err error) {
+	err = w.db.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket(w.defaultBucketName)
+		val = common.CopyBytes(bucket.Get(key))
+
+		return nil
+	})
+
+	return
+}
+
+// Delete removes key-value pair by key.
+func (w *BoltDatabase) Delete(key []byte) error {
+	return w.db.Update(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket(w.defaultBucketName)
+
+		return bucket.Delete(key)
+	})
+}
+
+// Close leaves underlying database.
+func (w *BoltDatabase) Close() {
+	w.db = nil
+}
+
+// NewBatch creates new batch.
+func (w *BoltDatabase) NewBatch() Batch {
+	return &boltBatch{wrapper: w}
+}
+
+/*
+ * Batch
+ */
+
+// boltBatch is a batch structure
+type boltBatch struct {
+	wrapper *BoltDatabase
+	writes  []kv
+	size    int
+}
+
+// Put puts key-value pair into batch.
+func (b *boltBatch) Put(key, value []byte) error {
+	b.writes = append(b.writes, kv{common.CopyBytes(key), common.CopyBytes(value), false})
+	b.size += len(value)
+	return nil
+}
+
+// Delete removes key-value pair from batch by key.
+func (b *boltBatch) Delete(key []byte) error {
+	b.writes = append(b.writes, kv{common.CopyBytes(key), nil, true})
+	b.size++
+	return nil
+}
+
+// Write writes batch into db.
+func (b *boltBatch) Write() error {
+	return b.wrapper.db.Update(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket(b.wrapper.defaultBucketName)
+
+		for _, kv := range b.writes {
+			var err error
+			if kv.del {
+				err = bucket.Delete(kv.k)
+			} else {
+				err = bucket.Put(kv.k, kv.v)
+			}
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+// ValueSize returns values sizes sum.
+func (b *boltBatch) ValueSize() int {
+	return b.size
+}
+
+// Reset cleans whole batch.
+func (b *boltBatch) Reset() {
+	b.writes = b.writes[:0]
+	b.size = 0
+}

--- a/src/poslachesis/lachesis.go
+++ b/src/poslachesis/lachesis.go
@@ -1,7 +1,7 @@
 package lachesis
 
 import (
-	"github.com/dgraph-io/badger"
+	"go.etcd.io/bbolt"
 	"google.golang.org/grpc"
 
 	"github.com/Fantom-foundation/go-lachesis/src/crypto"
@@ -28,11 +28,11 @@ type Lachesis struct {
 
 // New makes lachesis node.
 // It does not start any process.
-func New(db *badger.DB, host string, key *crypto.PrivateKey, conf *Config, opts ...grpc.DialOption) *Lachesis {
+func New(db *bbolt.DB, host string, key *crypto.PrivateKey, conf *Config, opts ...grpc.DialOption) *Lachesis {
 	return makeLachesis(db, host, key, conf, nil, opts...)
 }
 
-func makeLachesis(db *badger.DB, host string, key *crypto.PrivateKey, conf *Config, listen network.ListenFunc, opts ...grpc.DialOption) *Lachesis {
+func makeLachesis(db *bbolt.DB, host string, key *crypto.PrivateKey, conf *Config, listen network.ListenFunc, opts ...grpc.DialOption) *Lachesis {
 	ndb, cdb := makeStorages(db)
 
 	if conf == nil {
@@ -89,7 +89,7 @@ func (l *Lachesis) AddPeers(hosts ...string) {
  * Utils:
  */
 
-func makeStorages(db *badger.DB) (*posnode.Store, *posposet.Store) {
+func makeStorages(db *bbolt.DB) (*posnode.Store, *posposet.Store) {
 	var (
 		p      kvdb.Database
 		n      kvdb.Database
@@ -100,7 +100,7 @@ func makeStorages(db *badger.DB) (*posnode.Store, *posposet.Store) {
 		n = kvdb.NewMemDatabase()
 		cached = false
 	} else {
-		db := kvdb.NewBadgerDatabase(db)
+		db := kvdb.NewBoltDatabase(db)
 		p = kvdb.NewTable(db, "p_")
 		n = kvdb.NewTable(db, "n_")
 		cached = true

--- a/src/poslachesis/lachesis_test.go
+++ b/src/poslachesis/lachesis_test.go
@@ -1,10 +1,9 @@
 package lachesis
 
 import (
+	"go.etcd.io/bbolt"
 	"testing"
 	"time"
-
-	"github.com/dgraph-io/badger"
 
 	"github.com/Fantom-foundation/go-lachesis/src/crypto"
 	"github.com/Fantom-foundation/go-lachesis/src/logger"
@@ -47,7 +46,7 @@ func TestStar(t *testing.T) {
 // NewForTests makes lachesis node with fake network.
 // It does not start any process.
 func NewForTests(
-	db *badger.DB,
+	db *bbolt.DB,
 	host string,
 	key *crypto.PrivateKey,
 	conf *Config,


### PR DESCRIPTION
This pull request changes node storage engine to BoltDB, due to Badger inefficiency in regards to database size on disk