### PR TITLE
CacheWrapper

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: cb61e490db5de04f1b5fc5a0781619f2cb5aa02a754053cea8fb43d50885d1f9
-updated: 2019-07-26T12:49:10.047773342+10:00
+hash: 769981e2bcae5add1c12808b60a8a6d4633205d6753e041d49bb9e623eb9fcb1
+updated: 2019-07-31T17:58:16.878678101+07:00
 imports:
 - name: github.com/allegro/bigcache
   version: 0605c28b510103c549fb020d5fb50e1ad4093de8
@@ -29,6 +29,22 @@ imports:
   version: 6a90982ecee230ff6cba02d5bd386acc030be9d3
 - name: github.com/dustin/go-humanize
   version: 9f541cc9db5d55bce703bd99987c9d5cb8eea45e
+- name: github.com/emirpasic/gods
+  version: 1615341f118ae12f353cc8a983f35b584342c9b3
+  subpackages:
+  - containers
+  - maps
+  - maps/treemap
+  - trees
+  - trees/redblacktree
+  - utils
+- name: github.com/ethereum/go-ethereum
+  version: 7f3362595a3bdf1c27b17f16b7d90d89882312ab
+  subpackages:
+  - common
+  - common/hexutil
+  - common/math
+  - crypto/secp256k1
 - name: github.com/evalphobia/logrus_sentry
   version: ab0fa2ee9517a8e8c1de1c07e492e8164f852529
 - name: github.com/facebookgo/atomicfile
@@ -61,7 +77,7 @@ imports:
 - name: github.com/hashicorp/go-multierror
   version: 886a7fbe3eb1c874d46f623bfa70af45f425b3d1
 - name: github.com/hashicorp/golang-lru
-  version: 7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c
+  version: 7f827b33c0f158ec5dfbba01bb0b14a4541fd81d
   subpackages:
   - simplelru
 - name: github.com/hashicorp/hcl
@@ -140,7 +156,7 @@ imports:
 - name: go.etcd.io/bbolt
   version: a0458a2b35708eef59eb5f620ceb3cd1c01a824d
 - name: golang.org/x/crypto
-  version: 4def268fd1a49955bfb3dda92fe3db4f924f2285
+  version: cc06ce4a13d484c0101a9e92913248488a75786d
   subpackages:
   - sha3
 - name: golang.org/x/net

--- a/glide.yaml
+++ b/glide.yaml
@@ -64,6 +64,8 @@ import:
   version: master
 - package: go.etcd.io/bbolt
   version: ^1.3.3
+- package: github.com/emirpasic/gods
+  version: ~1.12.0
 testImport:
 - package: github.com/davecgh/go-spew
   version: ^1.1.1

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/dgraph-io/badger v0.0.0-20190308055650-deee8c7ae70b
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/evalphobia/logrus_sentry v0.8.2
 	github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5 // indirect
 	github.com/facebookgo/pidfile v0.0.0-20150612191647-f242e2999868

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUn
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
+github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/evalphobia/logrus_sentry v0.8.2 h1:dotxHq+YLZsT1Bb45bB5UQbfCh3gM/nFFetyN46VoDQ=
 github.com/evalphobia/logrus_sentry v0.8.2/go.mod h1:pKcp+vriitUqu9KiWj/VRFbRfFNUwz95/UkgG8a6MNc=
 github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5 h1:BBso6MBKW8ncyZLv37o+KNyy0HrrHgfnOaGQC2qvN+A=

--- a/src/kvdb/cache_wrapper.go
+++ b/src/kvdb/cache_wrapper.go
@@ -1,0 +1,330 @@
+package kvdb
+
+import (
+	"bytes"
+	"errors"
+	"sync"
+
+	rbt "github.com/emirpasic/gods/trees/redblacktree"
+
+	"github.com/Fantom-foundation/go-lachesis/src/common"
+)
+
+// CacheWrapper is a kvdb.Database wrapper around any BatchedDatabase.
+// On reading, it looks in memory cache first. If not found, it looks in a parent DB.
+// On writing, it writes only in cache. To flush the cache into parent DB, call Flush().
+type CacheWrapper struct {
+	parent Database
+	prefix []byte
+
+	modified *rbt.Tree // modified, comparing to parent, pairs. deleted values are nil
+
+	lock *sync.Mutex // we have no guarantees that rbt.Tree works with concurrent reads, so we can't use MutexRW
+}
+
+// NewCacheWrapper wraps parent. All the writes into the cache won't be written in parent until .Flush() is called.
+func NewCacheWrapper(parent Database) *CacheWrapper {
+	return &CacheWrapper{
+		parent:   parent,
+		modified: rbt.NewWithStringComparator(),
+		lock:     new(sync.Mutex),
+	}
+}
+
+/*
+ * Database interface implementation
+ */
+
+// NewTableFlushable returns a Database object that prefixes all keys with a given prefix.
+func (w *CacheWrapper) NewTableFlushable(prefix []byte) FlushableDatabase {
+	base := common.CopyBytes(w.prefix)
+	return &CacheWrapper{
+		parent:   w.parent,
+		modified: w.modified,
+		prefix:   append(append(base, []byte("-")...), prefix...),
+		lock:     w.lock,
+	}
+}
+
+// NewTable returns a Database object that prefixes all keys with a given prefix.
+func (w *CacheWrapper) NewTable(prefix []byte) Database {
+	return w.NewTableFlushable(prefix)
+}
+
+// prefixed key
+func (w *CacheWrapper) fullKey(key []byte) []byte {
+	base := common.CopyBytes(w.prefix)
+	return append(append(base, separator...), key...)
+}
+
+// Put puts key-value pair into the cache.
+func (w *CacheWrapper) Put(key []byte, value []byte) error {
+	if value == nil {
+		return errors.New("CacheWrapper: value is nil")
+	}
+
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	key = w.fullKey(key)
+
+	w.modified.Put(string(key), common.CopyBytes(value))
+	return nil
+}
+
+// Has checks if key is in the exists. Looks in cache first, then - in DB.
+func (w *CacheWrapper) Has(key []byte) (bool, error) {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	key = w.fullKey(key)
+
+	val, ok := w.modified.Get(string(key))
+	if ok {
+		return val != nil, nil
+	}
+	return w.parent.Has(key)
+}
+
+// Get returns key-value pair by key. Looks in cache first, then - in DB.
+func (w *CacheWrapper) Get(key []byte) ([]byte, error) {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	key = w.fullKey(key)
+
+	if entry, ok := w.modified.Get(string(key)); ok {
+		if entry == nil {
+			return nil, nil
+		}
+		return common.CopyBytes(entry.([]byte)), nil
+	}
+	return w.parent.Get(key)
+}
+
+// returns the smallest node which is > than specified node
+func nextNode(tree *rbt.Tree, node *rbt.Node) (next *rbt.Node, ok bool) {
+	origin := node
+	if node.Right != nil {
+		node = node.Right
+		for node.Left != nil {
+			node = node.Left
+		}
+		return node, node != nil
+	}
+	if node.Parent != nil {
+		for node.Parent != nil {
+			node = node.Parent
+			if tree.Comparator(origin.Key, node.Key) <= 0 {
+				return node, node != nil
+			}
+		}
+	}
+
+	return nil, false
+}
+
+func castToPair(node *rbt.Node) (key, val []byte) {
+	if node == nil {
+		return nil, nil
+	}
+	key = []byte(node.Key.(string))
+	if node.Value == nil {
+		val = nil // deleted key
+	} else {
+		val = node.Value.([]byte) // putted value
+	}
+	return key, val
+}
+
+// ForEach scans key-value pair by key prefix in lexicographic order. Looks in cache first, then - in DB.
+func (w *CacheWrapper) ForEach(prefix []byte, do func(key, val []byte) bool) error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	prefix = w.fullKey(prefix)
+	globalCont := true // if false, stop iterating both parent and tree
+
+	// call 'do' if pair qualifies
+	doIfSuitable := func(key, val, prevKey []byte) (cont bool, newPrevKey []byte) {
+		// if false, stop iterating both parent and tree
+		if !globalCont {
+			return false, prevKey
+		}
+		// check that prefixed. stop iterating tree if it is
+		if !bytes.HasPrefix(key, prefix) {
+			return false, prevKey
+		}
+		// check that val != nil (it means it's removed in tree). move to next tree's key if it is
+		if val == nil {
+			return true, key
+		}
+		// check that parent's key is bigger than prev returned key. move to next key if it is
+		if prevKey == nil || bytes.Compare(key, prevKey) > 0 {
+			// erase key's prefix, because I'm a table for external world
+			globalCont = do(key[len(w.prefix)+len(separator):], val) // if 'do' returned false, then never call it again
+			return globalCont, key                                   // next key must be greater
+		}
+		return true, key
+	}
+
+	// read first pair from tree
+	treeNode, treeOk := w.modified.Ceiling(string(prefix)) // not strict >=
+	treeKey, treeVal := castToPair(treeNode)
+	var prevKey []byte
+
+	step := func(parentKey, parentVal []byte) bool {
+		// until key from the tree is <= parents's key, use tree's key (because it has priority over parent pairs)
+		for treeOk && (parentKey == nil || bytes.Compare(treeKey, parentKey) <= 0) {
+			// it's not possible that treeKey isn't bigger than prevKey
+			// treeKey may be not prefixed
+			// treeVal may be nil (i.e. deleted)
+			treeOk, prevKey = doIfSuitable(treeKey, treeVal, prevKey)
+			if !treeOk {
+				break
+			}
+			treeNode, treeOk = nextNode(w.modified, treeNode) // strict >
+			treeKey, treeVal = castToPair(treeNode)
+		}
+		if parentKey == nil {
+			return false // dummy flag, passed below. means that we shouldn't use parent's pair
+		}
+		// try to use parents's key
+
+		// it's possible that parentKey is smaller than prevKey
+		// parentKey is prefixed
+		// parentVal cannot be nil
+		// parentKey may be deleted in tree (so we shouldn't use it). but it'll be checked anyway by comparing with prevKey
+		var cont bool
+		cont, prevKey = doIfSuitable(parentKey, parentVal, prevKey)
+		return cont
+	}
+	// read values from both parent and tree. tree has priority over parent
+	err := w.parent.ForEach(prefix, step)
+	if err != nil {
+		return err
+	}
+	// read all the left pairs from tree
+	if globalCont {
+		step(nil, nil)
+	}
+
+	return nil
+}
+
+// Delete removes key-value pair by key. In parent DB, key won't be deleted until .Flush() is called.
+func (w *CacheWrapper) Delete(key []byte) error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	key = w.fullKey(key)
+
+	w.modified.Put(string(key), nil)
+	return nil
+}
+
+// Drop all the not flashed keys. After this call, the state is identical to the state of parent DB.
+func (w *CacheWrapper) ClearNotFlushed() {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	w.modified.Clear()
+}
+
+// Close leaves underlying database.
+func (w *CacheWrapper) Close() {
+	w.modified = nil
+	w.parent.Close()
+}
+
+// NewBatch creates new batch.
+func (w *CacheWrapper) NewBatch() Batch {
+	return &cacheBatch{db: w}
+}
+
+// Num of not flushed keys, including deleted keys.
+func (w *CacheWrapper) NotFlushedPairs() int {
+	return w.modified.Size()
+}
+
+// Flushes current cache into parent DB.
+func (w *CacheWrapper) Flush() error {
+	batch := w.parent.NewBatch()
+	for it := w.modified.Iterator(); it.Next(); {
+		var err error
+
+		if it.Value() == nil {
+			err = batch.Delete([]byte(it.Key().(string)))
+		} else {
+			err = batch.Put([]byte(it.Key().(string)), it.Value().([]byte))
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if batch.ValueSize() > IdealBatchSize {
+			err = batch.Write()
+			if err != nil {
+				return err
+			}
+			batch.Reset()
+		}
+	}
+	w.modified.Clear()
+
+	return batch.Write()
+}
+
+/*
+ * Batch
+ */
+
+// cacheBatch is a batch structure.
+type cacheBatch struct {
+	db     Database
+	writes []kv
+	size   int
+}
+
+// Put puts key-value pair into batch.
+func (b *cacheBatch) Put(key, value []byte) error {
+	b.writes = append(b.writes, kv{common.CopyBytes(key), common.CopyBytes(value)})
+	b.size += len(value) + len(key)
+	return nil
+}
+
+// Delete removes key-value pair from batch by key.
+func (b *cacheBatch) Delete(key []byte) error {
+	b.writes = append(b.writes, kv{common.CopyBytes(key), nil})
+	b.size += len(key)
+	return nil
+}
+
+// Write writes batch into db. Not atomic.
+func (b *cacheBatch) Write() error {
+	for _, kv := range b.writes {
+		var err error
+
+		if kv.v == nil {
+			err = b.db.Delete(kv.k)
+		} else {
+			err = b.db.Put(kv.k, kv.v)
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValueSize returns values sizes sum.
+func (b *cacheBatch) ValueSize() int {
+	return b.size
+}
+
+// Reset cleans whole batch.
+func (b *cacheBatch) Reset() {
+	b.writes = b.writes[:0]
+	b.size = 0
+}

--- a/src/kvdb/cache_wrapper_test.go
+++ b/src/kvdb/cache_wrapper_test.go
@@ -1,0 +1,230 @@
+package kvdb
+
+import (
+	"github.com/Fantom-foundation/go-lachesis/src/common"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestForEach2(t *testing.T) {
+	tries := 15            // number of test iterations
+	opsPerIter := 0x200    // max number of put/delete ops per iteration
+	dictSize := opsPerIter // number of different words
+
+	// open raw databases
+	bbolt1, freeBbolt1 := bboltDB("1")
+	defer freeBbolt1()
+
+	bbolt2, freeBbolt2 := bboltDB("2")
+	defer freeBbolt2()
+
+	// create wrappers
+	dbs := map[string]Database{
+		"bbolt":  NewBoltDatabase(bbolt1),
+		"memory": NewMemDatabase(),
+	}
+
+	flushableDbs := map[string]FlushableDatabase{
+		"cache-over-bbolt":  NewCacheWrapper(NewBoltDatabase(bbolt2)),
+		"cache-over-memory": NewCacheWrapper(NewMemDatabase()),
+	}
+
+	dbsTables := [][]Database{
+		{
+			dbs["bbolt"],
+			dbs["bbolt"].NewTable([]byte{0, 1}),
+			dbs["bbolt"].NewTable([]byte{0}),
+			dbs["bbolt"].NewTable([]byte{0}).NewTable(common.Hex2Bytes("fffffffffffffffffffffffffffffffffffffe")),
+			dbs["bbolt"].NewTable([]byte{0}).NewTable(common.Hex2Bytes("ffffffffffffffffffffffffffffffffffffff")),
+		},
+		{
+			dbs["memory"],
+			dbs["memory"].NewTable([]byte{0, 1}),
+			dbs["memory"].NewTable([]byte{0}),
+			dbs["memory"].NewTable([]byte{0}).NewTable(common.Hex2Bytes("fffffffffffffffffffffffffffffffffffffe")),
+			dbs["memory"].NewTable([]byte{0}).NewTable(common.Hex2Bytes("ffffffffffffffffffffffffffffffffffffff")),
+		},
+	}
+
+	flushableDbsTables := [][]FlushableDatabase{
+		{
+			flushableDbs["cache-over-bbolt"],
+			flushableDbs["cache-over-bbolt"].NewTableFlushable([]byte{0, 1}),
+			flushableDbs["cache-over-bbolt"].NewTableFlushable([]byte{0}),
+			flushableDbs["cache-over-bbolt"].NewTableFlushable([]byte{0}).NewTableFlushable(common.Hex2Bytes("fffffffffffffffffffffffffffffffffffffe")),
+			flushableDbs["cache-over-bbolt"].NewTableFlushable([]byte{0}).NewTableFlushable(common.Hex2Bytes("ffffffffffffffffffffffffffffffffffffff")),
+		},
+		{
+			flushableDbs["cache-over-memory"],
+			flushableDbs["cache-over-memory"].NewTableFlushable([]byte{0, 1}),
+			flushableDbs["cache-over-memory"].NewTableFlushable([]byte{0}),
+			flushableDbs["cache-over-memory"].NewTableFlushable([]byte{0}).NewTableFlushable(common.Hex2Bytes("fffffffffffffffffffffffffffffffffffffe")),
+			flushableDbs["cache-over-memory"].NewTableFlushable([]byte{0}).NewTableFlushable(common.Hex2Bytes("ffffffffffffffffffffffffffffffffffffff")),
+		},
+	}
+
+	assertar := assert.New(t)
+	assertar.Equal(len(dbsTables), len(flushableDbsTables))
+	assertar.Equal(len(dbsTables[0]), len(flushableDbsTables[0]))
+
+	groupsNum := len(dbsTables)
+	tablesNum := len(dbsTables[0])
+
+	// use the same seed for determinism
+	r := rand.New(rand.NewSource(0))
+
+	// words dictionary
+	prefixes := [][]byte{
+		{},
+		{0},
+		{0x1},
+		{0x22},
+		{0x33},
+		{0x11},
+		{0x11, 0x22},
+		{0x11, 0x23},
+		{0x11, 0x22, 0x33},
+		{0x11, 0x22, 0x34},
+	}
+	dict := [][]byte{}
+	for i := 0; i < dictSize; i++ {
+		b := append(prefixes[i%len(prefixes)], big.NewInt(r.Int63()).Bytes()...)
+		dict = append(dict, b)
+	}
+
+	for try := 0; try < tries; try += 1 {
+		// random pet/delete operations
+		putDeleteRandom := func() {
+			for j := 0; j < tablesNum; j++ {
+				var batches []Batch
+				for i := 0; i < groupsNum; i++ {
+					batches = append(batches, dbsTables[i][j].NewBatch())
+					batches = append(batches, flushableDbsTables[i][j].NewBatch())
+				}
+
+				ops := 1 + r.Intn(opsPerIter)
+				for p := 0; p < ops; p++ {
+					var pair kv
+					if r.Intn(2) == 0 { // put
+						pair = kv{
+							k: dict[r.Intn(len(dict))],
+							v: dict[r.Intn(len(dict))],
+						}
+					} else { // delete
+						pair = kv{
+							k: dict[r.Intn(len(dict))],
+							v: nil,
+						}
+					}
+
+					for _, batch := range batches {
+						if pair.v != nil {
+							assertar.NoError(batch.Put(pair.k, pair.v))
+						} else {
+							assertar.NoError(batch.Delete(pair.k))
+						}
+					}
+				}
+
+				for _, batch := range batches {
+					size := batch.ValueSize()
+					assertar.NotEqual(0, size)
+					assertar.NoError(batch.Write())
+					assertar.Equal(size, batch.ValueSize())
+					batch.Reset()
+					assertar.Equal(0, batch.ValueSize())
+				}
+			}
+		}
+		// put/delete values
+		putDeleteRandom()
+
+		// flush
+		for _, db := range flushableDbs {
+			if try == 0 && !assertar.NotEqual(0, db.NotFlushedPairs()) {
+				return
+			}
+			assertar.NoError(db.Flush())
+			assertar.Equal(0, db.NotFlushedPairs())
+		}
+
+		// put/delete values (not flushed)
+		putDeleteRandom()
+
+		// try to ForEach random prefix
+		prefix := prefixes[try%len(prefixes)]
+		if try == 1 {
+			prefix = []byte{0, 0, 0, 0, 0, 0}
+		}
+		stopAfter := 1 + r.Intn(len(dict))
+
+		for j := 0; j < tablesNum; j++ {
+			expectPairs := []kv{}
+			testForEach := func(db Database, first bool) {
+				got := 0
+				assertar.NoError(db.ForEach(prefix, func(key, val []byte) bool {
+					assertar.NotEqual(got, stopAfter) // check that return true/false works here
+
+					if first {
+						expectPairs = append(expectPairs, kv{
+							k: key,
+							v: val,
+						})
+					} else {
+						assertar.NotEqual(got, len(expectPairs)) // check that we've for the same num of values
+						assertar.Equal(key, expectPairs[got].k)
+						assertar.Equal(val, expectPairs[got].v)
+					}
+
+					got += 1
+					return got < stopAfter
+				}))
+
+				assertar.Equal(got, len(expectPairs)) // check that we've got the same num of pairs
+			}
+
+			// check that all groups return the same result
+			for i := 0; i < groupsNum; i++ {
+				testForEach(dbsTables[i][j], i == 0)
+				testForEach(flushableDbsTables[i][j], false)
+			}
+		}
+
+		// try to get random values
+		ops := r.Intn(opsPerIter)
+		for p := 0; p < ops; p++ {
+			key := dict[r.Intn(len(dict))]
+
+			for j := 0; j < tablesNum; j++ {
+				// get values for first group, so we could check that all groups return the same result
+				ok, _ := dbsTables[0][j].Has(key)
+				vl, _ := dbsTables[0][j].Get(key)
+
+				// check that all groups return the same result
+				for i := 0; i < groupsNum; i++ {
+					ok1, err := dbsTables[i][j].Has(key)
+					assertar.NoError(err)
+					vl1, err := dbsTables[i][j].Get(key)
+					assertar.NoError(err)
+
+					ok2, err := flushableDbsTables[i][j].Has(key)
+					assertar.NoError(err)
+					vl2, err := flushableDbsTables[i][j].Get(key)
+					assertar.NoError(err)
+
+					assertar.Equal(ok1, ok2)
+					assertar.Equal(vl1, vl2)
+					assertar.Equal(ok1, ok)
+					assertar.Equal(vl1, vl)
+				}
+			}
+		}
+
+		if t.Failed() {
+			return
+		}
+	}
+}

--- a/src/kvdb/empty_db.go
+++ b/src/kvdb/empty_db.go
@@ -1,0 +1,66 @@
+package kvdb
+
+type EmptyDb struct{}
+
+// NewEmptyDb wraps map[string][]byte
+func NewEmptyDb() *EmptyDb {
+	return &EmptyDb{}
+}
+
+/*
+ * Database interface implementation
+ */
+
+func (w *EmptyDb) NewTable(prefix []byte) Database {
+	return w
+}
+
+func (w *EmptyDb) Put(key []byte, value []byte) error {
+	return nil
+}
+
+func (w *EmptyDb) Has(key []byte) (bool, error) {
+	return false, nil
+}
+
+func (w *EmptyDb) Get(key []byte) ([]byte, error) {
+	return nil, nil
+}
+
+func (w *EmptyDb) ForEach(prefix []byte, do func(key, val []byte) bool) error {
+	return nil
+}
+
+func (w *EmptyDb) Delete(key []byte) error {
+	return nil
+}
+
+func (w *EmptyDb) Close() {}
+
+func (w *EmptyDb) NewBatch() Batch {
+	return &emptyBatch{}
+}
+
+/*
+ * Batch
+ */
+
+type emptyBatch struct{}
+
+func (b *emptyBatch) Put(key, value []byte) error {
+	return nil
+}
+
+func (b *emptyBatch) Delete(key []byte) error {
+	return nil
+}
+
+func (b *emptyBatch) Write() error {
+	return nil
+}
+
+func (b *emptyBatch) ValueSize() int {
+	return 0
+}
+
+func (b *emptyBatch) Reset() {}

--- a/src/kvdb/interface.go
+++ b/src/kvdb/interface.go
@@ -26,6 +26,14 @@ type Database interface {
 	NewBatch() Batch
 }
 
+type FlushableDatabase interface {
+	NewTableFlushable(prefix []byte) FlushableDatabase
+	Database
+	NotFlushedPairs() int
+	Flush() error
+	ClearNotFlushed()
+}
+
 // Batch is a write-only database that commits changes to its host database
 // when Write is called. Batch cannot be used concurrently.
 type Batch interface {

--- a/src/kvdb/memory_database.go
+++ b/src/kvdb/memory_database.go
@@ -1,184 +1,26 @@
 package kvdb
 
-import (
-	"bytes"
-	"sync"
-
-	"github.com/Fantom-foundation/go-lachesis/src/common"
-)
-
-var (
-	// NOTE: key collisions are possible
-	separator = []byte("::")
-)
-
-// MemDatabase is a kvbd.Database wrapper of map[string][]byte
-// Do not use for any production it does not get persisted
+// MemDatabase is a memory-only database.
+// Do not use for any production. It does not get persisted!
 type MemDatabase struct {
-	db     map[string][]byte
-	prefix []byte
-	lock   *sync.RWMutex
+	*CacheWrapper
 }
 
-// NewMemDatabase wraps map[string][]byte
+func (w *MemDatabase) NotFlushedPairs() int {
+	return 0
+}
+
+func (w *MemDatabase) Flush() error {
+	return nil
+}
+
+func (w *MemDatabase) ClearNotFlushed() {}
+
+// MemDatabase is a memory-only database.
+// Do not use for any production. It does not get persisted!
+// Technically, it's the same as CacheWrapper, but it has no parent DB.
 func NewMemDatabase() *MemDatabase {
 	return &MemDatabase{
-		db:   make(map[string][]byte),
-		lock: new(sync.RWMutex),
+		CacheWrapper: NewCacheWrapper(NewEmptyDb()),
 	}
-}
-
-/*
- * Database interface implementation
- */
-
-// NewTable returns a Database object that prefixes all keys with a given prefix.
-func (w *MemDatabase) NewTable(prefix []byte) Database {
-	base := common.CopyBytes(w.prefix)
-	return &MemDatabase{
-		db:     w.db,
-		prefix: append(append(base, []byte("-")...), prefix...),
-		lock:   w.lock,
-	}
-}
-
-func (w *MemDatabase) fullKey(key []byte) []byte {
-	base := common.CopyBytes(w.prefix)
-	return append(append(base, separator...), key...)
-}
-
-// Put puts key-value pair into db.
-func (w *MemDatabase) Put(key []byte, value []byte) error {
-	w.lock.Lock()
-	defer w.lock.Unlock()
-
-	key = w.fullKey(key)
-
-	w.db[string(key)] = common.CopyBytes(value)
-	return nil
-}
-
-// Has checks if key is in the db.
-func (w *MemDatabase) Has(key []byte) (bool, error) {
-	w.lock.RLock()
-	defer w.lock.RUnlock()
-
-	key = w.fullKey(key)
-
-	_, ok := w.db[string(key)]
-	return ok, nil
-}
-
-// Get returns key-value pair by key.
-func (w *MemDatabase) Get(key []byte) ([]byte, error) {
-	w.lock.RLock()
-	defer w.lock.RUnlock()
-
-	key = w.fullKey(key)
-
-	if entry, ok := w.db[string(key)]; ok {
-		return common.CopyBytes(entry), nil
-	}
-	return nil, nil
-}
-
-// ForEach scans key-value pair by key prefix.
-func (w *MemDatabase) ForEach(prefix []byte, do func(key, val []byte) bool) error {
-	w.lock.RLock()
-	defer w.lock.RUnlock()
-
-	prefix = w.fullKey(prefix)
-
-	for k, val := range w.db {
-		key := common.CopyBytes([]byte(k))
-		if bytes.HasPrefix(key, prefix) {
-			key = key[len(w.prefix)+len(separator):]
-			if !do(key, val) {
-				break
-			}
-		}
-	}
-
-	return nil
-}
-
-// Delete removes key-value pair by key.
-func (w *MemDatabase) Delete(key []byte) error {
-	w.lock.Lock()
-	defer w.lock.Unlock()
-
-	key = w.fullKey(key)
-
-	delete(w.db, string(key))
-	return nil
-}
-
-// Close leaves underlying database.
-func (w *MemDatabase) Close() {
-	w.db = nil
-}
-
-// NewBatch creates new batch.
-func (w *MemDatabase) NewBatch() Batch {
-	return &memBatch{db: w}
-}
-
-/*
- * Batch
- */
-
-type kv struct {
-	k, v []byte
-	del  bool
-}
-
-// memBatch is a batch structure.
-type memBatch struct {
-	db     *MemDatabase
-	writes []kv
-	size   int
-}
-
-// Put puts key-value pair into batch.
-func (b *memBatch) Put(key, value []byte) error {
-	key = b.db.fullKey(key)
-
-	b.writes = append(b.writes, kv{common.CopyBytes(key), common.CopyBytes(value), false})
-	b.size += len(value)
-	return nil
-}
-
-// Delete removes key-value pair from batch by key.
-func (b *memBatch) Delete(key []byte) error {
-	key = b.db.fullKey(key)
-
-	b.writes = append(b.writes, kv{common.CopyBytes(key), nil, true})
-	b.size++
-	return nil
-}
-
-// Write writes batch into db.
-func (b *memBatch) Write() error {
-	b.db.lock.Lock()
-	defer b.db.lock.Unlock()
-
-	for _, kv := range b.writes {
-		if kv.del {
-			delete(b.db.db, string(kv.k))
-			continue
-		}
-		b.db.db[string(kv.k)] = kv.v
-	}
-	return nil
-}
-
-// ValueSize returns values sizes sum.
-func (b *memBatch) ValueSize() int {
-	return b.size
-}
-
-// Reset cleans whole batch.
-func (b *memBatch) Reset() {
-	b.writes = b.writes[:0]
-	b.size = 0
 }


### PR DESCRIPTION
CacheWrapper is a kvdb.Database wrapper around any Database.
On reading, it looks in memory cache first. If not found, it looks in a parent DB.
On writing, it writes only in cache.
To flush the cache into parent DB, call Flush().

It supports ForEach operation for reading pairs in lexicographical order, consistently with parent DB.