### PR TITLE
gossip: packs syncing

### DIFF
--- a/src/gossip/emitter.go
+++ b/src/gossip/emitter.go
@@ -91,17 +91,16 @@ func (em *Emitter) StopEventEmission() {
 
 // createEvent is not safe for concurrent use.
 func (em *Emitter) createEvent() *inter.Event {
+	if em.engine.GetMembers()[em.myAddr] == 0 {
+		return nil
+	}
+
 	var (
 		epoch      = em.engine.CurrentSuperFrameN()
 		seq        idx.Event
 		parents    hash.Events
 		maxLamport idx.Lamport
 	)
-
-	// clean tmp db
-	if em.prevEpoch < epoch {
-		em.store.delEpochStore(epoch - 1)
-	}
 
 	seeVec := em.engine.GetVectorIndex()
 

--- a/src/gossip/pack.go
+++ b/src/gossip/pack.go
@@ -18,8 +18,7 @@ const (
 	maxPackEventsNum = softLimitItems
 )
 
-func (s *Service) packs_onNewEvent(e *inter.Event) {
-	epoch := s.engine.CurrentSuperFrameN()
+func (s *Service) packs_onNewEvent(e *inter.Event, epoch idx.SuperFrame) {
 	// due to default values, we don't need to explicitly set values at a start of an epoch
 	packIdx := s.store.GetPacksNumOrDefault(epoch)
 	packInfo := s.store.GetPackInfoOrDefault(s.engine.CurrentSuperFrameN(), packIdx)

--- a/src/gossip/packs_downloader/packs_downloader.go
+++ b/src/gossip/packs_downloader/packs_downloader.go
@@ -59,7 +59,7 @@ func (d *PacksDownloader) RegisterPeer(peer Peer, myEpoch idx.SuperFrame) error 
 		return nil
 	}
 
-	log.Trace("Registering sync peer", "peer", peer, "epoch", myEpoch)
+	log.Trace("Registering sync peer", "peer", peer.Id, "epoch", myEpoch)
 	d.peers[peer.Id] = newPeer(peer, myEpoch, d.fetcher, d.onlyNotConnected, d.dropPeer)
 	d.peers[peer.Id].Start()
 
@@ -67,6 +67,9 @@ func (d *PacksDownloader) RegisterPeer(peer Peer, myEpoch idx.SuperFrame) error 
 }
 
 func (d *PacksDownloader) OnNewEpoch(myEpoch idx.SuperFrame, peerEpoch func(string) idx.SuperFrame) {
+	d.peersMu.Lock()
+	defer d.peersMu.Unlock()
+
 	newPeers := make(map[string]*PeerPacksDownloader)
 
 	for peerId, peerDwnld := range d.peers {

--- a/src/gossip/packs_downloader/peer_downloader.go
+++ b/src/gossip/packs_downloader/peer_downloader.go
@@ -215,11 +215,11 @@ func (d *PeerPacksDownloader) loop() {
 			if d.packInfos.Size() > maxPeerPacks {
 				// if we have too much packs -> d.sweepKnown() doesn't erase them -> we don't connect events from these packs.
 				// Also we do binary search, so we don't need much packs to store, so we shouldn't reach this if peer is ok.
-				log.Error("All the peer packs are unknown. Faulty peer?", "peer", d.peer)
+				log.Error("All the peer packs are unknown. Faulty peer?", "peer", d.peer.Id)
 				d.dropPeer(d.peer.Id)
 			}
 			if packInfo.index == 0 {
-				log.Error("invalid pack index", "peer", d.peer)
+				log.Error("invalid pack index", "peer", d.peer.Id)
 				continue
 			}
 
@@ -245,7 +245,7 @@ func (d *PeerPacksDownloader) loop() {
 
 			err := d.fetcher.Notify(d.peer.Id, pack.ids, pack.time, pack.fetchEvents)
 			if err != nil {
-				log.Error("pack inject error", "index", pack.index, "peer", d.peer, "err", err)
+				log.Error("pack inject error", "index", pack.index, "peer", d.peer.Id, "err", err)
 			}
 
 		case <-syncTicker.C:
@@ -288,7 +288,7 @@ func (d *PeerPacksDownloader) timedRequestFullPack(index idx.Pack, pinned bool) 
 	if prevRequestTime.IsZero() || time.Since(prevRequestTime) > arriveTimeout-gatherSlack {
 		err := d.peer.RequestPack(d.myEpoch, index)
 		if err != nil {
-			log.Error("pack request error", "index", index, "peer", d.peer, "err", err)
+			log.Error("pack request error", "index", index, "peer", d.peer.Id, "err", err)
 		}
 		d.prevRequest = time.Now()
 		if pinned {
@@ -303,7 +303,7 @@ func (d *PeerPacksDownloader) timedRequestPackInfo(index idx.Pack) {
 	if prevRequestTime.IsZero() || time.Since(prevRequestTime) > arriveTimeout-gatherSlack {
 		err := d.peer.RequestPackInfos(d.myEpoch, []idx.Pack{index})
 		if err != nil {
-			log.Error("pack info request error", "index", index, "peer", d.peer, "err", err)
+			log.Error("pack info request error", "index", index, "peer", d.peer.Id, "err", err)
 		}
 		d.prevRequest = time.Now()
 		d.fetchingInfo[index] = d.prevRequest
@@ -375,7 +375,7 @@ func (d *PeerPacksDownloader) sweepKnown() {
 			toRemove = append(toRemove, packIdx)
 
 			if !allKnown {
-				log.Error("Peer downloader error: met pack with an unknown head before pack with only known heads. Faulty peer?", "peer", d.peer)
+				log.Error("Peer downloader error: met pack with an unknown head before pack with only known heads. Faulty peer?", "peer", d.peer.Id)
 				d.dropPeer(d.peer.Id)
 				return
 			}

--- a/src/gossip/service.go
+++ b/src/gossip/service.go
@@ -91,7 +91,7 @@ func (s *Service) processEvent(realEngine Consensus, e *inter.Event) error {
 		s.store.Fatalf("ProcessEvent: event is already processed %s", e.Hash().String())
 	}
 
-	oldEpoch := realEngine.CurrentSuperFrameN()
+	oldEpoch := e.Epoch
 
 	s.store.SetEvent(e)
 	if realEngine != nil {
@@ -112,13 +112,13 @@ func (s *Service) processEvent(realEngine Consensus, e *inter.Event) error {
 	}
 	s.store.AddHead(e.Epoch, e.Hash())
 
-	s.packs_onNewEvent(e)
+	s.packs_onNewEvent(e, e.Epoch)
 
 	newEpoch := realEngine.CurrentSuperFrameN()
 	if newEpoch != oldEpoch {
 		s.packs_onNewEpoch(oldEpoch, newEpoch)
+		s.store.delEpochStore(oldEpoch)
 		s.mux.Post(newEpoch)
-		s.mux.Post(s.store.GetPacksNumOrDefault(newEpoch))
 	}
 
 	return nil


### PR DESCRIPTION
Implement the packs exchanging, i.e. the mechanism of division events into packs, and binary search of peer's packs to find the lowest not downloaded pack in the epoch.

It's intended to serve as a syncing mechanism when a peer just joins the network, i.e. it has to download all the epochs. Once peers are on the same epoch, other syncing mechanisms (events broadcast/relay and fetching by parents) start to play the main role.

The most of the commits were merged in #305