### PR TITLE
LRU-based ordering buffer 

### DIFF
--- a/src/event_check/all.go
+++ b/src/event_check/all.go
@@ -18,7 +18,7 @@ func ValidateAll_test(config *lachesis.DagConfig, reader epoch_check.DagReader, 
 	if err := epoch_check.New(config, reader).Validate(e); err != nil {
 		return err
 	}
-	if err := parents_check.New(config, reader).Validate(e, parents); err != nil {
+	if err := parents_check.New(config).Validate(e, parents); err != nil {
 		return err
 	}
 	if err := heavy_check.New(config, txSigner, 1).Validate(e); err != nil {

--- a/src/event_check/basic_check/basic_check.go
+++ b/src/event_check/basic_check/basic_check.go
@@ -16,7 +16,7 @@ const (
 	// It ensures that in all the "real" cases, the event will be limited by gas, not size.
 	// Yet it's technically possible to construct an event which is limited by size.
 	MaxEventSize = MaxGasPowerUsed / params.TxDataNonZeroGas
-	MaxExtraData = 256 // it has fair gas price, so it's fine to have a high limit
+	MaxExtraData = 256 // it has fair gas cost, so it's fine to have a high limit
 
 	EventGas  = params.TxGas // TODO estimate the cost more accurately
 	ParentGas = EventGas / 5
@@ -30,7 +30,7 @@ var (
 	ErrTooLarge       = errors.New("event size exceeds the limit")
 	ErrExtraTooLarge  = errors.New("event extra is too big")
 	ErrNoParents      = errors.New("event has no parents")
-	ErrTooMuchParents = errors.New("event has too much parents")
+	ErrTooManyParents = errors.New("event has too many parents")
 	ErrTooBigGasUsed  = errors.New("event uses too much gas power")
 	ErrWrongGasUsed   = errors.New("event has incorrect gas power")
 	ErrIntrinsicGas   = errors.New("intrinsic gas too low")
@@ -109,16 +109,16 @@ func (v *Validator) checkLimits(e *inter.Event) error {
 		return ErrExtraTooLarge
 	}
 	if len(e.Parents) > v.config.MaxParents {
-		return ErrTooMuchParents
+		return ErrTooManyParents
 	}
 	return nil
 }
 
 func (v *Validator) checkInited(e *inter.Event) error {
-	if e.Seq == 0 || e.Epoch == 0 || e.Frame == 0 || e.Lamport == 0 {
-		return ErrNotInited
+	if e.Seq <= 0 || e.Epoch <= 0 || e.Frame <= 0 || e.Lamport <= 0 {
+		return ErrNotInited // it's unsigned, but check for negative in a case if type will change
 	}
-	if e.ClaimedTime == 0 {
+	if e.ClaimedTime <= 0 {
 		return ErrZeroTime
 	}
 	if e.Seq > 1 && len(e.Parents) == 0 {

--- a/src/event_check/epoch_check/epoch_check.go
+++ b/src/event_check/epoch_check/epoch_check.go
@@ -15,8 +15,7 @@ var (
 )
 
 type DagReader interface {
-	GetEpoch() idx.Epoch
-	GetMembers() pos.Members
+	GetEpochMembers() (pos.Members, idx.Epoch)
 }
 
 // Check which require only current epoch info
@@ -33,10 +32,12 @@ func New(config *lachesis.DagConfig, reader DagReader) *Validator {
 }
 
 func (v *Validator) Validate(e *inter.Event) error {
-	if e.Epoch != v.reader.GetEpoch() {
+	// check epoch first, because validators group is known only for the current epoch
+	members, epoch := v.reader.GetEpochMembers()
+	if e.Epoch != epoch {
 		return ErrNotRecent
 	}
-	if _, ok := v.reader.GetMembers()[e.Creator]; !ok {
+	if _, ok := members[e.Creator]; !ok {
 		return ErrAuth
 	}
 	return nil

--- a/src/event_check/heavy_check/heavy_check.go
+++ b/src/event_check/heavy_check/heavy_check.go
@@ -15,7 +15,8 @@ var (
 	ErrWrongEventSig  = errors.New("event has wrong signature")
 	ErrMalformedTxSig = errors.New("tx has wrong signature")
 	ErrWrongTxHash    = errors.New("tx has wrong txs Merkle tree root")
-	errTerminated     = errors.New("terminated")
+
+	errTerminated = errors.New("terminated") // internal err
 )
 
 const (

--- a/src/event_check/heavy_check/heavy_check.go
+++ b/src/event_check/heavy_check/heavy_check.go
@@ -128,6 +128,7 @@ func (v *Validator) Validate(e *inter.Event) error {
 }
 
 func (v *Validator) loop() {
+	defer v.wg.Done()
 	for {
 		select {
 		case <-v.quit:

--- a/src/gossip/api.go
+++ b/src/gossip/api.go
@@ -3,6 +3,7 @@ package gossip
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // PublicEthereumAPI provides an API to access Ethereum-like information.
@@ -33,5 +34,5 @@ func (api *PublicEthereumAPI) Hashrate() hexutil.Uint64 {
 
 // ChainId is the EIP-155 replay-protection chain id for the current ethereum chain config.
 func (api *PublicEthereumAPI) ChainId() hexutil.Uint64 {
-	return hexutil.Uint64(api.s.config.Net.NetworkId)
+	return hexutil.Uint64(params.AllEthashProtocolChanges.ChainID.Uint64())
 }

--- a/src/gossip/consensus.go
+++ b/src/gossip/consensus.go
@@ -26,6 +26,8 @@ type Consensus interface {
 	GetEpoch() idx.Epoch
 	// GetMembers returns members of current epoch.
 	GetMembers() pos.Members
+	// GetEpochMembers atomically returns members of current epoch, and the epoch.
+	GetEpochMembers() (pos.Members, idx.Epoch)
 
 	// Bootstrap must be called (once) before calling other methods
 	Bootstrap(applyBlock inter.ApplyBlockFn)

--- a/src/gossip/fetcher/fetcher.go
+++ b/src/gossip/fetcher/fetcher.go
@@ -9,13 +9,12 @@ import (
 
 	"github.com/Fantom-foundation/go-lachesis/src/event_check"
 	"github.com/Fantom-foundation/go-lachesis/src/event_check/heavy_check"
-	"github.com/Fantom-foundation/go-lachesis/src/gossip/ordering"
 	"github.com/Fantom-foundation/go-lachesis/src/hash"
 	"github.com/Fantom-foundation/go-lachesis/src/inter"
 )
 
 /*
- * Fetcher is a network agent, which has handles basic hash-based events sync.
+ * Fetcher is a network agent, which handles basic hash-based events sync.
  * The core mechanic is very simple: interested hash arrived => request it.
  * The main reason why it has more than a few lines of code,
  * is because it tries to protect itself (and other nodes) against DoS.
@@ -50,6 +49,9 @@ type FilterInterestedFn func(ids hash.Events) hash.Events
 
 // EventsRequesterFn is a callback type for sending a event retrieval request.
 type EventsRequesterFn func(hash.Events) error
+
+// Called to connect a received event
+type PushEventFn func(e *inter.Event, peer string)
 
 // inject represents a schedules import operation.
 type inject struct {
@@ -94,7 +96,7 @@ type Fetcher struct {
 }
 
 type Callback struct {
-	PushEvent      ordering.PushEventFn
+	PushEvent      PushEventFn
 	OnlyInterested FilterInterestedFn
 	DropPeer       DropPeerFn
 

--- a/src/gossip/handler.go
+++ b/src/gossip/handler.go
@@ -143,7 +143,7 @@ func (pm *ProtocolManager) makeFetcher() *fetcher.Fetcher {
 	// checkers
 	basicCheck := basic_check.New(&pm.config.Net.Dag)
 	epochCheck := epoch_check.New(&pm.config.Net.Dag, pm.engine)
-	parentsCheck := parents_check.New(&pm.config.Net.Dag, pm.engine)
+	parentsCheck := parents_check.New(&pm.config.Net.Dag)
 	firstCheck := func(e *inter.Event) error {
 		if err := basicCheck.Validate(e); err != nil {
 			return err

--- a/src/gossip/ordering/ordering_test.go
+++ b/src/gossip/ordering/ordering_test.go
@@ -1,29 +1,15 @@
 package ordering
 
 import (
-	"github.com/Fantom-foundation/go-lachesis/src/event_check/parents_check"
-	"github.com/Fantom-foundation/go-lachesis/src/inter/pos"
-	"github.com/Fantom-foundation/go-lachesis/src/lachesis"
-	"github.com/ethereum/go-ethereum/common"
 	"math/rand"
 	"testing"
 	"time"
 
+	"github.com/Fantom-foundation/go-lachesis/src/event_check/parents_check"
 	"github.com/Fantom-foundation/go-lachesis/src/hash"
 	"github.com/Fantom-foundation/go-lachesis/src/inter"
+	"github.com/Fantom-foundation/go-lachesis/src/lachesis"
 )
-
-type testDagReader struct {
-	nodes []common.Address
-}
-
-func (t *testDagReader) GetMembers() pos.Members {
-	members := pos.Members{}
-	for _, addr := range t.nodes {
-		members.Set(addr, 1)
-	}
-	return members
-}
 
 func TestEventBuffer(t *testing.T) {
 	nodes := inter.GenNodes(5)
@@ -36,6 +22,7 @@ func TestEventBuffer(t *testing.T) {
 		},
 		Build: func(e *inter.Event, name string) *inter.Event {
 			e.Epoch = 1
+			e.ClaimedTime = inter.Timestamp(e.Seq)
 			return e
 		},
 	})
@@ -66,7 +53,7 @@ func TestEventBuffer(t *testing.T) {
 			return processed[e]
 		},
 
-		Check: parents_check.New(&lachesis.DagConfig{}, &testDagReader{nodes}).Validate,
+		Check: parents_check.New(&lachesis.DagConfig{}).Validate,
 	})
 
 	for _, rnd := range rand.Perm(len(ordered)) {

--- a/src/gossip/poset_hook.go
+++ b/src/gossip/poset_hook.go
@@ -49,6 +49,13 @@ func (hook *HookedEngine) GetEpoch() idx.Epoch {
 	return hook.engine.GetEpoch()
 }
 
+func (hook *HookedEngine) GetEpochMembers() (pos.Members, idx.Epoch) {
+	if hook.engine == nil {
+		return pos.Members{}, 1
+	}
+	return hook.engine.GetEpochMembers()
+}
+
 func (hook *HookedEngine) LastBlock() (idx.Block, hash.Event) {
 	if hook.engine == nil {
 		return idx.Block(1), hash.ZeroEvent

--- a/src/lachesis/config.go
+++ b/src/lachesis/config.go
@@ -18,7 +18,7 @@ const (
 // DagConfig of DAG.
 type DagConfig struct {
 	MaxParents int       `json:"maxParents"`
-	EpochLen   idx.Frame `json:"maxParents"`
+	EpochLen   idx.Frame `json:"epochLen"`
 }
 
 // Config describes lachesis net.

--- a/src/poset/epoch.go
+++ b/src/poset/epoch.go
@@ -90,6 +90,11 @@ func (p *Poset) GetMembers() pos.Members {
 	return p.Members.Copy()
 }
 
+// GetEpochMembers atomically returns members of current epoch, and the epoch.
+func (p *Poset) GetEpochMembers() (pos.Members, idx.Epoch) {
+	return p.GetMembers(), p.GetEpoch() // TODO atomic
+}
+
 // rootForklessCausesRoot returns hash of root B, if root A forkless causes root B.
 // Due to a fork, there may be many roots B with the same slot,
 // but forkless caused may be only one of them (if no more than 1/3n are Byzantine), with a specific hash.

--- a/src/poset/poset_test.go
+++ b/src/poset/poset_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Fantom-foundation/go-lachesis/src/inter"
 	"github.com/Fantom-foundation/go-lachesis/src/inter/idx"
-	"github.com/Fantom-foundation/go-lachesis/src/lachesis"
 	"github.com/Fantom-foundation/go-lachesis/src/logger"
 )
 
@@ -17,7 +16,6 @@ func TestPoset(t *testing.T) {
 
 	const posetCount = 3
 	nodes := inter.GenNodes(5)
-	dag := lachesis.DefaultDagConfig()
 
 	posets := make([]*ExtendedPoset, 0, posetCount)
 	inputs := make([]*EventStore, 0, posetCount)
@@ -32,7 +30,7 @@ func TestPoset(t *testing.T) {
 
 	// create events on poset0
 	var ordered inter.Events
-	inter.ForEachRandEvent(nodes, int(dag.EpochLen)-1, 3, nil, inter.ForEachEvent{
+	inter.ForEachRandEvent(nodes, int(posets[0].dag.EpochLen)-1, 3, nil, inter.ForEachEvent{
 		Process: func(e *inter.Event, name string) {
 			ordered = append(ordered, e)
 

--- a/src/poset/restore_test.go
+++ b/src/poset/restore_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Fantom-foundation/go-lachesis/src/inter"
 	"github.com/Fantom-foundation/go-lachesis/src/inter/idx"
-	"github.com/Fantom-foundation/go-lachesis/src/lachesis"
 	"github.com/Fantom-foundation/go-lachesis/src/logger"
 )
 
@@ -18,7 +17,6 @@ func TestRestore(t *testing.T) {
 
 	const posetCount = 3 // 2 last will be restored
 	const epochs = idx.Epoch(2)
-	dag := lachesis.DefaultDagConfig()
 
 	nodes := inter.GenNodes(5)
 
@@ -43,7 +41,7 @@ func TestRestore(t *testing.T) {
 	var ordered []*inter.Event
 	for epoch := idx.Epoch(1); epoch <= epochs; epoch++ {
 		r := rand.New(rand.NewSource(int64((epoch))))
-		_ = inter.ForEachRandEvent(nodes, int(dag.EpochLen)*3, 3, r, inter.ForEachEvent{
+		_ = inter.ForEachRandEvent(nodes, int(posets[0].dag.EpochLen)*3, 3, r, inter.ForEachEvent{
 			Process: func(e *inter.Event, name string) {
 				inputs[0].SetEvent(e)
 				assertar.NoError(posets[0].ProcessEvent(e))
@@ -67,7 +65,7 @@ func TestRestore(t *testing.T) {
 		for x, e := range ordered {
 			if (x < len(ordered)/4) || x%20 == 0 {
 				// restore
-				restored := New(dag, store, inputs[i])
+				restored := New(posets[0].dag, store, inputs[i])
 				n := i % len(nodes)
 				restored.SetName("restored_" + nodes[n].String())
 				store.SetName("restored_" + nodes[n].String())
@@ -91,7 +89,7 @@ func TestRestore(t *testing.T) {
 
 		// check that blocks are identical
 		assertar.Equal(len(posets[i].blocks), len(posets[j].blocks))
-		assertar.Equal(len(posets[i].blocks), int(epochs)*int(dag.EpochLen))
+		assertar.Equal(len(posets[i].blocks), int(epochs)*int(posets[0].dag.EpochLen))
 		assertar.Equal(len(posets[i].blocks), int(posets[i].LastBlockN))
 		for blockI := idx.Block(1); blockI <= idx.Block(len(posets[i].blocks)); blockI++ {
 			assertar.NotNil(posets[i].blocks[blockI])

--- a/src/poset/store_test.go
+++ b/src/poset/store_test.go
@@ -103,14 +103,12 @@ func benchmarkStore(b *testing.B) {
 		return stateHash, members
 	}
 
-	dag := lachesis.DefaultDagConfig()
-
 	// run test with random DAG, N + 1 epochs long
 	b.ResetTimer()
 	maxEpoch := idx.Epoch(b.N) + 1
 	for epoch := idx.Epoch(1); epoch <= maxEpoch; epoch++ {
 		r := rand.New(rand.NewSource(int64((epoch))))
-		_ = inter.ForEachRandEvent(nodes, int(dag.EpochLen*3), 3, r, inter.ForEachEvent{
+		_ = inter.ForEachRandEvent(nodes, int(p.dag.EpochLen*3), 3, r, inter.ForEachEvent{
 			Process: func(e *inter.Event, name string) {
 				input.SetEvent(e)
 				_ = p.ProcessEvent(e)

--- a/src/poset/transaction_test.go
+++ b/src/poset/transaction_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/src/inter"
 	"github.com/Fantom-foundation/go-lachesis/src/inter/idx"
 	"github.com/Fantom-foundation/go-lachesis/src/inter/pos"
-	"github.com/Fantom-foundation/go-lachesis/src/lachesis"
 	"github.com/Fantom-foundation/go-lachesis/src/logger"
 )
 
@@ -36,8 +35,7 @@ func TestPosetTxn(t *testing.T) {
 		return stateHash, members
 	}
 
-	dag := lachesis.DefaultDagConfig()
-	_ = inter.ForEachRandEvent(nodes, int(dag.EpochLen-1), 3, nil, inter.ForEachEvent{
+	_ = inter.ForEachRandEvent(nodes, int(p.dag.EpochLen-1), 3, nil, inter.ForEachEvent{
 		Process: func(e *inter.Event, name string) {
 			x.SetEvent(e)
 			assert.NoError(t, p.ProcessEvent(e))


### PR DESCRIPTION
- ordering buffer: use LRU instead of time-based GC. It guarantees that no more than N events are stored in RAM
- event checks: time check against self-parent
- fix races, refactor