### PR TITLE
Tx pool protection

### DIFF
--- a/src/event_check/basic_check/basic_check.go
+++ b/src/event_check/basic_check/basic_check.go
@@ -120,7 +120,8 @@ func (v *Validator) checkInited(e *inter.Event) error {
 	if e.Seq <= 0 || e.Epoch <= 0 || e.Frame <= 0 || e.Lamport <= 0 {
 		return ErrNotInited // it's unsigned, but check for negative in a case if type will change
 	}
-	if e.Seq >= math.MaxInt32/2 || e.Epoch >= math.MaxInt32/2 || e.Frame >= math.MaxInt32/2 || e.Lamport >= math.MaxInt32/2 {
+	if e.Seq >= math.MaxInt32/2 || e.Epoch >= math.MaxInt32/2 || e.Frame >= math.MaxInt32/2 ||
+		e.Lamport >= math.MaxInt32/2 || e.GasPowerUsed >= math.MaxInt64/2 || e.GasPowerLeft >= math.MaxInt64/2 {
 		return ErrHugeValue
 	}
 

--- a/src/gossip/apply_block.go
+++ b/src/gossip/apply_block.go
@@ -30,6 +30,7 @@ func (s *Service) ApplyBlock(block *inter.Block, stateHash common.Hash, members 
 
 		evmBlock.Transactions = append(evmBlock.Transactions, e.Transactions...)
 	}
+	s.occurredTxs.CollectConfirmedTxs(evmBlock.Transactions) // TODO collect all the confirmed txs, not only block txs
 
 	// Process txs
 	statedb := s.store.StateDB(stateHash)

--- a/src/gossip/config_emitter.go
+++ b/src/gossip/config_emitter.go
@@ -15,6 +15,8 @@ type EmitterConfig struct {
 
 	MaxGasRateGrowthFactor float64 // fine to use float, because no need in determinism
 
+	MaxTxsFromSender int
+
 	// thresholds on GasLeft
 	SmoothTpsThreshold uint64 `json:"smoothTpsThreshold"`
 	NoTxsThreshold     uint64 `json:"noTxsThreshold"`
@@ -26,6 +28,7 @@ func DefaultEmitterConfig() EmitterConfig {
 		MinEmitInterval:        1 * time.Second,
 		MaxEmitInterval:        60 * time.Second,
 		MaxGasRateGrowthFactor: 3.0,
+		MaxTxsFromSender:       2,
 
 		SmoothTpsThreshold: params.TxGas * 500,
 		NoTxsThreshold:     params.TxGas * 100,

--- a/src/gossip/emitter.go
+++ b/src/gossip/emitter.go
@@ -2,9 +2,6 @@ package gossip
 
 import (
 	"fmt"
-	"github.com/Fantom-foundation/go-lachesis/src/evm_core"
-	"github.com/Fantom-foundation/go-lachesis/src/inter/pos"
-	"github.com/Fantom-foundation/go-lachesis/src/utils"
 	"strings"
 	"sync"
 	"time"
@@ -19,12 +16,15 @@ import (
 
 	"github.com/Fantom-foundation/go-lachesis/src/event_check"
 	"github.com/Fantom-foundation/go-lachesis/src/event_check/basic_check"
+	"github.com/Fantom-foundation/go-lachesis/src/evm_core"
 	"github.com/Fantom-foundation/go-lachesis/src/gossip/occured_txs"
 	"github.com/Fantom-foundation/go-lachesis/src/hash"
 	"github.com/Fantom-foundation/go-lachesis/src/inter"
 	"github.com/Fantom-foundation/go-lachesis/src/inter/ancestor"
 	"github.com/Fantom-foundation/go-lachesis/src/inter/idx"
+	"github.com/Fantom-foundation/go-lachesis/src/inter/pos"
 	"github.com/Fantom-foundation/go-lachesis/src/lachesis"
+	"github.com/Fantom-foundation/go-lachesis/src/utils"
 )
 
 const (

--- a/src/gossip/handler_test.go
+++ b/src/gossip/handler_test.go
@@ -123,8 +123,8 @@ func testBroadcastEvent(t *testing.T, totalPeers, broadcastExpected int, allowAg
 	net := lachesis.FakeNetConfig(1)
 	config := DefaultConfig(net)
 	config.ForcedBroadcast = allowAggressive
-	config.Emitter.MinEmitInterval = 10 * time.Millisecond
-	config.Emitter.MaxEmitInterval = 10 * time.Millisecond
+	config.Emitter.MinEmitInterval = time.Duration(0)
+	config.Emitter.MaxEmitInterval = time.Duration(0)
 
 	var (
 		store       = NewMemStore()
@@ -171,6 +171,7 @@ func testBroadcastEvent(t *testing.T, totalPeers, broadcastExpected int, allowAg
 	emittedEvents := make([]*inter.Event, 0)
 	for i := 0; i < broadcastExpected; i++ {
 		emitted := svc.emitter.EmitEvent()
+		assertar.NotNil(emitted)
 		emittedEvents = append(emittedEvents, emitted)
 		// check it's broadcasted just after emitting
 		for _, peer := range peers {
@@ -203,6 +204,7 @@ func testBroadcastEvent(t *testing.T, totalPeers, broadcastExpected int, allowAg
 	// create new event, but send it from new peer
 	{
 		emitted := svc.emitter.createEvent()
+		assertar.NotNil(emitted)
 		assertar.NoError(p2p.Send(newPeer.app, NewEventHashesMsg, []hash.Event{emitted.Hash()})) // announce
 		// now PM should request it
 		assertar.NoError(p2p.ExpectMsg(newPeer.app, GetEventsMsg, []hash.Event{emitted.Hash()})) // request

--- a/src/gossip/occured_txs/txs_ring_buffer.go
+++ b/src/gossip/occured_txs/txs_ring_buffer.go
@@ -1,0 +1,117 @@
+package occured_txs
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/hashicorp/golang-lru"
+)
+
+type buffer struct {
+	senders *lru.Cache             // hash -> sender
+	from    map[common.Address]int // sender -> number of txs
+}
+
+type Buffer struct {
+	txSigner types.Signer
+	ring     *buffer
+}
+
+func New(size int, txSigner types.Signer) *Buffer {
+	ring := &buffer{
+		from: make(map[common.Address]int),
+	}
+	ring.senders, _ = lru.NewWithEvict(size, func(key interface{}, value interface{}) {
+		ring.decreaseSender(value.(common.Address))
+	})
+	return &Buffer{
+		ring:     ring,
+		txSigner: txSigner,
+	}
+}
+
+// not safe for concurrent use
+func (ring *buffer) Add(hash common.Hash, sender common.Address) {
+	ring.senders.Add(hash, sender)
+
+	ring.from[sender] += 1
+}
+
+// not safe for concurrent use
+func (ring *buffer) Delete(hash common.Hash) {
+	sender, ok := ring.Get(hash)
+	ring.senders.Remove(hash)
+	if ok {
+		ring.decreaseSender(sender)
+	}
+}
+
+// not safe for concurrent use
+func (ring *buffer) decreaseSender(sender common.Address) {
+	was := ring.from[sender]
+	if was <= 1 {
+		delete(ring.from, sender)
+	} else {
+		ring.from[sender] = was - 1
+	}
+}
+
+// not safe for concurrent use
+func (ring *buffer) Get(hash common.Hash) (common.Address, bool) {
+	sender, ok := ring.senders.Peek(hash)
+	if !ok {
+		return common.Address{}, false
+	}
+	return sender.(common.Address), true
+}
+
+// not safe for concurrent use
+func (ring *buffer) GetTxsNum(sender common.Address) int {
+	return ring.from[sender]
+}
+
+// not safe for concurrent use
+func (ring *buffer) Clear() {
+	ring.senders.Purge()
+	ring.from = make(map[common.Address]int)
+}
+
+// Txs are included into an event, but not included into a block
+// not safe for concurrent use
+func (s *Buffer) CollectNotConfirmedTxs(txs types.Transactions) error {
+	for _, tx := range txs {
+		sender, err := s.txSigner.Sender(tx)
+		if err != nil {
+			return err
+		}
+		s.ring.Add(tx.Hash(), sender)
+	}
+	return nil
+}
+
+// Txs are included into a block
+// not safe for concurrent use
+func (s *Buffer) CollectConfirmedTxs(txs types.Transactions) {
+	for _, tx := range txs {
+		s.ring.Delete(tx.Hash())
+	}
+}
+
+// not safe for concurrent use
+func (s *Buffer) MayBeConflicted(sender common.Address, txHash common.Hash) bool {
+	_, ok := s.ring.Get(txHash)
+	if ok {
+		return true // the tx was already included by somebody
+	}
+	// the sender already has a not confirmed tx, wait until it gets confirmed
+	return s.ring.GetTxsNum(sender) != 0
+}
+
+// not safe for concurrent use
+func (s *Buffer) Clear() {
+	s.ring.Clear()
+}
+
+// not safe for concurrent use
+func (s *Buffer) Len() int {
+	return s.ring.senders.Len()
+}

--- a/src/gossip/service.go
+++ b/src/gossip/service.go
@@ -2,13 +2,12 @@ package gossip
 
 import (
 	"fmt"
-	"github.com/Fantom-foundation/go-lachesis/src/gossip/occured_txs"
-	"github.com/ethereum/go-ethereum/core/types"
 	"math/rand"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	notify "github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/Fantom-foundation/go-lachesis/src/ethapi"
 	"github.com/Fantom-foundation/go-lachesis/src/evm_core"
+	"github.com/Fantom-foundation/go-lachesis/src/gossip/occured_txs"
 	"github.com/Fantom-foundation/go-lachesis/src/inter"
 	"github.com/Fantom-foundation/go-lachesis/src/inter/idx"
 	"github.com/Fantom-foundation/go-lachesis/src/logger"

--- a/src/gossip/service.go
+++ b/src/gossip/service.go
@@ -2,6 +2,8 @@ package gossip
 
 import (
 	"fmt"
+	"github.com/Fantom-foundation/go-lachesis/src/gossip/occured_txs"
+	"github.com/ethereum/go-ethereum/core/types"
 	"math/rand"
 	"sync"
 
@@ -20,6 +22,10 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/src/inter"
 	"github.com/Fantom-foundation/go-lachesis/src/inter/idx"
 	"github.com/Fantom-foundation/go-lachesis/src/logger"
+)
+
+const (
+	txsRingBufferSize = 20000 // Maximum number of stored hashes of included but not confirmed txs
 )
 
 type ServiceFeed struct {
@@ -60,12 +66,13 @@ type Service struct {
 	serverPool *serverPool
 
 	// application
-	node     *node.ServiceContext
-	store    *Store
-	engine   Consensus
-	engineMu *sync.RWMutex
-	emitter  *Emitter
-	txpool   *evm_core.TxPool
+	node        *node.ServiceContext
+	store       *Store
+	engine      Consensus
+	engineMu    *sync.RWMutex
+	emitter     *Emitter
+	txpool      *evm_core.TxPool
+	occurredTxs *occured_txs.Buffer
 
 	feed ServiceFeed
 
@@ -88,25 +95,22 @@ func NewService(ctx *node.ServiceContext, config Config, store *Store, engine Co
 		node:  ctx,
 		store: store,
 
-		engineMu: new(sync.RWMutex),
+		engineMu:    new(sync.RWMutex),
+		occurredTxs: occured_txs.New(txsRingBufferSize, types.NewEIP155Signer(params.AllEthashProtocolChanges.ChainID)),
 
 		Instance: logger.MakeInstance(),
 	}
 
-	engine = &HookedEngine{
+	svc.engine = &HookedEngine{
 		engine:       engine,
 		processEvent: svc.processEvent,
 	}
-	svc.engine = engine
-
-	engine.Bootstrap(svc.ApplyBlock)
+	svc.engine.Bootstrap(svc.ApplyBlock)
 
 	trustedNodes := []string{}
-
 	svc.serverPool = newServerPool(store.table.Peers, svc.done, &svc.wg, trustedNodes)
 
 	stateReader := svc.GetEvmStateReader()
-
 	svc.txpool = evm_core.NewTxPool(config.TxPool, params.AllEthashProtocolChanges, stateReader)
 
 	var err error
@@ -134,6 +138,8 @@ func (s *Service) processEvent(realEngine Consensus, e *inter.Event) error {
 			return err
 		}
 	}
+	_ = s.occurredTxs.CollectNotConfirmedTxs(e.Transactions)
+
 	// set member's last event. we don't care about forks, because this index is used only for emitter
 	s.store.SetLastEvent(e.Epoch, e.Creator, e.Hash())
 
@@ -152,13 +158,14 @@ func (s *Service) processEvent(realEngine Consensus, e *inter.Event) error {
 		s.packs_onNewEpoch(oldEpoch, newEpoch)
 		s.store.delEpochStore(oldEpoch)
 		s.feed.newEpoch.Send(newEpoch)
+		s.occurredTxs.Clear()
 	}
 
 	return nil
 }
 
 func (s *Service) makeEmitter() *Emitter {
-	return NewEmitter(&s.config, s.AccountManager(), s.engine, s.engineMu, s.store, s.txpool, func(emitted *inter.Event) {
+	return NewEmitter(&s.config, s.AccountManager(), s.engine, s.engineMu, s.store, s.txpool, s.occurredTxs, func(emitted *inter.Event) {
 		// s.engineMu is locked here
 
 		err := s.engine.ProcessEvent(emitted)

--- a/src/gossip/service.go
+++ b/src/gossip/service.go
@@ -114,7 +114,7 @@ func NewService(ctx *node.ServiceContext, config Config, store *Store, engine Co
 	svc.txpool = evm_core.NewTxPool(config.TxPool, params.AllEthashProtocolChanges, stateReader)
 
 	var err error
-	svc.pm, err = NewProtocolManager(&config, &svc.feed, svc.txpool, svc.engineMu, store, engine, svc.serverPool)
+	svc.pm, err = NewProtocolManager(&config, &svc.feed, svc.txpool, svc.engineMu, store, svc.engine, svc.serverPool)
 
 	svc.EthAPI = &EthAPIBackend{config.ExtRPCEnabled, svc, stateReader, nil}
 

--- a/src/integration/integration.go
+++ b/src/integration/integration.go
@@ -1,6 +1,8 @@
 package integration
 
 import (
+	"time"
+
 	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
 
 	"github.com/Fantom-foundation/go-lachesis/src/gossip"
@@ -19,6 +21,7 @@ func NewIntegration(ctx *adapters.ServiceContext, network lachesis.Config) *goss
 	)
 
 	gossipCfg.Emitter.Emitbase = coinbase.Address
+	gossipCfg.Emitter.MaxEmitInterval = 3 * time.Second
 
 	svc, err := gossip.NewService(ctx.NodeContext, gossipCfg, gdb, engine)
 	if err != nil {

--- a/src/inter/pos/members.go
+++ b/src/inter/pos/members.go
@@ -1,6 +1,7 @@
 package pos
 
 import (
+	"bytes"
 	"io"
 	"sort"
 
@@ -25,6 +26,23 @@ func (mm *Members) Set(addr common.Address, stake Stake) {
 	} else {
 		delete((*mm), addr)
 	}
+}
+
+func (mm Members) Addresses() []common.Address {
+	array := make([]common.Address, 0, len(mm))
+	for n := range mm {
+		array = append(array, n)
+	}
+	return array
+}
+
+func (mm Members) SortedAddresses() []common.Address {
+	array := mm.Addresses()
+	sort.Slice(array, func(i, j int) bool {
+		a, b := array[i], array[j]
+		return bytes.Compare(a.Bytes(), b.Bytes()) < 0
+	})
+	return array
 }
 
 func (mm Members) sortedArray() members {

--- a/src/utils/weighted_shuffle.go
+++ b/src/utils/weighted_shuffle.go
@@ -1,0 +1,111 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"github.com/Fantom-foundation/go-lachesis/src/inter/pos"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/Fantom-foundation/go-lachesis/src/common/littleendian"
+)
+
+type weightedShuffleNode struct {
+	thisWeight  pos.Stake
+	leftWeight  pos.Stake
+	rightWeight pos.Stake
+}
+
+type weightedShuffleTree struct {
+	seed      common.Hash
+	seedIndex int
+
+	weights []pos.Stake
+	nodes   []weightedShuffleNode
+}
+
+func (t *weightedShuffleTree) leftIndex(i int) int {
+	return i*2 + 1
+}
+
+func (t *weightedShuffleTree) rightIndex(i int) int {
+	return i*2 + 2
+}
+
+func (t *weightedShuffleTree) build(i int) pos.Stake {
+	if i >= len(t.weights) {
+		return 0
+	}
+	this_w := t.weights[i]
+	left_w := t.build(t.leftIndex(i))
+	right_w := t.build(t.rightIndex(i))
+
+	if this_w <= 0 {
+		panic("all the weight must be positive")
+	}
+
+	t.nodes[i] = weightedShuffleNode{
+		thisWeight:  this_w,
+		leftWeight:  left_w,
+		rightWeight: right_w,
+	}
+	return this_w + left_w + right_w
+}
+
+func (t *weightedShuffleTree) rand64() uint64 {
+	if t.seedIndex == 32 {
+		hasher := sha256.New() // use sha2 instead of sha3 for speed
+		hasher.Write(t.seed.Bytes())
+		t.seed = common.BytesToHash(hasher.Sum(nil))
+		t.seedIndex = 0
+	}
+	// use not used parts of old seed, instead of calculating new one
+	res := littleendian.BytesToInt64(t.seed[t.seedIndex : t.seedIndex+8])
+	t.seedIndex += 8
+	return res
+}
+
+func (t *weightedShuffleTree) retrieve(i int) int {
+	node := t.nodes[i]
+	total := node.rightWeight + node.leftWeight + node.thisWeight
+
+	r := pos.Stake(t.rand64()) % total
+
+	if r < node.thisWeight {
+		t.nodes[i].thisWeight = 0
+		return i
+	} else if r < node.thisWeight+node.leftWeight {
+		chosen := t.retrieve(t.leftIndex(i))
+		t.nodes[i].leftWeight -= t.weights[chosen]
+		return chosen
+	} else {
+		chosen := t.retrieve(t.rightIndex(i))
+		t.nodes[i].rightWeight -= t.weights[chosen]
+		return chosen
+	}
+}
+
+// Builds weighted random permutation
+// Returns first {size} entries of {weights} permutation.
+// Call with {size} == len(weights) to get the whole permutation.
+func WeightedPermutation(size int, weights []pos.Stake, seed common.Hash) []int {
+	if len(weights) < size {
+		panic("the permutation size must be less or equal to weights size")
+	}
+
+	if len(weights) == 0 {
+		return make([]int, 0)
+	}
+
+	tree := weightedShuffleTree{
+		weights: weights,
+		nodes:   make([]weightedShuffleNode, len(weights)),
+		seed:    seed,
+	}
+	tree.build(0)
+
+	permutation := make([]int, size)
+	for i := 0; i < size; i++ {
+		permutation[i] = tree.retrieve(0)
+	}
+	return permutation
+}

--- a/src/utils/weighted_shuffle_test.go
+++ b/src/utils/weighted_shuffle_test.go
@@ -1,0 +1,100 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"github.com/Fantom-foundation/go-lachesis/src/inter/pos"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Fantom-foundation/go-lachesis/src/common/littleendian"
+)
+
+func getTestweights_increasing(num int) []pos.Stake {
+	weights := make([]pos.Stake, num)
+	for i := 0; i < num; i++ {
+		weights[i] = pos.Stake(i+1) * 1000
+	}
+	return weights
+}
+
+func getTestWeights_equal(num int) []pos.Stake {
+	weights := make([]pos.Stake, num)
+	for i := 0; i < num; i++ {
+		weights[i] = 1000
+	}
+	return weights
+}
+
+// Test average distribution of the shuffle
+func Test_Permutation_distribution(t *testing.T) {
+	weightsArr := getTestweights_increasing(30)
+
+	weightHits := make(map[int]int) // weight -> number of occurrences
+	for round_seed := 0; round_seed < 3000; round_seed++ {
+		seed := hashOf(common.Hash{}, uint32(round_seed))
+		perm := WeightedPermutation(len(weightsArr)/10, weightsArr, seed)
+		for _, p := range perm {
+			weight := weightsArr[p]
+			weight_factor := int(weight / 1000)
+
+			_, ok := weightHits[weight_factor]
+			if !ok {
+				weightHits[weight_factor] = 0
+			}
+			weightHits[weight_factor] += 1
+		}
+	}
+
+	assertar := assert.New(t)
+	for weight_factor, hits := range weightHits {
+		//fmt.Printf("Test_RandomElection_distribution: %d \n", hits/weight_factor)
+		assertar.Equal((hits / weight_factor) > 20-8, true)
+		assertar.Equal((hits / weight_factor) < 20+8, true)
+		if t.Failed() {
+			return
+		}
+	}
+}
+
+// test that WeightedPermutation provides a correct permaition
+func testCorrectPermutation(t *testing.T, weightsArr []pos.Stake) {
+	assertar := assert.New(t)
+
+	perm := WeightedPermutation(len(weightsArr), weightsArr, common.Hash{})
+	assertar.Equal(len(weightsArr), len(perm))
+
+	met := make(map[int]bool)
+	for _, p := range perm {
+		assertar.True(p >= 0)
+		assertar.True(p < len(weightsArr))
+		assertar.False(met[p])
+		met[p] = true
+	}
+}
+
+func Test_Permutation_correctness(t *testing.T) {
+	testCorrectPermutation(t, getTestweights_increasing(1))
+	testCorrectPermutation(t, getTestweights_increasing(30))
+	testCorrectPermutation(t, getTestWeights_equal(1000))
+}
+
+func hashOf(a common.Hash, b uint32) common.Hash {
+	hasher := sha256.New()
+	hasher.Write(a.Bytes())
+	hasher.Write(littleendian.Int32ToBytes(uint32(b)))
+	return common.BytesToHash(hasher.Sum(nil))
+}
+
+func Test_Permutation_determinism(t *testing.T) {
+	weightsArr := getTestweights_increasing(5)
+
+	assertar := assert.New(t)
+
+	assertar.Equal([]int{3, 2, 4, 1, 0}, WeightedPermutation(len(weightsArr), weightsArr, hashOf(common.Hash{}, 0)))
+	assertar.Equal([]int{0, 4, 2, 1, 3}, WeightedPermutation(len(weightsArr), weightsArr, hashOf(common.Hash{}, 1)))
+	assertar.Equal([]int{3, 4, 2, 1, 0}, WeightedPermutation(len(weightsArr), weightsArr, hashOf(common.Hash{}, 2)))
+	assertar.Equal([]int{4, 2, 1, 3, 0}, WeightedPermutation(len(weightsArr), weightsArr, hashOf(common.Hash{}, 3)))
+	assertar.Equal([]int{1, 4}, WeightedPermutation(len(weightsArr)/2, weightsArr, hashOf(common.Hash{}, 4)))
+}


### PR DESCRIPTION
Implement the mechanism to decrease the chance of posting conflicting txs simultaneously by different validators.

Also slow down the emitting rate (to MaxEmitInterval) if there's no txs to post AND there's no confirmed txs.

#### Algorithm
Alice is a tx sender, Bob is a validator.

- Alice sends her transaction into transactions pool, exactly as she would do it in the eth62 protocol.
- When Bob receives the transaction from his transactions pool, he memorizes the time when he received the transaction.
- Bob calculates the deterministic (weighted by stake) permutation of validators against tx hash. The permutation defines the order in which validators try to post this tx, where the time period of each turn is 4 seconds. The possible time drift is ignored.
- - If it's not Bob's turn, then Bob ignores the tx
- If there's at least one not confirmed (but included into an event) tx from Alice
- - then Bob ignores the tx
- Bob posts the tx
