### PR TITLE
Make lint happy: The comeback

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ If everything goes well, it should output something along these lines:
 ok      github.com/Fantom-foundation/go-lachesis/evm_core   (cached)
 ok      github.com/Fantom-foundation/go-lachesis/gossip (cached)
 ?       github.com/Fantom-foundation/go-lachesis/gossip/fetcher [no test files]
-?       github.com/Fantom-foundation/go-lachesis/gossip/occured_txs [no test files]
+?       github.com/Fantom-foundation/go-lachesis/gossip/occuredtxs [no test files]
 ok      github.com/Fantom-foundation/go-lachesis/gossip/ordering    (cached)
-ok      github.com/Fantom-foundation/go-lachesis/gossip/packs_downloader    (cached)
+ok      github.com/Fantom-foundation/go-lachesis/gossip/packsdownloader    (cached)
 ```
 
 ### Operating a private network

--- a/debug/api.go
+++ b/debug/api.go
@@ -83,9 +83,9 @@ func (*HandlerT) GcStats() *debug.GCStats {
 	return s
 }
 
-// CpuProfile turns on CPU profiling for nsec seconds and writes
+// CPUProfile turns on CPU profiling for nsec seconds and writes
 // profile data to file.
-func (h *HandlerT) CpuProfile(file string, nsec uint) error {
+func (h *HandlerT) CPUProfile(file string, nsec uint) error {
 	if err := h.StartCPUProfile(file); err != nil {
 		return err
 	}

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -516,8 +516,8 @@ func NewPublicBlockChainAPI(b Backend) *PublicBlockChainAPI {
 	return &PublicBlockChainAPI{b}
 }
 
-// ChainId returns the chainID value for transaction replay protection.
-func (s *PublicBlockChainAPI) ChainId() *hexutil.Big {
+// ChainID returns the chainID value for transaction replay protection.
+func (s *PublicBlockChainAPI) ChainID() *hexutil.Big {
 	return (*hexutil.Big)(s.b.ChainConfig().ChainID)
 }
 
@@ -1375,7 +1375,7 @@ func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 		args.Nonce = (*hexutil.Uint64)(&nonce)
 	}
 	if args.Data != nil && args.Input != nil && !bytes.Equal(*args.Data, *args.Input) {
-		return errors.New(`Both "data" and "input" are set and not equal. Please use "input" to pass transaction call data.`)
+		return errors.New(`Both "data" and "input" are set and not equal. Please use "input" to pass transaction call data`)
 	}
 	if args.To == nil {
 		// Contract creation

--- a/evm_core/apply_genesis_test.go
+++ b/evm_core/apply_genesis_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/Fantom-foundation/go-lachesis/kvdb/memorydb"
-	"github.com/Fantom-foundation/go-lachesis/kvdb/no_key_is_err"
+	"github.com/Fantom-foundation/go-lachesis/kvdb/nokeyiserr"
 	"github.com/Fantom-foundation/go-lachesis/kvdb/table"
 	"github.com/Fantom-foundation/go-lachesis/lachesis"
 	"github.com/Fantom-foundation/go-lachesis/logger"
@@ -18,7 +18,7 @@ func TestApplyGenesis(t *testing.T) {
 	logger.SetTestMode(t)
 
 	db := rawdb.NewDatabase(
-		no_key_is_err.Wrap(
+		nokeyiserr.Wrap(
 			table.New(
 				memorydb.New(), []byte("evm_"))))
 

--- a/gossip/api.go
+++ b/gossip/api.go
@@ -33,6 +33,6 @@ func (api *PublicEthereumAPI) Hashrate() hexutil.Uint64 {
 }
 
 // ChainId is the EIP-155 replay-protection chain id for the current ethereum chain config.
-func (api *PublicEthereumAPI) ChainId() hexutil.Uint64 {
+func (api *PublicEthereumAPI) ChainID() hexutil.Uint64 {
 	return hexutil.Uint64(params.AllEthashProtocolChanges.ChainID.Uint64())
 }

--- a/gossip/emitter.go
+++ b/gossip/emitter.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/event_check"
 	"github.com/Fantom-foundation/go-lachesis/event_check/basic_check"
 	"github.com/Fantom-foundation/go-lachesis/evm_core"
-	"github.com/Fantom-foundation/go-lachesis/gossip/occured_txs"
+	"github.com/Fantom-foundation/go-lachesis/gossip/occuredtxs"
 	"github.com/Fantom-foundation/go-lachesis/hash"
 	"github.com/Fantom-foundation/go-lachesis/inter"
 	"github.com/Fantom-foundation/go-lachesis/inter/ancestor"
@@ -40,7 +40,7 @@ type EmitterWorld struct {
 	EngineMu    *sync.RWMutex
 	Txpool      txPool
 	Am          *accounts.Manager
-	OccurredTxs *occured_txs.Buffer
+	OccurredTxs *occuredtxs.Buffer
 
 	OnEmitted func(e *inter.Event)
 	IsSynced  func() bool

--- a/gossip/helper_test.go
+++ b/gossip/helper_test.go
@@ -147,7 +147,7 @@ func newTestPeer(name string, version int, pm *ProtocolManager, shake bool) (*te
 func (p *testPeer) handshake(t *testing.T, progress *PeerProgress, genesis common.Hash) {
 	msg := &ethStatusData{
 		ProtocolVersion:   uint32(p.version),
-		NetworkId:         lachesis.FakeNetworkID,
+		NetworkID:         lachesis.FakeNetworkID,
 		Genesis:           genesis,
 		DummyTD:           big.NewInt(int64(progress.NumOfBlocks)), // for ETH clients
 		DummyCurrentBlock: common.Hash(progress.LastBlock),

--- a/gossip/occuredtxs/txs_ring_buffer.go
+++ b/gossip/occuredtxs/txs_ring_buffer.go
@@ -1,4 +1,4 @@
-package occured_txs
+package occuredtxs
 
 import (
 	"github.com/ethereum/go-ethereum/common"

--- a/gossip/pack.go
+++ b/gossip/pack.go
@@ -18,7 +18,7 @@ const (
 	maxPackEventsNum = softLimitItems
 )
 
-func (s *Service) packs_onNewEvent(e *inter.Event, epoch idx.Epoch) {
+func (s *Service) packsOnNewEvent(e *inter.Event, epoch idx.Epoch) {
 	// due to default values, we don't need to explicitly set values at a start of an epoch
 	packIdx := s.store.GetPacksNumOrDefault(epoch)
 	packInfo := s.store.GetPackInfoOrDefault(s.engine.GetEpoch(), packIdx)
@@ -38,7 +38,7 @@ func (s *Service) packs_onNewEvent(e *inter.Event, epoch idx.Epoch) {
 	s.store.SetPackInfo(epoch, packIdx, packInfo)
 }
 
-func (s *Service) packs_onNewEpoch(oldEpoch, newEpoch idx.Epoch) {
+func (s *Service) packsOnNewEpoch(oldEpoch, newEpoch idx.Epoch) {
 	// pin the last pack
 	packIdx := s.store.GetPacksNumOrDefault(oldEpoch)
 	packInfo := s.store.GetPackInfoOrDefault(s.engine.GetEpoch(), packIdx)

--- a/gossip/packsdownloader/packs_downloader.go
+++ b/gossip/packsdownloader/packs_downloader.go
@@ -1,4 +1,4 @@
-package packs_downloader
+package packsdownloader
 
 import (
 	"github.com/Fantom-foundation/go-lachesis/gossip/fetcher"

--- a/gossip/packsdownloader/peer_downloader.go
+++ b/gossip/packsdownloader/peer_downloader.go
@@ -1,4 +1,4 @@
-package packs_downloader
+package packsdownloader
 
 import (
 	"errors"

--- a/gossip/packsdownloader/peer_downloader_test.go
+++ b/gossip/packsdownloader/peer_downloader_test.go
@@ -1,4 +1,4 @@
-package packs_downloader
+package packsdownloader
 
 import (
 	"fmt"

--- a/gossip/peer.go
+++ b/gossip/peer.go
@@ -358,7 +358,7 @@ func (p *peer) Handshake(network uint64, progress PeerProgress, genesis common.H
 		// send both EthStatusMsg and ProgressMsg, eth62 clients will understand only status
 		err := p2p.Send(p.rw, EthStatusMsg, &ethStatusData{
 			ProtocolVersion:   uint32(p.version),
-			NetworkId:         network,
+			NetworkID:         network,
 			Genesis:           genesis,
 			DummyTD:           big.NewInt(int64(progress.NumOfBlocks)), // for ETH clients
 			DummyCurrentBlock: common.Hash(progress.LastBlock),
@@ -409,8 +409,8 @@ func (p *peer) readStatus(network uint64, status *ethStatusData, genesis common.
 	if status.Genesis != genesis {
 		return errResp(ErrGenesisMismatch, "%x (!= %x)", status.Genesis[:8], genesis[:8])
 	}
-	if status.NetworkId != network {
-		return errResp(ErrNetworkIdMismatch, "%d (!= %d)", status.NetworkId, network)
+	if status.NetworkID != network {
+		return errResp(ErrNetworkIDMismatch, "%d (!= %d)", status.NetworkID, network)
 	}
 	if int(status.ProtocolVersion) != p.version {
 		return errResp(ErrProtocolVersionMismatch, "%d (!= %d)", status.ProtocolVersion, p.version)

--- a/gossip/protocol.go
+++ b/gossip/protocol.go
@@ -71,7 +71,7 @@ const (
 	ErrDecode
 	ErrInvalidMsgCode
 	ErrProtocolVersionMismatch
-	ErrNetworkIdMismatch
+	ErrNetworkIDMismatch
 	ErrGenesisMismatch
 	ErrNoStatusMsg
 	ErrExtraStatusMsg
@@ -89,7 +89,7 @@ var errorToString = map[int]string{
 	ErrDecode:                  "Invalid message",
 	ErrInvalidMsgCode:          "Invalid message code",
 	ErrProtocolVersionMismatch: "Protocol version mismatch",
-	ErrNetworkIdMismatch:       "NetworkId mismatch",
+	ErrNetworkIDMismatch:       "NetworkId mismatch",
 	ErrGenesisMismatch:         "Genesis object mismatch",
 	ErrNoStatusMsg:             "No status message",
 	ErrExtraStatusMsg:          "Extra status message",
@@ -113,7 +113,7 @@ type txPool interface {
 // ethStatusData is the network packet for the status message. It's used for compatibility with some ETH wallets.
 type ethStatusData struct {
 	ProtocolVersion   uint32
-	NetworkId         uint64
+	NetworkID         uint64
 	DummyTD           *big.Int
 	DummyCurrentBlock common.Hash
 	Genesis           common.Hash

--- a/gossip/protocol_test.go
+++ b/gossip/protocol_test.go
@@ -31,7 +31,7 @@ func testStatusMsgErrors(t *testing.T, protocol int) {
 	pm, _ := newTestProtocolManagerMust(t, 5, 5, nil, nil)
 	var (
 		genesis   = pm.engine.GetGenesisHash()
-		networkId = lachesis.FakeNetworkID
+		networkID = lachesis.FakeNetworkID
 	)
 	defer pm.Stop()
 
@@ -45,15 +45,15 @@ func testStatusMsgErrors(t *testing.T, protocol int) {
 			wantError: errResp(ErrNoStatusMsg, "first msg has code 2 (!= 0)"),
 		},
 		{
-			code: EthStatusMsg, data: ethStatusData{ProtocolVersion: 10, NetworkId: networkId, Genesis: genesis},
+			code: EthStatusMsg, data: ethStatusData{ProtocolVersion: 10, NetworkID: networkID, Genesis: genesis},
 			wantError: errResp(ErrProtocolVersionMismatch, "10 (!= %d)", protocol),
 		},
 		{
-			code: EthStatusMsg, data: ethStatusData{ProtocolVersion: uint32(protocol), NetworkId: 999, Genesis: genesis},
-			wantError: errResp(ErrNetworkIdMismatch, "999 (!= %d)", networkId),
+			code: EthStatusMsg, data: ethStatusData{ProtocolVersion: uint32(protocol), NetworkID: 999, Genesis: genesis},
+			wantError: errResp(ErrNetworkIDMismatch, "999 (!= %d)", networkID),
 		},
 		{
-			code: EthStatusMsg, data: ethStatusData{ProtocolVersion: uint32(protocol), NetworkId: networkId, Genesis: common.Hash{3}},
+			code: EthStatusMsg, data: ethStatusData{ProtocolVersion: uint32(protocol), NetworkID: networkID, Genesis: common.Hash{3}},
 			wantError: errResp(ErrGenesisMismatch, "0300000000000000 (!= %x)", genesis.Bytes()[:8]),
 		},
 	}

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -21,7 +21,7 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/event_check"
 	"github.com/Fantom-foundation/go-lachesis/evm_core"
 	"github.com/Fantom-foundation/go-lachesis/gossip/gasprice"
-	"github.com/Fantom-foundation/go-lachesis/gossip/occured_txs"
+	"github.com/Fantom-foundation/go-lachesis/gossip/occuredtxs"
 	"github.com/Fantom-foundation/go-lachesis/inter"
 	"github.com/Fantom-foundation/go-lachesis/inter/idx"
 	"github.com/Fantom-foundation/go-lachesis/logger"
@@ -75,7 +75,7 @@ type Service struct {
 	engineMu    *sync.RWMutex
 	emitter     *Emitter
 	txpool      *evm_core.TxPool
-	occurredTxs *occured_txs.Buffer
+	occurredTxs *occuredtxs.Buffer
 
 	feed ServiceFeed
 
@@ -99,7 +99,7 @@ func NewService(ctx *node.ServiceContext, config Config, store *Store, engine Co
 		store: store,
 
 		engineMu:    new(sync.RWMutex),
-		occurredTxs: occured_txs.New(txsRingBufferSize, types.NewEIP155Signer(params.AllEthashProtocolChanges.ChainID)),
+		occurredTxs: occuredtxs.New(txsRingBufferSize, types.NewEIP155Signer(params.AllEthashProtocolChanges.ChainID)),
 
 		Instance: logger.MakeInstance(),
 	}
@@ -155,7 +155,7 @@ func (s *Service) processEvent(realEngine Consensus, e *inter.Event) error {
 	}
 	s.store.AddHead(e.Epoch, e.Hash())
 
-	s.packs_onNewEvent(e, e.Epoch)
+	s.packsOnNewEvent(e, e.Epoch)
 	s.emitter.OnNewEvent(e)
 
 	newEpoch := oldEpoch
@@ -164,7 +164,7 @@ func (s *Service) processEvent(realEngine Consensus, e *inter.Event) error {
 	}
 
 	if newEpoch != oldEpoch {
-		s.packs_onNewEpoch(oldEpoch, newEpoch)
+		s.packsOnNewEpoch(oldEpoch, newEpoch)
 		s.store.delEpochStore(oldEpoch)
 		s.store.getEpochStore(newEpoch)
 		s.feed.newEpoch.Send(newEpoch)

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/kvdb"
 	"github.com/Fantom-foundation/go-lachesis/kvdb/flushable"
 	"github.com/Fantom-foundation/go-lachesis/kvdb/memorydb"
-	"github.com/Fantom-foundation/go-lachesis/kvdb/no_key_is_err"
+	"github.com/Fantom-foundation/go-lachesis/kvdb/nokeyiserr"
 	"github.com/Fantom-foundation/go-lachesis/kvdb/table"
 	"github.com/Fantom-foundation/go-lachesis/logger"
 )
@@ -79,7 +79,7 @@ func NewStore(dbs *flushable.SyncedPool, cfg StoreConfig) *Store {
 
 	table.MigrateTables(&s.table, s.mainDb)
 
-	evmTable := no_key_is_err.Wrap(table.New(s.mainDb, []byte("evm_"))) // ETH expects that "not found" is an error
+	evmTable := nokeyiserr.Wrap(table.New(s.mainDb, []byte("evm_"))) // ETH expects that "not found" is an error
 	s.table.Evm = rawdb.NewDatabase(evmTable)
 	s.table.EvmState = state.NewDatabase(s.table.Evm)
 

--- a/inter/ancestor/parents_test.go
+++ b/inter/ancestor/parents_test.go
@@ -138,13 +138,13 @@ func testSpecialNamedParents(t *testing.T, asciiScheme string, exp map[int]map[s
 
 			strategy := NewCasualityStrategy(vecClock, validators)
 
-			selfParent_, parents := FindBestParents(5, heads.Slice(), selfParent, strategy)
+			selfParentResult, parents := FindBestParents(5, heads.Slice(), selfParent, strategy)
 
 			if selfParent != nil {
 				assertar.Equal(parents[0], *selfParent)
-				assertar.Equal(*selfParent_, *selfParent)
+				assertar.Equal(*selfParentResult, *selfParent)
 			} else {
-				assertar.Nil(selfParent_)
+				assertar.Nil(selfParentResult)
 			}
 			//t.Logf("\"%s\": \"%s\",", node.String(), parentsToString(parents))
 			if !assertar.Equal(

--- a/inter/pos/validators.go
+++ b/inter/pos/validators.go
@@ -116,11 +116,10 @@ func (vv Validators) EncodeRLP(w io.Writer) error {
 }
 
 // DecodeRLP is for RLP deserialization.
-func (pp *Validators) DecodeRLP(s *rlp.Stream) error {
-	if *pp == nil {
-		*pp = Validators{}
+func (vv *Validators) DecodeRLP(s *rlp.Stream) error {
+	if *vv == nil {
+		*vv = Validators{}
 	}
-	vv := *pp
 
 	var arr []validator
 	if err := s.Decode(&arr); err != nil {
@@ -128,7 +127,7 @@ func (pp *Validators) DecodeRLP(s *rlp.Stream) error {
 	}
 
 	for _, w := range arr {
-		vv[w.Addr] = w.Stake
+		(*vv)[w.Addr] = w.Stake
 	}
 
 	return nil

--- a/kvdb/flushable/synced_pool.go
+++ b/kvdb/flushable/synced_pool.go
@@ -185,7 +185,7 @@ func (p *SyncedPool) checkDbsSynced() error {
 
 	var (
 		key    = []byte("flag")
-		prevId *[]byte
+		prevID *[]byte
 		descrs []string
 		list   = func() string {
 			return strings.Join(descrs, ",\n")
@@ -203,10 +203,10 @@ func (p *SyncedPool) checkDbsSynced() error {
 		if bytes.HasPrefix(mark, []byte("dirty")) {
 			return fmt.Errorf("dirty state: %s", list())
 		}
-		if prevId == nil {
-			prevId = &mark
+		if prevID == nil {
+			prevID = &mark
 		}
-		if !bytes.Equal(mark, *prevId) {
+		if !bytes.Equal(mark, *prevID) {
 			return fmt.Errorf("not synced: %s", list())
 		}
 	}

--- a/kvdb/nokeyiserr/wrapper.go
+++ b/kvdb/nokeyiserr/wrapper.go
@@ -1,4 +1,4 @@
-package no_key_is_err
+package nokeyiserr
 
 import (
 	"errors"


### PR DESCRIPTION
More changes to please `golint`.

At this stage, only three kind of errors are left:

- Uncommented stuff.
- Package names with underscores.
- Use of unexported return types on exported functions.

First two are easy to solve. Eager to see how to handle the third one.

Signed-off-by: Agustin Chiappe Berrini <jnieve@gmail.com>

Please check if what you want to add to `go-lachesis` list meets [quality standards](https://github.com/Fantom-foundation/go-lachesis/blob/master/CONTRIBUTING.md#quality-standard) before sending pull request.

**Please provide package links to:**

- github.com repo:
- godoc.org:
- goreportcard.com:
- coverage service link ([cover.run](https://cover.run/), [gocover](http://gocover.io/), [coveralls](https://coveralls.io/) etc.), example: `[![cover.run](https://cover.run/go/github.com/user/repository.svg?style=flat&tag=golang-1.10)](https://cover.run/go?tag=golang-1.10&repo=github.com%2Fuser%2Frepository)`

**Make sure that you've checked the boxes below before you submit PR:**
- [ ] I have added my package in alphabetical order.
- [ ] I have an appropriate description with correct grammar.
- [ ] I know that this package was not listed before.
- [ ] I have added godoc link to the repo and to my pull request.
- [ ] I have added coverage service link to the repo and to my pull request.
- [ ] I have added goreportcard link to the repo and to my pull request.
- [ ] I have read [Contribution guidelines](https://github.com/Fantom-foundation/go-lachesis/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/Fantom-foundation/go-lachesis/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/Fantom-foundation/go-lachesis/blob/master/CONTRIBUTING.md#quality-standard).
