### PR TITLE
new Hash() method for Block

### DIFF
--- a/poset/restore_test.go
+++ b/poset/restore_test.go
@@ -271,7 +271,7 @@ func compareStates(assertar *assert.Assertions, expected, restored *ExtendedPose
 	// check LastAtropos and Head() method
 	if expected.Checkpoint.LastBlockN != 0 {
 		assertar.Equal(
-			expected.blocks[idx.Block(len(expected.blocks))].Hash(),
+			expected.blocks[idx.Block(len(expected.blocks))].Atropos(),
 			restored.Checkpoint.LastAtropos,
 			"atropos must be last event in block")
 	}


### PR DESCRIPTION
Current implementation of `Hash()` method for `Block` does not guarantee the blocks with the same hash value have the very same order of events included into them.

This PR implements new `Hash()` method which is calculated as hash of all event hashes in the block and thus would guarantee the same hash value for the same order of events in the block and different hashes for blocks with different order of events (as long as there is no hash collision).

New `Hash()` method is more computational expensive. 