### PR TITLE
SFC node-side index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+# build
+.PHONY : build txstorm
+build :
+	go build -o build/lachesis ./cmd/lachesis
+
+txstorm :
+	go build -o build/tx-storm ./cmd/tx-storm
+#test
+.PHONY : test
+test :
+	go test ./...
+
+#clean
+.PHONY : clean
+clean :
+	rm ./build/lachesis ./build/tx-storm

--- a/demo/benchmark/replay.sh
+++ b/demo/benchmark/replay.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+# This script will launch a cluster of Lachesis nodes
+# The parameter N = number of nodes to run
+
+set -e
+
+# number of nodes N
+N=5
+LIMIT_CPU=$(echo "scale=2; 1/$N" | bc)
+LIMIT_IO=$(echo "500/$N" | bc)
+
+#
+PROG=lachesis
+EXEC=../../build/lachesis
+
+# default ip using localhost
+IP=127.0.0.1
+# default port PORT
+# the actual ports are PORT+1, PORT+2, etc (18541, 18542, 18543, ... )
+PORT=18540
+
+LACHESIS_BASE_DIR=/tmp/lachesis-demo-replay/datadir
+rm -rf ${LACHESIS_BASE_DIR} > /dev/null
+mkdir ${LACHESIS_BASE_DIR}
+
+declare -a pids
+
+# Set up plg tool
+cp ${GOPATH}/src/github.com/Fantom-foundation/tun-replay/build/plg .
+PLG=./plg
+#echo "PLG=${PLG}"
+
+
+# Function to be called when user press ctrl-c.
+ctrl_c() {
+    echo "Shell terminating ..."
+    for pid in "${pids[@]}"
+    do
+	echo "Killing ${pid}..."
+	kill -9 ${pid}
+	# Suppresses "[pid] Terminated ..." message.
+	wait ${pid} &>/dev/null
+    done
+    exit;
+}
+
+trap ctrl_c SIGHUP SIGINT
+echo "You may press ctrl-c to kill all started processes..."
+
+declare -a progs
+
+echo -e "\nStart $N nodes:\n"
+for i in $(seq $N)
+do
+    port=$((PORT + i))
+    localport=$((5050 + i))
+
+    prog="exec${i}.sh"
+
+    echo "#!/bin/bash" > ${prog}
+    echo "${EXEC} --fakenet $i/$N --port ${localport} \
+      --rpc --rpcapi \"eth,debug,admin,web3\" --rpcport ${port} --nousb --verbosity 3 \
+      --datadir ${LACHESIS_BASE_DIR}/lach$i" >> ${prog}
+    chmod +x ${prog}
+    progs+="\"./${prog}\" "
+done
+
+finalcmd="sudo ${PLG} --record --subnet 127.0.0.1/24 -f dump.traffic  ${progs}"
+echo -e "Started replaying"
+echo -e "${finalcmd}"
+
+# execute the plg command
+# sudo ${PLG} --record --subnet 10.0.0.0/24 -f dump.traffic  ${progs}
+sudo ${finalcmd}
+
+
+# now connecting the nodes
+
+attach_and_exec() {
+     local URL=$1
+     local CMD=$2
+
+     for attempt in $(seq 20)
+     do
+         if (( attempt > 5 ));
+         then
+             echo "  - attempt ${attempt}: " >&2
+         fi;
+
+         res=$("${EXEC}" --exec "${CMD}" attach http://${URL} 2> /dev/null)
+         if [ $? -eq 0 ]
+         then
+             #echo "success" >&2
+             echo $res
+             return 0
+         else
+             #echo "wait" >&2
+             sleep 1
+         fi
+     done
+     echo "failed RPC connection to ${NAME}" >&2
+     return 1
+ }
+
+
+ echo -e "\nConnect nodes to ring:\n"
+ for i in $(seq $N)
+ do
+     j=$((i % N + 1))
+
+     echo " getting node-$j address:"
+ 	 url=${IP}:$((PORT + j))
+ 	 echo "    at url: ${url}"
+
+     enode=$(attach_and_exec ${url} 'admin.nodeInfo.enode')
+     echo "    p2p address = ${enode}"
+
+     echo " connecting node-$i to node-$j:"
+     url=${IP}:$((PORT + i))
+     echo "    at url: ${url}"
+
+     res=$(attach_and_exec ${url} "admin.addPeer(${enode})")
+     echo "    result = ${res}"
+ done
+
+
+
+echo
+echo "Sleep for 10000 seconds..."
+sleep 10000

--- a/demo/benchmark/stop.sh
+++ b/demo/benchmark/stop.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+PROG=lachesis
+
+# kill all lachesis processes
+pkill "${PROG}"
+
+# remove demo data
+sudo rm -rf /tmp/lachesis-demo-replay/datadir
+rm -rf exec*.sh dump.traffic

--- a/demo/discovery/start.sh
+++ b/demo/discovery/start.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# This script will launch a cluster of N Lachesis nodes
+# using 
+# The parameter N = number of nodes to run
+
+set -e
+
+# number of nodes N
+N=7
+LIMIT_CPU=$(echo "scale=2; 1/$N" | bc)
+LIMIT_IO=$(echo "500/$N" | bc)
+
+
+FVM=${GOPATH}/src/github.com/Fantom-foundation/go-ethereum
+BOOTNODE=${FVM}/build/bin/bootnode
+
+echo "Generate bootnode.key"
+${BOOTNODE} -genkey bootnode.key
+
+echo "Start bootnode with bootnode.key"
+bootnode=$( "${BOOTNODE}" -nodekey bootnode.key 2>/dev/null | head -1 & )
+#bootnode=$( cat bootenode.txt )
+
+echo -e "Bootnode=${bootnode}"
+
+######
+EXEC=../../build/lachesis
+
+# default ip using localhost
+IP=127.0.0.1
+# default port PORT
+# the actual ports are PORT+1, PORT+2, etc (18541, 18542, 18543, ... )
+PORT=18540
+
+# demo directory 
+LACHESIS_BASE_DIR=/tmp/lachesis-demo
+
+echo -e "\nStart $N nodes:"
+for i in $(seq $N)
+do
+    port=$((PORT + i))
+    localport=$((5050 + i))
+
+    ${EXEC} \
+	--bootnodes "${bootnode}" \
+	--fakenet $i/$N \
+	--port ${localport} --rpc --rpcapi "eth,debug,admin,web3" --rpcport ${port} --nousb --verbosity 3 \
+	--datadir "${LACHESIS_BASE_DIR}/datadir/lach$i" &
+    echo -e "Started lachesis client at ${IP}:${port}, pid: $!"
+done
+
+
+
+echo
+echo "Sleep for 10000 seconds..."
+sleep 10000

--- a/demo/discovery/stop.sh
+++ b/demo/discovery/stop.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# kill all bootnode and lachesis processes
+pkill "bootnode"
+pkill "lachesis"
+
+# remove demo data
+#rm -rf /tmp/lachesis-demo/datadir/

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# This script will launch a cluster of Lachesis nodes
+# The parameter N = number of nodes to run
+
+set -e
+
+# number of nodes N
+N=5
+LIMIT_CPU=$(echo "scale=2; 1/$N" | bc)
+LIMIT_IO=$(echo "500/$N" | bc)
+
+#
+PROG=lachesis
+EXEC=../build/lachesis
+
+# default ip using localhost
+IP=127.0.0.1
+# default port PORT
+# the actual ports are PORT+1, PORT+2, etc (18541, 18542, 18543, ... )
+#PORT=18540
+PORT=4000
+
+declare -r LACHESIS_BASE_DIR=/tmp/lachesis-demo
+
+
+echo -e "\nStart $N nodes:"
+for i in $(seq $N)
+do
+    port=$((PORT + i))
+    localport=$((5050 + i))
+
+    ${EXEC} \
+	--fakenet $i/$N \
+	--port ${localport} --rpc --rpcapi "eth,debug,admin,web3" --rpcport ${port} --nousb --verbosity 3 \
+	--datadir "${LACHESIS_BASE_DIR}/datadir/lach$i" &
+    echo -e "Started lachesis client at ${IP}:${port}"
+done
+
+
+
+attach_and_exec() {
+    local URL=$1
+    local CMD=$2
+
+    for attempt in $(seq 20)
+    do
+        if (( attempt > 5 ));
+        then
+            echo "  - attempt ${attempt}: " >&2
+        fi;
+
+        res=$("${EXEC}" --exec "${CMD}" attach http://${URL} 2> /dev/null)
+        if [ $? -eq 0 ]
+        then
+            #echo "success" >&2
+            echo $res
+            return 0
+        else
+            #echo "wait" >&2
+            sleep 1
+        fi
+    done
+    echo "failed RPC connection to ${NAME}" >&2
+    return 1
+}
+
+
+echo -e "\nConnect nodes to ring:\n"
+for i in $(seq $N)
+do
+    j=$((i % N + 1))
+
+    echo " getting node-$j address:"
+	url=${IP}:$((PORT + j))
+	echo "    at url: ${url}"
+
+    enode=$(attach_and_exec ${url} 'admin.nodeInfo.enode')
+    echo "    p2p address = ${enode}"
+
+    echo " connecting node-$i to node-$j:"
+    url=${IP}:$((PORT + i))
+    echo "    at url: ${url}"
+
+    res=$(attach_and_exec ${url} "admin.addPeer(${enode})")
+    echo "    result = ${res}"
+done
+
+
+echo
+echo "Sleep for 10000 seconds..."
+sleep 10000

--- a/demo/start_dyn_first.sh
+++ b/demo/start_dyn_first.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# This script will launch a cluster of Lachesis nodes
+# The parameter N = number of nodes to run
+
+. ./utils.sh
+
+# create and start nodes
+start_nodes 1 $N $T
+
+# connect these nodes together
+connect_nodes 1 $N
+
+echo
+echo "Sleep for 10000 seconds..."
+sleep 10000

--- a/demo/start_dyn_second.sh
+++ b/demo/start_dyn_second.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# This script will launch a cluster of Lachesis nodes
+
+. ./utils.sh
+
+# start new nodes
+echo "Starting the second group of nodes"
+echo -e "\nStart $M nodes:\n"
+for i in $(seq $((N+1)) $T);
+do
+    start_node $i $T
+done
+
+# and connect the new nodes together with the existing ones
+echo -e "\nConnect new nodes to ring:\n"
+for i in $(seq $((N+1)) $((T-1)));
+do
+    j=$((i + 1))
+    echo "i=$i, j=$j"
+    conn=$(connect_pair $i $j)
+done
+
+conn=$(connect_pair 1 $((N+1)))
+conn=$(connect_pair $T 1)
+
+##
+
+
+echo
+echo "Sleep for 10000 seconds..."
+sleep 10000

--- a/demo/stop.sh
+++ b/demo/stop.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+PROG=lachesis
+
+# kill all lachesis processes
+pkill "${PROG}"
+
+# remove demo data
+rm -rf /tmp/lachesis-demo/datadir/

--- a/demo/txstorm-start.sh
+++ b/demo/txstorm-start.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Number of tx-storm agents
+N=5
+
+# Program
+PROG=../build/tx-storm
+
+# default values
+PORT_BASE=3000
+RPCP_BASE=4000
+WSP_BASE=4500
+
+TEST_ACCS_START=1000
+TEST_ACCS_COUNT=100000
+
+# default ip using localhost
+IP=127.0.0.1
+# default port PORT
+# the actual ports are PORT+1, PORT+2, etc (18541, 18542, 18543, ... )
+#PORT=18540
+PORT=4000
+
+TXLOGDIR=./txstorm_logs
+mkdir -p ${TXLOGDIR}
+
+# start N tx generators
+echo -e "Start $N tx generators:"
+
+for i in $(seq $N)
+do
+    port=$((PORT + i))
+    echo -e "tx-storm $i at port ${port}:"
+    f=${TXLOGDIR}/${i}
+    
+    ${PROG} \
+	--num=$i/$N --rate=10 \
+	--accs-start=${TEST_ACCS_START} --accs-count=${TEST_ACCS_COUNT} \
+	--metrics --verbosity 5 \
+	http://${IP}:${port} >${f}.log 2>${f}.err &
+done

--- a/demo/txstorm-stop.sh
+++ b/demo/txstorm-stop.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+PROG=tx-storm
+
+# kill all dot-tool processes
+pkill "${PROG}"
+
+# remove txstorm_logs data
+#rm -rf ./txstorm_logs

--- a/demo/utils.sh
+++ b/demo/utils.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+declare -a pids
+
+# number of nodes N
+N=3
+# number of new nodes M
+M=3
+# total
+T=$((N+M))
+
+set -e
+LIMIT_CPU=$(echo "scale=2; 1/$N" | bc)
+LIMIT_IO=$(echo "500/$N" | bc)
+
+# base dir for running demo
+LACHESIS_BASE_DIR=/tmp/lachesis-demo
+
+#
+PROG=lachesis
+EXEC=../build/lachesis
+
+# default ip using localhost
+IP=127.0.0.1
+# default port PORT
+# the actual ports are PORT+1, PORT+2, etc (18641, 18642, 18643, ... )
+PORT=18800
+# default base local port
+# actual local ports are LOCALPORT+1, LOCALPORT+2, ...
+LOCALPORT=5800
+
+
+# Function to be called when user press ctrl-c.
+ctrl_c() {
+    echo "Shell terminating ..."
+    for pid in "${pids[@]}"
+    do
+	echo "Killing ${pid}..."
+	kill -9 ${pid}
+	# Suppresses "[pid] Terminated ..." message.
+	wait ${pid} &>/dev/null
+    done
+    exit;
+}
+
+start_node() {
+	local i=$1
+	local N=$2
+	echo -e "start_node node $i:"
+
+    port=$((PORT + i))
+	localport=$((LOCALPORT + i))
+
+	echo -e "port=${port}, localport=${localport} "
+
+    ${EXEC} \
+	--fakenet $i/$N \
+	--port ${localport} --rpc --rpcapi "eth,debug,admin,web3" --rpcport ${port} --nousb --verbosity 3 \
+	--datadir "${LACHESIS_BASE_DIR}/datadir/lach$i" &
+	pids+=($!)
+    echo -e "Started lachesis client at ${IP}:${port}, pid: $!"
+    echo -e "\n"
+}
+
+start_nodes() {
+	local i=$1
+	local j=$2
+	local N=$3
+	echo -e "\nStart $N nodes:\n"
+	for i in $(seq $i $j)
+	do
+	    start_node $i $N
+	done
+}
+
+attach_and_exec() {
+    local URL=$1
+    local CMD=$2
+
+    for attempt in $(seq 20)
+    do
+        if (( attempt > 5 ));
+        then
+            echo "  - attempt ${attempt}: " >&2
+        fi;
+
+        res=$("${EXEC}" --exec "${CMD}" attach http://${URL} 2> /dev/null)
+        if [ $? -eq 0 ]
+        then
+            #echo "success" >&2
+            echo $res
+            return 0
+        else
+            #echo "wait" >&2
+            sleep 1
+        fi
+    done
+    echo "failed RPC connection to ${NAME}" >&2
+    return 1
+}
+
+connect_pair() {
+    local from=$1
+    local to=$2
+
+	echo " getting node-${to} address:"
+	url=${IP}:$((PORT + to))
+	echo "    at url: ${url}"
+
+    enode=$(attach_and_exec ${url} 'admin.nodeInfo.enode')
+    echo "    p2p address = ${enode}"
+
+    echo " connecting node-${from} to node-${to}:"
+    url=${IP}:$((PORT + from))
+    echo "    at url: ${url}"
+
+    res=$(attach_and_exec ${url} "admin.addPeer(${enode})")
+    echo "    result = ${res}"
+
+	return 0
+}
+
+connect_nodes() {
+	local from=$1
+	local to=$2
+
+	echo -e "\nConnect nodes to ring:\n"
+	for i in $(seq ${from} $((to-1)))
+	do
+	    j=$((i + 1))
+	    conn=$(connect_pair $i $j)
+	done
+	conn=$(connect_pair ${to} ${from})
+}
+
+

--- a/gossip/apply_genesis.go
+++ b/gossip/apply_genesis.go
@@ -1,42 +1,64 @@
 package gossip
 
 import (
-	"github.com/ethereum/go-ethereum/common"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/Fantom-foundation/go-lachesis/evmcore"
 	"github.com/Fantom-foundation/go-lachesis/hash"
 	"github.com/Fantom-foundation/go-lachesis/inter"
+	"github.com/Fantom-foundation/go-lachesis/inter/pos"
 	"github.com/Fantom-foundation/go-lachesis/lachesis"
 )
 
 func (s *Store) ApplyGenesis(net *lachesis.Config) (genesisAtropos hash.Event, genesisEvmState common.Hash, err error) {
 	evmBlock, err := evmcore.ApplyGenesis(s.table.Evm, net)
 	if err != nil {
-		return
+		return hash.Event{}, common.Hash{}, err
 	}
+
+	genesisAtropos = hash.Event(evmBlock.Hash)
+	genesisEvmState = evmBlock.Root
+
+	if s.GetBlock(0) != nil {
+		return genesisAtropos, genesisEvmState, nil
+	}
+	// first time genesis is applied
 
 	block := inter.NewBlock(0,
 		net.Genesis.Time,
-		hash.Event(evmBlock.Hash),
+		genesisAtropos,
 		hash.Event{},
-		hash.Events{hash.Event(evmBlock.Hash)},
+		hash.Events{genesisAtropos},
 	)
 
 	block.Root = evmBlock.Root
 	s.SetBlock(block)
-	genesisAtropos = block.Hash()
-	genesisEvmState = block.Root
-	s.SetEpochStats(0, EpochStats{
+	s.SetEpochStats(0, &EpochStats{
 		Start:    net.Genesis.Time,
 		End:      net.Genesis.Time,
 		TotalFee: new(big.Int),
 	})
-	s.SetDirtyEpochStats(EpochStats{
+	s.SetDirtyEpochStats(&EpochStats{
 		Start:    net.Genesis.Time,
-		End:      0,
 		TotalFee: new(big.Int),
 	})
 
-	return
+	for i, validator := range net.Genesis.Validators.SortedAddresses() { // sort validators to get deterministic stakerIDs
+		stakerID := uint64(i + 1)
+		stakeAmount := net.Genesis.Validators.Get(validator)
+
+		staker := &SfcStaker{
+			Address:      validator,
+			CreatedEpoch: 0,
+			CreatedTime:  net.Genesis.Time,
+			StakeAmount:  pos.StakeToBalance(stakeAmount),
+			DelegatedMe:  big.NewInt(0),
+		}
+		s.SetSfcStaker(stakerID, staker)
+		s.SetEpochValidator(0, stakerID, staker)
+	}
+
+	return genesisAtropos, genesisEvmState, nil
 }

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -56,6 +56,10 @@ type (
 		EpochStatsCacheSize int
 		// Cache size for LastEpochHeaders.
 		LastEpochHeadersCacheSize int
+		// Cache size for Stakers.
+		StakersCacheSize int
+		// Cache size for Delegators.
+		DelegatorsCacheSize int
 	}
 )
 
@@ -98,6 +102,8 @@ func DefaultStoreConfig() StoreConfig {
 		TxPositionsCacheSize:      1000,
 		EpochStatsCacheSize:       100,
 		LastEpochHeadersCacheSize: 2,
+		DelegatorsCacheSize:       4000,
+		StakersCacheSize:          4000,
 	}
 }
 
@@ -112,5 +118,7 @@ func LiteStoreConfig() StoreConfig {
 		TxPositionsCacheSize:      100,
 		EpochStatsCacheSize:       100,
 		LastEpochHeadersCacheSize: 2,
+		DelegatorsCacheSize:       400,
+		StakersCacheSize:          400,
 	}
 }

--- a/gossip/consensus_callbacks.go
+++ b/gossip/consensus_callbacks.go
@@ -294,7 +294,7 @@ func (s *Service) selectValidatorsGroup(oldEpoch, newEpoch idx.Epoch) (newValida
 
 	newValidators = pos.Validators{}
 	for _, it := range s.store.GetEpochValidators(newEpoch) {
-		newValidators.Set(it.Staker.Address, pos.BalanceToStake(it.Staker.CalcEfficientStake()))
+		newValidators.Set(it.Staker.Address, pos.BalanceToStake(it.Staker.CalcTotalStake()))
 	}
 
 	return newValidators

--- a/gossip/evm_state_reader_test.go
+++ b/gossip/evm_state_reader_test.go
@@ -24,12 +24,12 @@ func TestGetGenesisBlock(t *testing.T) {
 	store := NewMemStore()
 
 	net := lachesis.FakeNetConfig(genesis.FakeAccounts(0, 5, big.NewInt(0), 1))
-	addrWithCode := net.Genesis.Alloc.Addresses()[0]
-	accountWithCode := net.Genesis.Alloc[addrWithCode]
+	addrWithStorage := net.Genesis.Alloc.Addresses()[0]
+	accountWithCode := net.Genesis.Alloc[addrWithStorage]
 	accountWithCode.Code = []byte{1, 2, 3}
 	accountWithCode.Storage = make(map[common.Hash]common.Hash)
 	accountWithCode.Storage[common.Hash{}] = common.BytesToHash(common.Big1.Bytes())
-	net.Genesis.Alloc[addrWithCode] = accountWithCode
+	net.Genesis.Alloc[addrWithStorage] = accountWithCode
 
 	genesisHash, stateHash, err := store.ApplyGenesis(&net)
 	assertar.NoError(err)
@@ -52,11 +52,10 @@ func TestGetGenesisBlock(t *testing.T) {
 	assertar.NoError(err)
 	for addr, account := range net.Genesis.Alloc {
 		assertar.Equal(account.Balance.String(), statedb.GetBalance(addr).String())
-		if addr == addrWithCode {
-			assertar.Equal(account.Code, statedb.GetCode(addr))
-			assertar.Equal(account.Storage[common.Hash{}], statedb.GetState(addr, common.Hash{}))
+		assertar.Equal(account.Code, statedb.GetCode(addr))
+		if addr == addrWithStorage {
+			assertar.Equal(accountWithCode.Storage[common.Hash{}], statedb.GetState(addr, common.Hash{}))
 		} else {
-			assertar.Empty(statedb.GetCode(addr))
 			assertar.Equal(common.Hash{}, statedb.GetState(addr, common.Hash{}))
 		}
 	}

--- a/gossip/handler_test.go
+++ b/gossip/handler_test.go
@@ -149,7 +149,7 @@ func testBroadcastEvent(t *testing.T, totalPeers, broadcastExpected int, allowAg
 	engine := poset.New(net.Dag, engineStore, store)
 	engine.Bootstrap(inter.ConsensusCallbacks{})
 
-	coinbase := net.Genesis.Alloc.Addresses()[0]
+	coinbase := net.Genesis.Validators.Addresses()[0]
 	ctx := &node.ServiceContext{
 		AccountManager: mockAccountManager(net.Genesis.Alloc, coinbase),
 	}

--- a/gossip/helper_test.go
+++ b/gossip/helper_test.go
@@ -120,6 +120,8 @@ func newTestPeer(name string, version int, pm *ProtocolManager, shake bool) (*te
 	go func() {
 		select {
 		case pm.newPeerCh <- peer:
+			pm.wg.Add(1)
+			defer pm.wg.Done()
 			errc <- pm.handle(peer)
 		case <-pm.quitSync:
 			errc <- p2p.DiscQuitting

--- a/gossip/sfc_index.go
+++ b/gossip/sfc_index.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/utils"
 )
 
+// SfcStaker is the node-side representation of SFC staker
 type SfcStaker struct {
 	CreatedEpoch idx.Epoch
 	CreatedTime  inter.Timestamp
@@ -24,15 +25,18 @@ type SfcStaker struct {
 	Address common.Address
 }
 
+// SfcStakerAndID is pair SfcStaker + StakerID
 type SfcStakerAndID struct {
 	StakerID uint64
 	Staker   *SfcStaker
 }
 
-func (st *SfcStaker) CalcEfficientStake() *big.Int {
+// CalcTotalStake returns sum of staker's stake and delegated to staker stake
+func (st *SfcStaker) CalcTotalStake() *big.Int {
 	return new(big.Int).Add(st.StakeAmount, st.DelegatedMe)
 }
 
+// SfcDelegator is the node-side representation of SFC delegator
 type SfcDelegator struct {
 	CreatedEpoch idx.Epoch
 	CreatedTime  inter.Timestamp
@@ -166,7 +170,7 @@ func (s *Service) processSfc(block *inter.Block, receipts types.Receipts, blockF
 
 			meritPos := epochPos.ValidatorMerit(it.Staker.Address)
 
-			validatingPower := it.Staker.CalcEfficientStake() // TODO
+			validatingPower := it.Staker.CalcTotalStake() // TODO
 
 			statedb.SetState(sfc.ContractAddress, meritPos.StakeAmount(), utils.BigTo256(it.Staker.StakeAmount))
 			statedb.SetState(sfc.ContractAddress, meritPos.DelegatedMe(), utils.BigTo256(it.Staker.DelegatedMe))

--- a/gossip/sfc_index.go
+++ b/gossip/sfc_index.go
@@ -1,0 +1,195 @@
+package gossip
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/Fantom-foundation/go-lachesis/inter"
+	"github.com/Fantom-foundation/go-lachesis/inter/idx"
+	"github.com/Fantom-foundation/go-lachesis/lachesis/genesis/sfc"
+	"github.com/Fantom-foundation/go-lachesis/lachesis/genesis/sfc/sfcpos"
+	"github.com/Fantom-foundation/go-lachesis/utils"
+)
+
+type SfcStaker struct {
+	CreatedEpoch idx.Epoch
+	CreatedTime  inter.Timestamp
+
+	StakeAmount *big.Int
+	DelegatedMe *big.Int
+
+	Address common.Address
+}
+
+type SfcStakerAndID struct {
+	StakerID uint64
+	Staker   *SfcStaker
+}
+
+func (st *SfcStaker) CalcEfficientStake() *big.Int {
+	return new(big.Int).Add(st.StakeAmount, st.DelegatedMe)
+}
+
+type SfcDelegator struct {
+	CreatedEpoch idx.Epoch
+	CreatedTime  inter.Timestamp
+
+	Amount *big.Int
+
+	ToStakerID uint64
+}
+
+// processSfc applies the new SFC state
+func (s *Service) processSfc(block *inter.Block, receipts types.Receipts, blockFee *big.Int, sealEpoch bool, cheaters inter.Cheaters, statedb *state.StateDB) {
+	// s.engineMu is locked here
+
+	// process SFC contract logs
+	epoch := s.engine.GetEpoch()
+	for _, receipt := range receipts {
+		for _, l := range receipt.Logs {
+			if l.Address != sfc.ContractAddress {
+				continue
+			}
+			// Add new stakers
+			if l.Topics[0] == sfcpos.CreateStakeTopic {
+				stakerID := new(big.Int).SetBytes(l.Topics[1][:]).Uint64()
+				address := common.BytesToAddress(l.Topics[2][12:])
+				amount := new(big.Int).SetBytes(l.Data[0:32])
+
+				s.store.SetSfcStaker(stakerID, &SfcStaker{
+					Address:      address,
+					CreatedEpoch: epoch,
+					CreatedTime:  block.Time,
+					StakeAmount:  amount,
+					DelegatedMe:  big.NewInt(0),
+				})
+			}
+
+			// Increase stakes
+			if l.Topics[0] == sfcpos.IncreasedStakeTopic {
+				stakerID := new(big.Int).SetBytes(l.Topics[1][:]).Uint64()
+				newAmount := new(big.Int).SetBytes(l.Data[0:32])
+
+				staker := s.store.GetSfcStaker(stakerID)
+				if staker == nil {
+					s.Log.Error("Internal SFC index isn't synced with SFC contract")
+					continue
+				}
+				staker.StakeAmount = newAmount
+				s.store.SetSfcStaker(stakerID, staker)
+			}
+
+			// Add new delegators
+			if l.Topics[0] == sfcpos.CreatedDelegationTopic {
+				address := common.BytesToAddress(l.Topics[1][12:])
+				toStakerID := new(big.Int).SetBytes(l.Topics[2][12:]).Uint64()
+				amount := new(big.Int).SetBytes(l.Data[0:32])
+
+				staker := s.store.GetSfcStaker(toStakerID)
+				if staker == nil {
+					s.Log.Error("Internal SFC index isn't synced with SFC contract")
+					continue
+				}
+				staker.DelegatedMe.Add(staker.DelegatedMe, amount)
+
+				s.store.SetSfcDelegator(address, &SfcDelegator{
+					ToStakerID:   toStakerID,
+					CreatedEpoch: epoch,
+					CreatedTime:  block.Time,
+					Amount:       amount,
+				})
+				s.store.SetSfcStaker(toStakerID, staker)
+			}
+
+			// Delete stakes
+			if l.Topics[0] == sfcpos.DeactivateStakeTopic {
+				stakerID := new(big.Int).SetBytes(l.Topics[1][:]).Uint64()
+				s.store.DelSfcStaker(stakerID)
+			}
+
+			// Delete delegators
+			if l.Topics[0] == sfcpos.DeactivateDelegationTopic {
+				address := common.BytesToAddress(l.Topics[1][12:])
+
+				delegator := s.store.GetSfcDelegator(address)
+				staker := s.store.GetSfcStaker(delegator.ToStakerID)
+				if staker != nil {
+					staker.DelegatedMe.Sub(staker.DelegatedMe, delegator.Amount)
+					s.store.SetSfcStaker(delegator.ToStakerID, staker)
+				}
+				s.store.DelSfcDelegator(address)
+			}
+		}
+	}
+
+	// Update EpochStats
+	stats := s.store.GetDirtyEpochStats()
+	stats.TotalFee = new(big.Int).Add(stats.TotalFee, blockFee)
+	if sealEpoch {
+		// dirty EpochStats becomes active
+		stats.End = block.Time
+		s.store.SetEpochStats(epoch, stats)
+
+		// new dirty EpochStats
+		s.store.SetDirtyEpochStats(&EpochStats{
+			Start:    block.Time,
+			TotalFee: new(big.Int),
+		})
+	} else {
+		s.store.SetDirtyEpochStats(stats)
+	}
+
+	// Write cheaters into SFC
+	/*for _, validator := range cheaters {
+		position := sfcpos.VStake(validator)
+		if statedb.GetState(sfc.ContractAddress, position.IsCheater()) == (common.Hash{}) {
+			statedb.SetState(sfc.ContractAddress, position.IsCheater(), common.BytesToHash([]byte{1}))
+		}
+	}*/
+
+	if sealEpoch {
+
+		epoch256 := utils.U64to256(uint64(epoch))
+		statedb.SetState(sfc.ContractAddress, sfcpos.CurrentSealedEpoch(), epoch256)
+
+		// Write epoch snapshot (for reward)
+		cheatersSet := cheaters.Set()
+		epochPos := sfcpos.EpochSnapshot(epoch)
+		totalValidatingPower := new(big.Int)
+		for _, it := range s.store.GetEpochValidators(epoch) {
+			if _, ok := cheatersSet[it.Staker.Address]; ok {
+				continue // don't give reward to cheaters
+			}
+
+			meritPos := epochPos.ValidatorMerit(it.Staker.Address)
+
+			validatingPower := it.Staker.CalcEfficientStake() // TODO
+
+			statedb.SetState(sfc.ContractAddress, meritPos.StakeAmount(), utils.BigTo256(it.Staker.StakeAmount))
+			statedb.SetState(sfc.ContractAddress, meritPos.DelegatedMe(), utils.BigTo256(it.Staker.DelegatedMe))
+			statedb.SetState(sfc.ContractAddress, meritPos.ValidatingPower(), utils.BigTo256(validatingPower))
+
+			totalValidatingPower.Add(totalValidatingPower, validatingPower)
+		}
+		statedb.SetState(sfc.ContractAddress, epochPos.TotalValidatingPower(), utils.BigTo256(totalValidatingPower))
+		statedb.SetState(sfc.ContractAddress, epochPos.EpochFee(), utils.BigTo256(stats.TotalFee))
+		statedb.SetState(sfc.ContractAddress, epochPos.EndTime(), utils.U64to256(uint64(stats.End.Unix())))
+		statedb.SetState(sfc.ContractAddress, epochPos.Duration(), utils.U64to256(uint64((stats.End - stats.Start).Unix())))
+
+		// Erase cheaters from our stakers index
+		/*for _, validator := range cheaters {
+			s.store.DelSfcStaker(validator)
+		}*/
+		// Select new validators
+		for _, it := range s.store.GetSfcStakers() {
+			// Note: cheaters are already erased from Stakers table
+			if _, ok := cheatersSet[it.Staker.Address]; ok {
+				s.Log.Crit("Cheaters must be erased from Stakers table")
+			}
+			s.store.SetEpochValidator(epoch+1, it.StakerID, it.Staker)
+		}
+	}
+}

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -42,6 +42,11 @@ type Store struct {
 		Receipts    kvdb.KeyValueStore `table:"receipts"`
 		TxPositions kvdb.KeyValueStore `table:"txp"`
 
+		// SFC-related tables
+		Validators kvdb.KeyValueStore `table:"va"`
+		Stakers    kvdb.KeyValueStore `table:"vs"`
+		Delegators kvdb.KeyValueStore `table:"de"`
+
 		TmpDbs kvdb.KeyValueStore `table:"tmpdbs"`
 
 		Evm      ethdb.Database
@@ -57,6 +62,8 @@ type Store struct {
 		TxPositions      *lru.Cache `cache:"-"` // store by pointer
 		EpochStats       *lru.Cache `cache:"-"` // store by value
 		LastEpochHeaders *lru.Cache `cache:"-"` // store by pointer
+		Stakers          *lru.Cache `cache:"-"` // store by pointer
+		Delegators       *lru.Cache `cache:"-"` // store by pointer
 	}
 
 	mutexes struct {
@@ -108,6 +115,8 @@ func (s *Store) initCache() {
 	s.cache.TxPositions = s.makeCache(s.cfg.TxPositionsCacheSize)
 	s.cache.EpochStats = s.makeCache(s.cfg.EpochStatsCacheSize)
 	s.cache.LastEpochHeaders = s.makeCache(s.cfg.LastEpochHeadersCacheSize)
+	s.cache.Stakers = s.makeCache(s.cfg.StakersCacheSize)
+	s.cache.Delegators = s.makeCache(s.cfg.DelegatorsCacheSize)
 }
 
 func (s *Store) initMutexes() {

--- a/gossip/store_epoch_stats.go
+++ b/gossip/store_epoch_stats.go
@@ -18,8 +18,8 @@ func (s *Store) GetEpochStats(epoch idx.Epoch) *EpochStats {
 	// Get data from LRU cache first.
 	if s.cache.EpochStats != nil {
 		if c, ok := s.cache.EpochStats.Get(string(key)); ok {
-			if b, ok := c.(EpochStats); ok {
-				return &b
+			if b, ok := c.(*EpochStats); ok {
+				return b
 			}
 		}
 	}
@@ -28,19 +28,19 @@ func (s *Store) GetEpochStats(epoch idx.Epoch) *EpochStats {
 
 	// Add to LRU cache.
 	if w != nil && s.cache.EpochStats != nil {
-		s.cache.EpochStats.Add(string(key), *w)
+		s.cache.EpochStats.Add(string(key), w)
 	}
 
 	return w
 }
 
 // SetDirtyEpochStats set EpochStats for current (not sealed) epoch
-func (s *Store) SetDirtyEpochStats(value EpochStats) {
+func (s *Store) SetDirtyEpochStats(value *EpochStats) {
 	s.SetEpochStats(idx.Epoch(math.MaxInt32), value)
 }
 
 // SetEpochStats set EpochStats for an already sealed epoch
-func (s *Store) SetEpochStats(epoch idx.Epoch, value EpochStats) {
+func (s *Store) SetEpochStats(epoch idx.Epoch, value *EpochStats) {
 	key := epoch.Bytes()
 
 	s.set(s.table.EpochStats, key, value)

--- a/gossip/store_sfc_delegators.go
+++ b/gossip/store_sfc_delegators.go
@@ -1,0 +1,46 @@
+package gossip
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func (s *Store) SetSfcDelegator(address common.Address, v *SfcDelegator) {
+	s.set(s.table.Delegators, address.Bytes(), v)
+
+	// Add to LRU cache.
+	if s.cache.Delegators != nil {
+		s.cache.Delegators.Add(address, v)
+	}
+}
+
+func (s *Store) DelSfcDelegator(address common.Address) {
+	err := s.table.Delegators.Delete(address.Bytes())
+	if err != nil {
+		s.Log.Crit("Failed to erase delegator")
+	}
+
+	// Add to LRU cache.
+	if s.cache.Delegators != nil {
+		s.cache.Delegators.Remove(address)
+	}
+}
+
+func (s *Store) GetSfcDelegator(address common.Address) *SfcDelegator {
+	// Get data from LRU cache first.
+	if s.cache.Delegators != nil {
+		if c, ok := s.cache.Delegators.Get(address); ok {
+			if b, ok := c.(*SfcDelegator); ok {
+				return b
+			}
+		}
+	}
+
+	w, _ := s.get(s.table.Delegators, address.Bytes(), &SfcDelegator{}).(*SfcDelegator)
+
+	// Add to LRU cache.
+	if w != nil && s.cache.Delegators != nil {
+		s.cache.Delegators.Add(address, w)
+	}
+
+	return w
+}

--- a/gossip/store_sfc_delegators.go
+++ b/gossip/store_sfc_delegators.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// SetSfcDelegator stores SfcDelegator
 func (s *Store) SetSfcDelegator(address common.Address, v *SfcDelegator) {
 	s.set(s.table.Delegators, address.Bytes(), v)
 
@@ -13,6 +14,7 @@ func (s *Store) SetSfcDelegator(address common.Address, v *SfcDelegator) {
 	}
 }
 
+// DelSfcDelegator deletes SfcDelegator
 func (s *Store) DelSfcDelegator(address common.Address) {
 	err := s.table.Delegators.Delete(address.Bytes())
 	if err != nil {
@@ -25,6 +27,7 @@ func (s *Store) DelSfcDelegator(address common.Address) {
 	}
 }
 
+// GetSfcDelegator returns stored SfcDelegator
 func (s *Store) GetSfcDelegator(address common.Address) *SfcDelegator {
 	// Get data from LRU cache first.
 	if s.cache.Delegators != nil {

--- a/gossip/store_sfc_stakers.go
+++ b/gossip/store_sfc_stakers.go
@@ -1,0 +1,93 @@
+package gossip
+
+import (
+	"github.com/Fantom-foundation/go-lachesis/common/bigendian"
+	"github.com/Fantom-foundation/go-lachesis/inter/idx"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+func (s *Store) SetEpochValidator(epoch idx.Epoch, stakerID uint64, v *SfcStaker) {
+	key := append(epoch.Bytes(), bigendian.Int64ToBytes(stakerID)...)
+
+	s.set(s.table.Validators, key, v)
+}
+
+func (s *Store) GetEpochValidator(epoch idx.Epoch, stakerID uint64) *SfcStaker {
+	key := append(epoch.Bytes(), bigendian.Int64ToBytes(stakerID)...)
+
+	w, _ := s.get(s.table.Validators, key, &SfcStaker{}).(*SfcStaker)
+	return w
+}
+
+func (s *Store) SetSfcStaker(stakerID uint64, v *SfcStaker) {
+	s.set(s.table.Stakers, bigendian.Int64ToBytes(stakerID), v)
+
+	// Add to LRU cache.
+	if s.cache.Stakers != nil {
+		s.cache.Stakers.Add(stakerID, v)
+	}
+}
+
+func (s *Store) DelSfcStaker(stakerID uint64) {
+	err := s.table.Stakers.Delete(bigendian.Int64ToBytes(stakerID))
+	if err != nil {
+		s.Log.Crit("Failed to erase staker")
+	}
+
+	// Add to LRU cache.
+	if s.cache.Stakers != nil {
+		s.cache.Stakers.Remove(stakerID)
+	}
+}
+
+func (s *Store) GetSfcStakers() []SfcStakerAndID {
+	it := s.table.Stakers.NewIterator()
+	defer it.Release()
+	return s.forEachSfcStaker(it)
+}
+
+func (s *Store) GetEpochValidators(epoch idx.Epoch) []SfcStakerAndID {
+	it := s.table.Validators.NewIteratorWithPrefix(epoch.Bytes())
+	defer it.Release()
+	return s.forEachSfcStaker(it)
+}
+
+func (s *Store) forEachSfcStaker(it ethdb.Iterator) []SfcStakerAndID {
+	stakers := make([]SfcStakerAndID, 0, 1000)
+	for it.Next() {
+		staker := &SfcStaker{}
+		err := rlp.DecodeBytes(it.Value(), staker)
+		if err != nil {
+			s.Log.Crit("Failed to decode rlp", "err", err)
+		}
+
+		stakerIdBytes := it.Key()[len(it.Key())-8:]
+		stakers = append(stakers, SfcStakerAndID{
+			StakerID: bigendian.BytesToInt64(stakerIdBytes),
+			Staker:   staker,
+		})
+	}
+
+	return stakers
+}
+
+func (s *Store) GetSfcStaker(stakerID uint64) *SfcStaker {
+	// Get data from LRU cache first.
+	if s.cache.Stakers != nil {
+		if c, ok := s.cache.Stakers.Get(stakerID); ok {
+			if b, ok := c.(*SfcStaker); ok {
+				return b
+			}
+		}
+	}
+
+	w, _ := s.get(s.table.Stakers, bigendian.Int64ToBytes(stakerID), &SfcStaker{}).(*SfcStaker)
+
+	// Add to LRU cache.
+	if w != nil && s.cache.Stakers != nil {
+		s.cache.Stakers.Add(stakerID, w)
+	}
+
+	return w
+}

--- a/gossip/store_sfc_stakers.go
+++ b/gossip/store_sfc_stakers.go
@@ -7,12 +7,14 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
+// SetEpochValidator stores EpochValidator
 func (s *Store) SetEpochValidator(epoch idx.Epoch, stakerID uint64, v *SfcStaker) {
 	key := append(epoch.Bytes(), bigendian.Int64ToBytes(stakerID)...)
 
 	s.set(s.table.Validators, key, v)
 }
 
+// GetEpochValidator returns stored EpochValidator
 func (s *Store) GetEpochValidator(epoch idx.Epoch, stakerID uint64) *SfcStaker {
 	key := append(epoch.Bytes(), bigendian.Int64ToBytes(stakerID)...)
 
@@ -20,6 +22,7 @@ func (s *Store) GetEpochValidator(epoch idx.Epoch, stakerID uint64) *SfcStaker {
 	return w
 }
 
+// SetSfcStaker stores SfcStaker
 func (s *Store) SetSfcStaker(stakerID uint64, v *SfcStaker) {
 	s.set(s.table.Stakers, bigendian.Int64ToBytes(stakerID), v)
 
@@ -29,6 +32,7 @@ func (s *Store) SetSfcStaker(stakerID uint64, v *SfcStaker) {
 	}
 }
 
+// DelSfcStaker deletes SfcStaker
 func (s *Store) DelSfcStaker(stakerID uint64) {
 	err := s.table.Stakers.Delete(bigendian.Int64ToBytes(stakerID))
 	if err != nil {
@@ -41,12 +45,14 @@ func (s *Store) DelSfcStaker(stakerID uint64) {
 	}
 }
 
+// GetSfcStakers returns all stored SfcStakers
 func (s *Store) GetSfcStakers() []SfcStakerAndID {
 	it := s.table.Stakers.NewIterator()
 	defer it.Release()
 	return s.forEachSfcStaker(it)
 }
 
+// GetEpochValidators returns all stored EpochValidators on the epoch
 func (s *Store) GetEpochValidators(epoch idx.Epoch) []SfcStakerAndID {
 	it := s.table.Validators.NewIteratorWithPrefix(epoch.Bytes())
 	defer it.Release()
@@ -62,9 +68,9 @@ func (s *Store) forEachSfcStaker(it ethdb.Iterator) []SfcStakerAndID {
 			s.Log.Crit("Failed to decode rlp", "err", err)
 		}
 
-		stakerIdBytes := it.Key()[len(it.Key())-8:]
+		stakerIDBytes := it.Key()[len(it.Key())-8:]
 		stakers = append(stakers, SfcStakerAndID{
-			StakerID: bigendian.BytesToInt64(stakerIdBytes),
+			StakerID: bigendian.BytesToInt64(stakerIDBytes),
 			Staker:   staker,
 		})
 	}
@@ -72,6 +78,7 @@ func (s *Store) forEachSfcStaker(it ethdb.Iterator) []SfcStakerAndID {
 	return stakers
 }
 
+// GetSfcStaker returns stored SfcStaker
 func (s *Store) GetSfcStaker(stakerID uint64) *SfcStaker {
 	// Get data from LRU cache first.
 	if s.cache.Stakers != nil {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -65,7 +65,7 @@ func testSim(t *testing.T, connect topology) {
 
 	// create and start nodes
 	nodes := make([]enode.ID, count)
-	addrs := network.Genesis.Alloc.Addresses()
+	addrs := network.Genesis.Validators.Addresses()
 	for i, addr := range addrs {
 		key := network.Genesis.Alloc[addr].PrivateKey
 		id := enode.PubkeyToIDV4(&key.PublicKey)

--- a/inter/cheaters_list.go
+++ b/inter/cheaters_list.go
@@ -8,6 +8,14 @@ import (
 // Cheaters is a slice type for storing cheaters list.
 type Cheaters []common.Address
 
+func (s Cheaters) Set() map[common.Address]struct{} {
+	set := map[common.Address]struct{}{}
+	for _, element := range s {
+		set[element] = struct{}{}
+	}
+	return set
+}
+
 // Len returns the length of s.
 func (s Cheaters) Len() int { return len(s) }
 

--- a/inter/cheaters_list.go
+++ b/inter/cheaters_list.go
@@ -8,6 +8,7 @@ import (
 // Cheaters is a slice type for storing cheaters list.
 type Cheaters []common.Address
 
+// Set returns map of cheaters
 func (s Cheaters) Set() map[common.Address]struct{} {
 	set := map[common.Address]struct{}{}
 	for _, element := range s {

--- a/lachesis/genesis/genesis.go
+++ b/lachesis/genesis/genesis.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Fantom-foundation/go-lachesis/inter"
 	"github.com/Fantom-foundation/go-lachesis/inter/pos"
+	"github.com/Fantom-foundation/go-lachesis/lachesis/genesis/sfc"
 )
 
 var (
@@ -20,13 +21,24 @@ type Genesis struct {
 	ExtraData  []byte
 }
 
+func preDeploySfc(g Genesis) Genesis {
+	g.Alloc[sfc.ContractAddress] = Account{
+		Code:    sfc.GetContractBin_v1(),
+		Storage: sfc.AssembleStorage(g.Validators, g.Time, nil),
+		Balance: pos.StakeToBalance(g.Validators.TotalStake()),
+	}
+	return g
+}
+
 // FakeGenesis generates fake genesis with n-nodes.
 func FakeGenesis(accs VAccounts) Genesis {
-	return Genesis{
+	g := Genesis{
 		Alloc:      accs.Accounts,
 		Validators: accs.Validators,
 		Time:       genesisTestTime,
 	}
+	g = preDeploySfc(g)
+	return g
 }
 
 // MainGenesis returns builtin genesis keys of mainnet.
@@ -35,15 +47,17 @@ func MainGenesis() Genesis {
 	validators.Set(common.HexToAddress("a123456789123456789123456789012345678901"), 1000000000000)
 	validators.Set(common.HexToAddress("a123456789123456789123456789012345678902"), 1000000000000)
 
-	return Genesis{
+	g := Genesis{
 		Time: genesisTestTime,
 		Alloc: Accounts{
 			// TODO: fill with official keys and balances before release!
-			common.HexToAddress("a123456789123456789123456789012345678901"): Account{Balance: pos.StakeToBalance(1000000000000)},
-			common.HexToAddress("a123456789123456789123456789012345678902"): Account{Balance: pos.StakeToBalance(1000000000000)},
+			common.HexToAddress("a123456789123456789123456789012345678901"): Account{Balance: pos.StakeToBalance(50000000000000)},
+			common.HexToAddress("a123456789123456789123456789012345678902"): Account{Balance: pos.StakeToBalance(50000000000000)},
 		},
 		Validators: *validators,
 	}
+	g = preDeploySfc(g)
+	return g
 }
 
 // TestGenesis returns builtin genesis keys of testnet.
@@ -52,13 +66,15 @@ func TestGenesis() Genesis {
 	validators.Set(common.HexToAddress("b123456789123456789123456789012345678901"), 1000000000000)
 	validators.Set(common.HexToAddress("b123456789123456789123456789012345678902"), 1000000000000)
 
-	return Genesis{
+	g := Genesis{
 		Time: genesisTestTime,
 		Alloc: Accounts{
 			// TODO: fill with official keys and balances before release!
-			common.HexToAddress("b123456789123456789123456789012345678901"): Account{Balance: pos.StakeToBalance(1000000000000)},
-			common.HexToAddress("b123456789123456789123456789012345678902"): Account{Balance: pos.StakeToBalance(1000000000000)},
+			common.HexToAddress("b123456789123456789123456789012345678901"): Account{Balance: pos.StakeToBalance(50000000000000)},
+			common.HexToAddress("b123456789123456789123456789012345678902"): Account{Balance: pos.StakeToBalance(50000000000000)},
 		},
 		Validators: *validators,
 	}
+	g = preDeploySfc(g)
+	return g
 }

--- a/lachesis/genesis/genesis.go
+++ b/lachesis/genesis/genesis.go
@@ -23,7 +23,7 @@ type Genesis struct {
 
 func preDeploySfc(g Genesis) Genesis {
 	g.Alloc[sfc.ContractAddress] = Account{
-		Code:    sfc.GetContractBin_v1(),
+		Code:    sfc.GetContractBinV1(),
 		Storage: sfc.AssembleStorage(g.Validators, g.Time, nil),
 		Balance: pos.StakeToBalance(g.Validators.TotalStake()),
 	}

--- a/lachesis/genesis/sfc/sfc_predeploy.go
+++ b/lachesis/genesis/sfc/sfc_predeploy.go
@@ -10,13 +10,13 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/utils"
 )
 
-// SFC contract first implementation bin code
+// GetContractBinV1 is SFC contract first implementation bin code
 // Must be compiled with bin-runtime flag
-func GetContractBin_v1() []byte {
+func GetContractBinV1() []byte {
 	return hexutil.MustDecode("0x00")
 }
 
-// the SFC proxy contract address
+// ContractAddress is the SFC proxy contract address
 var ContractAddress = common.HexToAddress("0xfa00face00fc0000000000000000000000000100")
 
 // the SFC contract first implementation address

--- a/lachesis/genesis/sfc/sfc_predeploy.go
+++ b/lachesis/genesis/sfc/sfc_predeploy.go
@@ -29,20 +29,24 @@ func AssembleStorage(validators pos.Validators, genesisTime inter.Timestamp, sto
 	}
 
 	// set validators
-	for stakerIdx, validator := range validators.SortedAddresses() { // sort validators to get deterministic stakerIdxs
-		position := sfcpos.VStake(validator)
+	for i, validator := range validators.SortedAddresses() { // sort validators to get deterministic stakerIDs
+		stakerID := uint64(i + 1)
+		stakePos := sfcpos.VStake(stakerID)
 
-		stakeAmount := common.BytesToHash(pos.StakeToBalance(validators.Get(validator)).Bytes())
+		stakeAmount := utils.BigTo256(pos.StakeToBalance(validators.Get(validator)))
 
-		storage[position.StakeAmount()] = stakeAmount
-		storage[position.CreatedEpoch()] = utils.U64to256(0)
-		storage[position.CreatedTime()] = utils.U64to256(uint64(genesisTime.Unix()))
-		storage[position.StakerIdx()] = utils.U64to256(uint64(stakerIdx + 1))
+		storage[stakePos.StakeAmount()] = stakeAmount
+		storage[stakePos.CreatedEpoch()] = utils.U64to256(0)
+		storage[stakePos.CreatedTime()] = utils.U64to256(uint64(genesisTime.Unix()))
+		storage[stakePos.Address()] = validator.Hash()
+
+		stakerIDPos := sfcpos.VStakerID(validator)
+		storage[stakerIDPos] = utils.U64to256(stakerID)
 	}
 
 	storage[sfcpos.VStakersNum()] = utils.U64to256(uint64(validators.Len()))
 	storage[sfcpos.VStakersLastIdx()] = utils.U64to256(uint64(validators.Len()))
-	storage[sfcpos.VStakeTotalAmount()] = common.BytesToHash((pos.StakeToBalance(validators.TotalStake())).Bytes())
+	storage[sfcpos.VStakeTotalAmount()] = utils.BigTo256((pos.StakeToBalance(validators.TotalStake())))
 
 	return storage
 }

--- a/lachesis/genesis/sfc/sfc_predeploy.go
+++ b/lachesis/genesis/sfc/sfc_predeploy.go
@@ -32,7 +32,7 @@ func AssembleStorage(validators pos.Validators, genesisTime inter.Timestamp, sto
 	for stakerIdx, validator := range validators.SortedAddresses() { // sort validators to get deterministic stakerIdxs
 		position := sfcpos.VStake(validator)
 
-		stakeAmount := common.BytesToHash(pos.StakeToBalance(validators[validator]).Bytes())
+		stakeAmount := common.BytesToHash(pos.StakeToBalance(validators.Get(validator)).Bytes())
 
 		storage[position.StakeAmount()] = stakeAmount
 		storage[position.CreatedEpoch()] = utils.U64to256(0)
@@ -40,8 +40,8 @@ func AssembleStorage(validators pos.Validators, genesisTime inter.Timestamp, sto
 		storage[position.StakerIdx()] = utils.U64to256(uint64(stakerIdx + 1))
 	}
 
-	storage[sfcpos.VStakersNum()] = utils.U64to256(uint64(len(validators)))
-	storage[sfcpos.VStakersLastIdx()] = utils.U64to256(uint64(len(validators)))
+	storage[sfcpos.VStakersNum()] = utils.U64to256(uint64(validators.Len()))
+	storage[sfcpos.VStakersLastIdx()] = utils.U64to256(uint64(validators.Len()))
 	storage[sfcpos.VStakeTotalAmount()] = common.BytesToHash((pos.StakeToBalance(validators.TotalStake())).Bytes())
 
 	return storage

--- a/lachesis/genesis/sfc/sfc_predeploy.go
+++ b/lachesis/genesis/sfc/sfc_predeploy.go
@@ -1,0 +1,48 @@
+package sfc
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/Fantom-foundation/go-lachesis/inter"
+	"github.com/Fantom-foundation/go-lachesis/inter/pos"
+	"github.com/Fantom-foundation/go-lachesis/lachesis/genesis/sfc/sfcpos"
+	"github.com/Fantom-foundation/go-lachesis/utils"
+)
+
+// SFC contract first implementation bin code
+// Must be compiled with bin-runtime flag
+func GetContractBin_v1() []byte {
+	return hexutil.MustDecode("0x00")
+}
+
+// the SFC proxy contract address
+var ContractAddress = common.HexToAddress("0xfa00face00fc0000000000000000000000000100")
+
+// the SFC contract first implementation address
+//var ContractAddress_v1 = common.HexToAddress("0xfa00beef0fc00000000000000000000000000101")
+
+// AssembleStorage builds the genesis storage for the SFC contract
+func AssembleStorage(validators pos.Validators, genesisTime inter.Timestamp, storage map[common.Hash]common.Hash) map[common.Hash]common.Hash {
+	if storage == nil {
+		storage = make(map[common.Hash]common.Hash)
+	}
+
+	// set validators
+	for stakerIdx, validator := range validators.SortedAddresses() { // sort validators to get deterministic stakerIdxs
+		position := sfcpos.VStake(validator)
+
+		stakeAmount := common.BytesToHash(pos.StakeToBalance(validators[validator]).Bytes())
+
+		storage[position.StakeAmount()] = stakeAmount
+		storage[position.CreatedEpoch()] = utils.U64to256(0)
+		storage[position.CreatedTime()] = utils.U64to256(uint64(genesisTime.Unix()))
+		storage[position.StakerIdx()] = utils.U64to256(uint64(stakerIdx + 1))
+	}
+
+	storage[sfcpos.VStakersNum()] = utils.U64to256(uint64(len(validators)))
+	storage[sfcpos.VStakersLastIdx()] = utils.U64to256(uint64(len(validators)))
+	storage[sfcpos.VStakeTotalAmount()] = common.BytesToHash((pos.StakeToBalance(validators.TotalStake())).Bytes())
+
+	return storage
+}

--- a/lachesis/genesis/sfc/sfcpos/positions.go
+++ b/lachesis/genesis/sfc/sfcpos/positions.go
@@ -133,9 +133,9 @@ func (p *ValidatorMeritPos) DelegatedMe() common.Hash {
 
 func getMapValue(base common.Hash, key common.Hash, mapIdx int64) common.Hash {
 	hasher := sha3.NewLegacyKeccak256()
-	hasher.Write(key.Bytes())
+	_, _ = hasher.Write(key.Bytes())
 	start := base.Big()
-	hasher.Write(utils.BigTo256(start.Add(start, big.NewInt(mapIdx))).Bytes())
+	_, _ = hasher.Write(utils.BigTo256(start.Add(start, big.NewInt(mapIdx))).Bytes())
 
 	return common.BytesToHash(hasher.Sum(nil))
 }

--- a/lachesis/genesis/sfc/sfcpos/positions.go
+++ b/lachesis/genesis/sfc/sfcpos/positions.go
@@ -1,0 +1,143 @@
+package sfcpos
+
+import (
+	"github.com/Fantom-foundation/go-lachesis/inter/idx"
+	"github.com/Fantom-foundation/go-lachesis/utils"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"golang.org/x/crypto/sha3"
+)
+
+// Global variables
+
+func LastEpoch() common.Hash {
+	return utils.U64to256(0)
+}
+
+func VStakersLastIdx() common.Hash {
+	return utils.U64to256(3)
+}
+
+func VStakersNum() common.Hash {
+	return utils.U64to256(4)
+}
+
+func VStakeTotalAmount() common.Hash {
+	return utils.U64to256(5)
+}
+
+// VStake
+
+type VStakePos struct {
+	object
+}
+
+func VStake(vstaker common.Address) VStakePos {
+	position := getMapValue(common.Hash{}, vstaker.Hash(), 2)
+
+	return VStakePos{object{base: position.Big()}}
+}
+
+func (p *VStakePos) IsCheater() common.Hash {
+	return p.Field(0)
+}
+
+func (p *VStakePos) StakerIdx() common.Hash {
+	return p.Field(1)
+}
+
+func (p *VStakePos) CreatedEpoch() common.Hash {
+	return p.Field(2)
+}
+
+func (p *VStakePos) CreatedTime() common.Hash {
+	return p.Field(3)
+}
+
+func (p *VStakePos) StakeAmount() common.Hash {
+	return p.Field(6)
+}
+
+// EpochSnapshot
+
+type EpochSnapshotPos struct {
+	object
+}
+
+func EpochSnapshot(epoch idx.Epoch) EpochSnapshotPos {
+	position := getMapValue(common.Hash{}, utils.U64to256(uint64(epoch)), 1)
+
+	return EpochSnapshotPos{object{base: position.Big()}}
+}
+
+func (p *EpochSnapshotPos) EndTime() common.Hash {
+	return p.Field(1)
+}
+
+func (p *EpochSnapshotPos) Duration() common.Hash {
+	return p.Field(2)
+}
+
+func (p *EpochSnapshotPos) EpochFee() common.Hash {
+	return p.Field(3)
+}
+
+func (p *EpochSnapshotPos) TotalValidatingPower() common.Hash {
+	return p.Field(4)
+}
+
+// ValidatorMerit
+
+type ValidatorMeritPos struct {
+	object
+}
+
+func (p *EpochSnapshotPos) ValidatorMerit(validator common.Address) ValidatorMeritPos {
+	base := p.Field(0)
+
+	position := getMapValue(base, validator.Hash(), 0)
+
+	return ValidatorMeritPos{object{base: position.Big()}}
+}
+
+func (p *ValidatorMeritPos) ValidatingPower() common.Hash {
+	return p.Field(0)
+}
+
+func (p *ValidatorMeritPos) StakeAmount() common.Hash {
+	return p.Field(1)
+}
+
+func (p *ValidatorMeritPos) DelegatedMe() common.Hash {
+	return p.Field(2)
+}
+
+func (p *ValidatorMeritPos) StakerIdx() common.Hash {
+	return p.Field(3)
+}
+
+// Util
+
+func getMapValue(base common.Hash, key common.Hash, mapIdx int64) common.Hash {
+	hasher := sha3.NewLegacyKeccak256()
+	hasher.Write(key.Bytes())
+	start := base.Big()
+	hasher.Write(common.BytesToHash(start.Add(start, big.NewInt(mapIdx)).Bytes()).Bytes())
+
+	return common.BytesToHash(hasher.Sum(nil))
+}
+
+type object struct {
+	base *big.Int
+}
+
+func (p *object) Field(offset int64) common.Hash {
+	if offset == 0 {
+		return common.BytesToHash(p.base.Bytes())
+	}
+
+	start := new(big.Int).Set(p.base)
+
+	return common.BytesToHash(start.Add(start, big.NewInt(offset)).Bytes())
+}

--- a/lachesis/genesis/sfc/sfcpos/positions.go
+++ b/lachesis/genesis/sfc/sfcpos/positions.go
@@ -11,7 +11,7 @@ import (
 
 // Global variables
 
-func LastEpoch() common.Hash {
+func CurrentSealedEpoch() common.Hash {
 	return utils.U64to256(0)
 }
 

--- a/utils/uint2hash.go
+++ b/utils/uint2hash.go
@@ -6,10 +6,14 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+func BigTo256(b *big.Int) common.Hash {
+	return common.BytesToHash(b.Bytes())
+}
+
 func U64to256(u64 uint64) common.Hash {
-	return common.BytesToHash(new(big.Int).SetUint64(u64).Bytes())
+	return BigTo256(new(big.Int).SetUint64(u64))
 }
 
 func I64to256(i64 int64) common.Hash {
-	return common.BytesToHash(new(big.Int).SetInt64(i64).Bytes())
+	return BigTo256(new(big.Int).SetInt64(i64))
 }

--- a/utils/uint2hash.go
+++ b/utils/uint2hash.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func U64to256(u64 uint64) common.Hash {
+	return common.BytesToHash(new(big.Int).SetUint64(u64).Bytes())
+}
+
+func I64to256(i64 int64) common.Hash {
+	return common.BytesToHash(new(big.Int).SetInt64(i64).Bytes())
+}

--- a/utils/uint2hash.go
+++ b/utils/uint2hash.go
@@ -6,14 +6,17 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// BigTo256 converts big number to 32 bytes array
 func BigTo256(b *big.Int) common.Hash {
 	return common.BytesToHash(b.Bytes())
 }
 
+// U64to256 converts uint64 to 32 bytes array
 func U64to256(u64 uint64) common.Hash {
 	return BigTo256(new(big.Int).SetUint64(u64))
 }
 
+// I64to256 converts int64 to 32 bytes array
 func I64to256(i64 int64) common.Hash {
 	return BigTo256(new(big.Int).SetInt64(i64))
 }


### PR DESCRIPTION
- SFC contract is pre-deployed in genesis state, with genesis stakers in its storage
- node maintains its own DB of stakers and validators by listening SFC contract logs during block processing
- node writes epoch snapshots into SFC contract during epoch sealing
- SFC contract bytecode isn't committed in this PR, because SFC still may be a subject of modifications. So testers should insert an actual bytecode into GetContractBinV1() function