### PR TITLE
Consensus optimization

### DIFF
--- a/gossip/consensus_callbacks.go
+++ b/gossip/consensus_callbacks.go
@@ -310,12 +310,12 @@ func (s *Service) applyBlock(block *inter.Block, decidedFrame idx.Frame, cheater
 func (s *Service) selectValidatorsGroup(oldEpoch, newEpoch idx.Epoch) (newValidators *pos.Validators) {
 	// s.engineMu is locked here
 
-	newValidators = pos.NewValidators()
+	builder := pos.NewBuilder()
 	for _, it := range s.store.GetEpochValidators(newEpoch) {
-		newValidators.Set(it.StakerID, pos.BalanceToStake(it.Staker.CalcTotalStake()))
+		builder.Set(it.StakerID, pos.BalanceToStake(it.Staker.CalcTotalStake()))
 	}
 
-	return newValidators
+	return builder.Build()
 }
 
 // onEventConfirmed is callback type to notify about event confirmation

--- a/gossip/emitter.go
+++ b/gossip/emitter.go
@@ -369,7 +369,7 @@ func (em *Emitter) createEvent(poolTxs map[common.Address]types.Transactions) *i
 	event.GasPowerUsed = basiccheck.CalcGasPowerUsed(event, em.dag)
 	availableGasPower := gaspowercheck.CalcGasPower(&event.EventHeaderData, selfParentHeader, validators, em.world.Store.GetLastHeaders(epoch-1), em.world.Store.GetEpochStats(epoch-1).End, &em.dag.GasPower)
 	if event.GasPowerUsed > availableGasPower {
-		em.Log.Warn("Not enough gas power to emit event")
+		em.Periodic.Warn(time.Second, "Not enough gas power to emit event. Too small stake?")
 		return nil
 	}
 	event.GasPowerLeft = availableGasPower - event.GasPowerUsed

--- a/gossip/poset_hook.go
+++ b/gossip/poset_hook.go
@@ -60,7 +60,7 @@ func (hook *HookedEngine) GetEpoch() idx.Epoch {
 // GetEpochValidators atomically returns validators of current epoch, and the epoch.
 func (hook *HookedEngine) GetEpochValidators() (*pos.Validators, idx.Epoch) {
 	if hook.engine == nil {
-		return pos.NewValidators(), 1
+		return pos.NewBuilder().Build(), 1
 	}
 	return hook.engine.GetEpochValidators()
 }
@@ -76,7 +76,7 @@ func (hook *HookedEngine) LastBlock() (idx.Block, hash.Event) {
 // GetValidators returns validators of current epoch.
 func (hook *HookedEngine) GetValidators() *pos.Validators {
 	if hook.engine == nil {
-		return pos.NewValidators()
+		return pos.NewBuilder().Build()
 	}
 	return hook.engine.GetValidators()
 }

--- a/gossip/poset_hook.go
+++ b/gossip/poset_hook.go
@@ -60,7 +60,7 @@ func (hook *HookedEngine) GetEpoch() idx.Epoch {
 // GetEpochValidators atomically returns validators of current epoch, and the epoch.
 func (hook *HookedEngine) GetEpochValidators() (*pos.Validators, idx.Epoch) {
 	if hook.engine == nil {
-		return pos.NewBuilder().Build(), 1
+		return pos.EmptyValidators, 1
 	}
 	return hook.engine.GetEpochValidators()
 }
@@ -76,7 +76,7 @@ func (hook *HookedEngine) LastBlock() (idx.Block, hash.Event) {
 // GetValidators returns validators of current epoch.
 func (hook *HookedEngine) GetValidators() *pos.Validators {
 	if hook.engine == nil {
-		return pos.NewBuilder().Build()
+		return pos.EmptyValidators
 	}
 	return hook.engine.GetValidators()
 }

--- a/hash/event_hash.go
+++ b/hash/event_hash.go
@@ -227,14 +227,17 @@ func (hh *Events) Add(hash ...Event) {
  * EventsStack methods:
  */
 
+// Push event ID on top
 func (s *EventsStack) Push(v Event) {
 	*s = append(*s, v)
 }
 
+// PushAll event IDs on top
 func (s *EventsStack) PushAll(vv Events) {
 	*s = append(*s, vv...)
 }
 
+// Pop event ID from top. Erases element.
 func (s *EventsStack) Pop() *Event {
 	l := len(*s)
 	if l == 0 {
@@ -251,6 +254,7 @@ func (s *EventsStack) Pop() *Event {
  * OrderedEvents methods:
  */
 
+// String returns string representation.
 func (hh OrderedEvents) String() string {
 	buf := &strings.Builder{}
 
@@ -293,12 +297,14 @@ func WireToOrderedEvents(buf [][]byte) OrderedEvents {
 	return hh
 }
 
+
 func (hh OrderedEvents) Len() int      { return len(hh) }
 func (hh OrderedEvents) Swap(i, j int) { hh[i], hh[j] = hh[j], hh[i] }
 func (hh OrderedEvents) Less(i, j int) bool {
 	return bytes.Compare(hh[i].Bytes(), hh[j].Bytes()) < 0
 }
 
+// Of returns hash of data
 func Of(data ...[]byte) (hash common.Hash) {
 	d := sha3.NewLegacyKeccak256()
 	for _, b := range data {

--- a/hash/event_hash.go
+++ b/hash/event_hash.go
@@ -231,6 +231,10 @@ func (s *EventsStack) Push(v Event) {
 	*s = append(*s, v)
 }
 
+func (s *EventsStack) PushAll(vv Events) {
+	*s = append(*s, vv...)
+}
+
 func (s *EventsStack) Pop() *Event {
 	l := len(*s)
 	if l == 0 {

--- a/inter/ancestor/parents_test.go
+++ b/inter/ancestor/parents_test.go
@@ -86,10 +86,11 @@ func testSpecialNamedParents(t *testing.T, asciiScheme string, exp map[int]map[s
 		},
 	})
 
-	validators := pos.NewValidators()
+	validatorsBuiler := pos.NewBuilder()
 	for _, peer := range nodes {
-		validators.Set(peer, 1)
+		validatorsBuiler.Set(peer, 1)
 	}
+	validators := validatorsBuiler.Build()
 
 	events := make(map[hash.Event]*inter.EventHeaderData)
 	getEvent := func(id hash.Event) *inter.EventHeaderData {

--- a/inter/ancestor/parents_test.go
+++ b/inter/ancestor/parents_test.go
@@ -86,11 +86,7 @@ func testSpecialNamedParents(t *testing.T, asciiScheme string, exp map[int]map[s
 		},
 	})
 
-	validatorsBuiler := pos.NewBuilder()
-	for _, peer := range nodes {
-		validatorsBuiler.Set(peer, 1)
-	}
-	validators := validatorsBuiler.Build()
+	validators := pos.EqualStakeValidators(nodes, 1)
 
 	events := make(map[hash.Event]*inter.EventHeaderData)
 	getEvent := func(id hash.Event) *inter.EventHeaderData {

--- a/inter/ascii_scheme.go
+++ b/inter/ascii_scheme.go
@@ -222,7 +222,7 @@ func DAGtoASCIIscheme(events Events) (string, error) {
 		scheme rows
 
 		processed = make(map[hash.Event]*Event)
-		peerCols  = make(map[idx.StakerID]int)
+		nodeCols  = make(map[idx.StakerID]int)
 		ok        bool
 
 		eventIndex       = make(map[idx.StakerID]map[hash.Event]int)
@@ -251,9 +251,9 @@ func DAGtoASCIIscheme(events Events) (string, error) {
 		ehash := e.Hash()
 		r := &row{}
 		// creator
-		if r.Self, ok = peerCols[e.Creator]; !ok {
-			r.Self = len(peerCols)
-			peerCols[e.Creator] = r.Self
+		if r.Self, ok = nodeCols[e.Creator]; !ok {
+			r.Self = len(nodeCols)
+			nodeCols[e.Creator] = r.Self
 		}
 		// name
 		r.Name = hash.GetEventName(ehash)
@@ -268,7 +268,7 @@ func DAGtoASCIIscheme(events Events) (string, error) {
 			scheme.ColWidth = w
 		}
 		// parents
-		r.Refs = make([]int, len(peerCols))
+		r.Refs = make([]int, len(nodeCols))
 		selfRefs := 0
 		for _, p := range e.Parents {
 			parent := processed[p]
@@ -284,7 +284,7 @@ func DAGtoASCIIscheme(events Events) (string, error) {
 				}
 			}
 
-			refCol := peerCols[parent.Creator]
+			refCol := nodeCols[parent.Creator]
 
 			var shift int
 			if parent.Creator != e.Creator {

--- a/inter/pos/stake.go
+++ b/inter/pos/stake.go
@@ -21,7 +21,7 @@ type (
 	// StakeCounter counts stakes.
 	StakeCounter struct {
 		validators Validators
-		already    map[idx.StakerID]struct{}
+		already    []bool // idx.Validator -> bool
 
 		quorum Stake
 		sum    Stake
@@ -57,19 +57,25 @@ func newStakeCounter(vv Validators) *StakeCounter {
 	return &StakeCounter{
 		validators: vv,
 		quorum:     vv.Quorum(),
-		already:    make(map[idx.StakerID]struct{}),
+		already:    make([]bool, vv.Len()),
 		sum:        0,
 	}
 }
 
 // Count validator and return true if it hadn't counted before.
-func (s *StakeCounter) Count(id idx.StakerID) bool {
-	if _, ok := s.already[id]; ok {
+func (s *StakeCounter) Count(v idx.StakerID) bool {
+	stakerIdx := s.validators.GetIdx(v)
+	return s.CountByIdx(stakerIdx)
+}
+
+// CountByIdx validator and return true if it hadn't counted before.
+func (s *StakeCounter) CountByIdx(stakerIdx idx.Validator) bool {
+	if s.already[stakerIdx] {
 		return false
 	}
-	s.already[id] = struct{}{}
+	s.already[stakerIdx] = true
 
-	s.sum += s.validators.StakeOf(id)
+	s.sum += s.validators.GetByIdx(stakerIdx)
 	return true
 }
 

--- a/inter/pos/stake.go
+++ b/inter/pos/stake.go
@@ -75,7 +75,7 @@ func (s *StakeCounter) CountByIdx(stakerIdx idx.Validator) bool {
 	}
 	s.already[stakerIdx] = true
 
-	s.sum += s.validators.GetByIdx(stakerIdx)
+	s.sum += s.validators.GetStakeByIdx(stakerIdx)
 	return true
 }
 

--- a/inter/pos/validators.go
+++ b/inter/pos/validators.go
@@ -17,12 +17,15 @@ type (
 		ids        []idx.StakerID
 		totalStake Stake
 	}
-	// Validators of epoch with stake.
+	// Validators group of an epoch with stakes.
+	// Optimized for BFT algorithm calculations.
+	// Read-only.
 	Validators struct {
 		values map[idx.StakerID]Stake
 		cache  cache
 	}
 
+	// ValidatorsBuilder is a helper to create Validators object
 	ValidatorsBuilder map[idx.StakerID]Stake
 
 	// GenesisValidator is helper structure to define genesis validators
@@ -36,11 +39,12 @@ type (
 	GValidators map[idx.StakerID]GenesisValidator
 )
 
+// NewBuilder creates new ValidatorsBuilder
 func NewBuilder() ValidatorsBuilder {
 	return ValidatorsBuilder{}
 }
 
-// Set appends item to Validator object
+// Set appends item to ValidatorsBuilder object
 func (vv ValidatorsBuilder) Set(id idx.StakerID, stake Stake) {
 	// add
 	if stake == 0 {
@@ -50,11 +54,12 @@ func (vv ValidatorsBuilder) Set(id idx.StakerID, stake Stake) {
 	}
 }
 
+// Build new Validators object
 func (vv ValidatorsBuilder) Build() *Validators {
 	return NewValidators(vv)
 }
 
-// NewValidators return new pointer of Validators object
+// NewValidators returns new pointer of Validators object
 func NewValidators(values ValidatorsBuilder) *Validators {
 	valuesCopy := make(ValidatorsBuilder)
 	for id, s := range values {
@@ -78,6 +83,7 @@ func (vv *Validators) Iterate() []idx.StakerID {
 	return vv.cache.ids
 }
 
+// calcCaches calculates internal caches for validators
 func (vv *Validators) calcCaches() cache {
 	cache := cache{
 		indexes: make(map[idx.StakerID]idx.Validator),
@@ -131,6 +137,7 @@ func (vv *Validators) Idxs() map[idx.StakerID]idx.Validator {
 	return vv.cache.indexes
 }
 
+// sortedArray is sorted by stake and ID
 func (vv *Validators) sortedArray() validators {
 	array := make(validators, 0, len(vv.values))
 	for id, s := range vv.values {

--- a/inter/pos/validators.go
+++ b/inter/pos/validators.go
@@ -51,7 +51,6 @@ func NewBuilder() ValidatorsBuilder {
 
 // Set appends item to ValidatorsBuilder object
 func (vv ValidatorsBuilder) Set(id idx.StakerID, stake Stake) {
-	// add
 	if stake == 0 {
 		delete(vv, id)
 	} else {
@@ -61,11 +60,29 @@ func (vv ValidatorsBuilder) Set(id idx.StakerID, stake Stake) {
 
 // Build new read-only Validators object
 func (vv ValidatorsBuilder) Build() *Validators {
-	return NewValidators(vv)
+	return newValidators(vv)
 }
 
-// NewValidators builds new read-only Validators object
-func NewValidators(values ValidatorsBuilder) *Validators {
+// EqualStakeValidators builds new read-only Validators object with equal stakes (for tests)
+func EqualStakeValidators(ids []idx.StakerID, stake Stake) *Validators {
+	builder := NewBuilder()
+	for _, id := range ids {
+		builder.Set(id, stake)
+	}
+	return builder.Build()
+}
+
+// ArrayToValidators builds new read-only Validators object from array
+func ArrayToValidators(ids []idx.StakerID, stakes []Stake) *Validators {
+	builder := NewBuilder()
+	for i, id := range ids {
+		builder.Set(id, stakes[i])
+	}
+	return builder.Build()
+}
+
+// newValidators builds new read-only Validators object
+func newValidators(values ValidatorsBuilder) *Validators {
 	valuesCopy := make(ValidatorsBuilder)
 	for id, s := range values {
 		valuesCopy.Set(id, s)
@@ -158,7 +175,7 @@ func (vv *Validators) sortedArray() validators {
 
 // Copy constructs a copy.
 func (vv *Validators) Copy() *Validators {
-	return NewValidators(vv.values)
+	return newValidators(vv.values)
 }
 
 // Builder returns a mutable copy of content

--- a/inter/pos/validators.go
+++ b/inter/pos/validators.go
@@ -116,8 +116,8 @@ func (vv *Validators) GetIdx(id idx.StakerID) idx.Validator {
 	return vv.cache.indexes[id]
 }
 
-// GetByIdx returns stake for validator by index
-func (vv *Validators) GetByIdx(i idx.Validator) Stake {
+// GetStakeByIdx returns stake for validator by index
+func (vv *Validators) GetStakeByIdx(i idx.Validator) Stake {
 	return vv.cache.stakes[i]
 }
 

--- a/inter/pos/validators.go
+++ b/inter/pos/validators.go
@@ -39,6 +39,11 @@ type (
 	GValidators map[idx.StakerID]GenesisValidator
 )
 
+var (
+	// EmptyValidators is empty validators group
+	EmptyValidators = NewBuilder().Build()
+)
+
 // NewBuilder creates new mutable ValidatorsBuilder
 func NewBuilder() ValidatorsBuilder {
 	return ValidatorsBuilder{}

--- a/inter/pos/validators.go
+++ b/inter/pos/validators.go
@@ -39,7 +39,7 @@ type (
 	GValidators map[idx.StakerID]GenesisValidator
 )
 
-// NewBuilder creates new ValidatorsBuilder
+// NewBuilder creates new mutable ValidatorsBuilder
 func NewBuilder() ValidatorsBuilder {
 	return ValidatorsBuilder{}
 }
@@ -54,12 +54,12 @@ func (vv ValidatorsBuilder) Set(id idx.StakerID, stake Stake) {
 	}
 }
 
-// Build new Validators object
+// Build new read-only Validators object
 func (vv ValidatorsBuilder) Build() *Validators {
 	return NewValidators(vv)
 }
 
-// NewValidators returns new pointer of Validators object
+// NewValidators builds new read-only Validators object
 func NewValidators(values ValidatorsBuilder) *Validators {
 	valuesCopy := make(ValidatorsBuilder)
 	for id, s := range values {
@@ -73,12 +73,12 @@ func NewValidators(values ValidatorsBuilder) *Validators {
 	return vv
 }
 
-// Len return count of validators in Validators objects
+// Len returns count of validators in Validators objects
 func (vv *Validators) Len() int {
 	return len(vv.values)
 }
 
-// Iterate return slice of ids for get validators in loop
+// Iterate returns slice of ids for get validators in loop
 func (vv *Validators) Iterate() []idx.StakerID {
 	return vv.cache.ids
 }
@@ -101,21 +101,22 @@ func (vv *Validators) calcCaches() cache {
 	return cache
 }
 
-// Get return stake for validator address
+// Get returns stake for validator by ID
 func (vv *Validators) Get(id idx.StakerID) Stake {
 	return vv.values[id]
 }
 
+// GetIdx returns index (offset) of validator in the group
 func (vv *Validators) GetIdx(id idx.StakerID) idx.Validator {
 	return vv.cache.indexes[id]
 }
 
-// Get return stake for validator address
+// GetByIdx returns stake for validator by index
 func (vv *Validators) GetByIdx(i idx.Validator) Stake {
 	return vv.cache.stakes[i]
 }
 
-// Exists return boolean true if address exists in Validators object
+// Exists returns boolean true if address exists in Validators object
 func (vv *Validators) Exists(id idx.StakerID) bool {
 	_, ok := vv.values[id]
 	return ok
@@ -155,6 +156,7 @@ func (vv *Validators) Copy() *Validators {
 	return NewValidators(vv.values)
 }
 
+// Builder returns a mutable copy of content
 func (vv *Validators) Builder() ValidatorsBuilder {
 	return vv.Copy().values
 }

--- a/inter/pos/validators.go
+++ b/inter/pos/validators.go
@@ -11,12 +11,19 @@ import (
 )
 
 type (
+	cache struct {
+		indexes    map[idx.StakerID]idx.Validator
+		stakes     []Stake
+		ids        []idx.StakerID
+		totalStake Stake
+	}
 	// Validators of epoch with stake.
 	Validators struct {
-		indexes map[idx.StakerID]int
-		list    []Stake
-		ids     []idx.StakerID
+		values map[idx.StakerID]Stake
+		cache  cache
 	}
+
+	ValidatorsBuilder map[idx.StakerID]Stake
 
 	// GenesisValidator is helper structure to define genesis validators
 	GenesisValidator struct {
@@ -29,108 +36,104 @@ type (
 	GValidators map[idx.StakerID]GenesisValidator
 )
 
-// NewValidators return new pointer of Validators object
-func NewValidators() *Validators {
-	return &Validators{
-		indexes: make(map[idx.StakerID]int),
-		list:    make([]Stake, 0, 200),
-		ids:     make([]idx.StakerID, 0, 200),
-	}
-}
-
-// Len return count of validators in Validators objects
-func (vv Validators) Len() int {
-	return len(vv.list)
-}
-
-// Iterate return chanel of ids for get validators in loop
-func (vv Validators) Iterate() <-chan idx.StakerID {
-	c := make(chan idx.StakerID)
-	go func() {
-		for _, a := range vv.ids {
-			c <- a
-		}
-		close(c)
-	}()
-	return c
+func NewBuilder() ValidatorsBuilder {
+	return ValidatorsBuilder{}
 }
 
 // Set appends item to Validator object
-func (vv *Validators) Set(id idx.StakerID, stake Stake) {
-	if stake != 0 {
-		i, ok := vv.indexes[id]
-		if ok {
-			vv.list[i] = stake
-			return
-		}
-		vv.list = append(vv.list, stake)
-		vv.ids = append(vv.ids, id)
-		vv.indexes[id] = len(vv.list) - 1
+func (vv ValidatorsBuilder) Set(id idx.StakerID, stake Stake) {
+	// add
+	if stake == 0 {
+		delete(vv, id)
 	} else {
-		i, ok := vv.indexes[id]
-		if ok {
-			delete(vv.indexes, id)
-			idxOrig := len(vv.list) - 1
-			if i == idxOrig {
-				vv.list = vv.list[:idxOrig]
-				vv.ids = vv.ids[:idxOrig]
-			} else {
-				// Move last to deleted position + truncate list len
-				vv.list[i] = vv.list[idxOrig]
-				vv.list = vv.list[:idxOrig]
-
-				vv.indexes[vv.ids[idxOrig]] = i
-
-				vv.ids[i] = vv.ids[idxOrig]
-				vv.ids = vv.ids[:idxOrig]
-			}
-		}
+		vv[id] = stake
 	}
+}
+
+func (vv ValidatorsBuilder) Build() *Validators {
+	return NewValidators(vv)
+}
+
+// NewValidators return new pointer of Validators object
+func NewValidators(values ValidatorsBuilder) *Validators {
+	valuesCopy := make(ValidatorsBuilder)
+	for id, s := range values {
+		valuesCopy.Set(id, s)
+	}
+
+	vv := &Validators{
+		values: valuesCopy,
+	}
+	vv.cache = vv.calcCaches()
+	return vv
+}
+
+// Len return count of validators in Validators objects
+func (vv *Validators) Len() int {
+	return len(vv.values)
+}
+
+// Iterate return slice of ids for get validators in loop
+func (vv *Validators) Iterate() []idx.StakerID {
+	return vv.cache.ids
+}
+
+func (vv *Validators) calcCaches() cache {
+	cache := cache{
+		indexes: make(map[idx.StakerID]idx.Validator),
+		stakes:  make([]Stake, vv.Len()),
+		ids:     make([]idx.StakerID, vv.Len()),
+	}
+
+	for i, v := range vv.sortedArray() {
+		cache.indexes[v.ID] = idx.Validator(i)
+		cache.stakes[i] = v.Stake
+		cache.ids[i] = v.ID
+		cache.totalStake += v.Stake
+	}
+
+	return cache
 }
 
 // Get return stake for validator address
-func (vv Validators) Get(id idx.StakerID) Stake {
-	i, ok := vv.indexes[id]
-	if ok {
-		return vv.list[i]
-	}
-	return 0
+func (vv *Validators) Get(id idx.StakerID) Stake {
+	return vv.values[id]
+}
+
+func (vv *Validators) GetIdx(id idx.StakerID) idx.Validator {
+	return vv.cache.indexes[id]
+}
+
+// Get return stake for validator address
+func (vv *Validators) GetByIdx(i idx.Validator) Stake {
+	return vv.cache.stakes[i]
 }
 
 // Exists return boolean true if address exists in Validators object
-func (vv Validators) Exists(id idx.StakerID) bool {
-	_, ok := vv.indexes[id]
+func (vv *Validators) Exists(id idx.StakerID) bool {
+	_, ok := vv.values[id]
 	return ok
 }
 
 // IDs returns not sorted ids.
-func (vv Validators) IDs() []idx.StakerID {
-	return vv.ids
+func (vv *Validators) IDs() []idx.StakerID {
+	return vv.cache.ids
 }
 
 // SortedIDs returns deterministically sorted ids.
 // The order is the same as for Idxs().
-func (vv Validators) SortedIDs() []idx.StakerID {
-	array := make([]idx.StakerID, len(vv.list))
-	for i, s := range vv.sortedArray() {
-		array[i] = s.ID
-	}
-	return array
+func (vv *Validators) SortedIDs() []idx.StakerID {
+	return vv.cache.ids
 }
 
 // Idxs gets deterministic total order of validators.
-func (vv Validators) Idxs() map[idx.StakerID]idx.Validator {
-	idxs := make(map[idx.StakerID]idx.Validator, len(vv.list))
-	for i, v := range vv.sortedArray() {
-		idxs[v.ID] = idx.Validator(i)
-	}
-	return idxs
+func (vv *Validators) Idxs() map[idx.StakerID]idx.Validator {
+	return vv.cache.indexes
 }
 
-func (vv Validators) sortedArray() validators {
-	array := make(validators, 0, len(vv.list))
-	for id, i := range vv.indexes {
-		s := vv.list[i]
+func (vv *Validators) sortedArray() validators {
+	array := make(validators, 0, len(vv.values))
+	for id, s := range vv.values {
 		array = append(array, validator{
 			ID:    id,
 			Stake: s,
@@ -142,81 +145,51 @@ func (vv Validators) sortedArray() validators {
 
 // Copy constructs a copy.
 func (vv *Validators) Copy() *Validators {
-	res := NewValidators()
+	return NewValidators(vv.values)
+}
 
-	if cap(res.list) < len(vv.list) {
-		res.list = make([]Stake, len(vv.list))
-		res.ids = make([]idx.StakerID, len(vv.list))
-	}
-	res.list = res.list[0:len(vv.list)]
-	res.ids = res.ids[0:len(vv.list)]
-	copy(res.list, vv.list)
-	copy(res.ids, vv.ids)
-
-	for id, i := range vv.indexes {
-		res.indexes[id] = i
-	}
-
-	return res
+func (vv *Validators) Builder() ValidatorsBuilder {
+	return vv.Copy().values
 }
 
 // Quorum limit of validators.
-func (vv Validators) Quorum() Stake {
+func (vv *Validators) Quorum() Stake {
 	return vv.TotalStake()*2/3 + 1
 }
 
 // TotalStake of validators.
-func (vv Validators) TotalStake() (sum Stake) {
-	for _, s := range vv.list {
-		sum += s
-	}
-	return
-}
-
-// StakeOf validator.
-func (vv Validators) StakeOf(id idx.StakerID) Stake {
-	return vv.Get(id)
+func (vv *Validators) TotalStake() (sum Stake) {
+	return vv.cache.totalStake
 }
 
 // EncodeRLP is for RLP serialization.
-func (vv Validators) EncodeRLP(w io.Writer) error {
+func (vv *Validators) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, vv.sortedArray())
 }
 
 // DecodeRLP is for RLP deserialization.
 func (vv *Validators) DecodeRLP(s *rlp.Stream) error {
-	if vv == nil {
-		vv = NewValidators()
-	}
-	if vv.ids == nil {
-		vv.ids = make([]idx.StakerID, 0, 200)
-	}
-	if vv.indexes == nil {
-		vv.indexes = make(map[idx.StakerID]int)
-	}
-	if vv.list == nil {
-		vv.list = make([]Stake, 0, 200)
-	}
-
 	var arr []validator
 	if err := s.Decode(&arr); err != nil {
 		return err
 	}
 
+	builder := NewBuilder()
 	for _, w := range arr {
-		vv.Set(w.ID, w.Stake)
+		builder.Set(w.ID, w.Stake)
 	}
+	*vv = *builder.Build()
 
 	return nil
 }
 
 // Validators converts GValidators to Validators
 func (gv GValidators) Validators() *Validators {
-	validators := NewValidators()
+	builder := NewBuilder()
 	for stakerID, validator := range gv {
-		validators.Set(stakerID, validator.Stake)
+		builder.Set(stakerID, validator.Stake)
 	}
-	return validators
+	return builder.Build()
 }
 
 // Addresses returns not sorted genesis addresses

--- a/inter/pos/validators_test.go
+++ b/inter/pos/validators_test.go
@@ -8,55 +8,64 @@ import (
 )
 
 func TestNewValidators(t *testing.T) {
-	v := NewValidators()
+	b := NewBuilder()
 
-	assert.NotNil(t, v)
-	assert.NotNil(t, v.list)
-	assert.NotNil(t, v.indexes)
+	assert.NotNil(t, b)
+	assert.NotNil(t, b.Build())
 
-	assert.Equal(t, 0, v.Len())
+	assert.Equal(t, 0, b.Build().Len())
 }
 
 func TestValidators_Set(t *testing.T) {
-	v := NewValidators()
+	b := NewBuilder()
 
-	v.Set(1, 1)
-	v.Set(2, 2)
-	v.Set(3, 3)
-	v.Set(4, 4)
-	v.Set(5, 5)
+	b.Set(1, 1)
+	b.Set(2, 2)
+	b.Set(3, 3)
+	b.Set(4, 4)
+	b.Set(5, 5)
+
+	v := b.Build()
 
 	assert.Equal(t, 5, v.Len())
 	assert.Equal(t, Stake(15), v.TotalStake())
 
-	v.Set(1, 10)
-	v.Set(3, 30)
+	b.Set(1, 10)
+	b.Set(3, 30)
+
+	v = b.Build()
 
 	assert.Equal(t, 5, v.Len())
 	assert.Equal(t, Stake(51), v.TotalStake())
 
-	v.Set(2, 0)
-	v.Set(5, 0)
+	b.Set(2, 0)
+	b.Set(5, 0)
+
+	v = b.Build()
 
 	assert.Equal(t, 3, v.Len())
 	assert.Equal(t, Stake(44), v.TotalStake())
 
-	v.Set(4, 0)
-	v.Set(3, 0)
-	v.Set(1, 0)
+	b.Set(4, 0)
+	b.Set(3, 0)
+	b.Set(1, 0)
+
+	v = b.Build()
 
 	assert.Equal(t, 0, v.Len())
 	assert.Equal(t, Stake(0), v.TotalStake())
 }
 
 func TestValidators_Get(t *testing.T) {
-	v := NewValidators()
+	b := NewBuilder()
 
-	v.Set(0, 1)
-	v.Set(2, 2)
-	v.Set(3, 3)
-	v.Set(4, 4)
-	v.Set(7, 5)
+	b.Set(0, 1)
+	b.Set(2, 2)
+	b.Set(3, 3)
+	b.Set(4, 4)
+	b.Set(7, 5)
+
+	v := b.Build()
 
 	assert.Equal(t, Stake(1), v.Get(0))
 	assert.Equal(t, Stake(0), v.Get(1))
@@ -69,19 +78,21 @@ func TestValidators_Get(t *testing.T) {
 }
 
 func TestValidators_Iterate(t *testing.T) {
-	v := NewValidators()
+	b := NewBuilder()
 
-	v.Set(1, 1)
-	v.Set(2, 2)
-	v.Set(3, 3)
-	v.Set(4, 4)
-	v.Set(5, 5)
+	b.Set(1, 1)
+	b.Set(2, 2)
+	b.Set(3, 3)
+	b.Set(4, 4)
+	b.Set(5, 5)
+
+	v := b.Build()
 
 	count := 0
 	sum := 0
-	for addr := range v.Iterate() {
+	for _, id := range v.Iterate() {
 		count++
-		sum += int(v.Get(addr))
+		sum += int(v.Get(id))
 	}
 
 	assert.Equal(t, 5, count)
@@ -89,21 +100,21 @@ func TestValidators_Iterate(t *testing.T) {
 }
 
 func TestValidators_Copy(t *testing.T) {
-	v := NewValidators()
+	b := NewBuilder()
 
-	v.Set(1, 1)
-	v.Set(2, 2)
-	v.Set(3, 3)
-	v.Set(4, 4)
-	v.Set(5, 5)
+	b.Set(1, 1)
+	b.Set(2, 2)
+	b.Set(3, 3)
+	b.Set(4, 4)
+	b.Set(5, 5)
 
+	v := b.Build()
 	vv := v.Copy()
 
-	assert.Equal(t, v.list, vv.list)
-	assert.Equal(t, v.indexes, vv.indexes)
-	assert.Equal(t, v.ids, vv.ids)
+	assert.Equal(t, v.values, vv.values)
 
-	assert.NotEqual(t, unsafe.Pointer(&v.list), unsafe.Pointer(&vv.list))
-	assert.NotEqual(t, unsafe.Pointer(&v.indexes), unsafe.Pointer(&vv.indexes))
-	assert.NotEqual(t, unsafe.Pointer(&v.ids), unsafe.Pointer(&vv.ids))
+	assert.NotEqual(t, unsafe.Pointer(&v.values), unsafe.Pointer(&vv.values))
+	assert.NotEqual(t, unsafe.Pointer(&v.cache.indexes), unsafe.Pointer(&vv.cache.indexes))
+	assert.NotEqual(t, unsafe.Pointer(&v.cache.ids), unsafe.Pointer(&vv.cache.ids))
+	assert.NotEqual(t, unsafe.Pointer(&v.cache.stakes), unsafe.Pointer(&vv.cache.stakes))
 }

--- a/poset/common_test.go
+++ b/poset/common_test.go
@@ -68,7 +68,7 @@ func FakePoset(namespace string, nodes []idx.StakerID, mods ...memorydb.Mod) (*E
 	}
 	_ = dbs.Flush(atropos.Bytes())
 
-	input := NewEventStore(nil)
+	input := NewEventStore(nil, 100)
 
 	config := lachesis.FakeNetDagConfig()
 	if config.EpochLen > 100 {

--- a/poset/election/debug.go
+++ b/poset/election/debug.go
@@ -44,7 +44,7 @@ func (el *Election) String(voters []hash.Event) string {
 	info := "Every line contains votes from a root, for each subject. y is yes, n is no. Upper case means 'decided'. '-' means that subject was already decided when root was processed.\n"
 	for _, root := range voters { // voter
 		info += root.String() + ": "
-		for forV := range el.validators.Iterate() { // subject
+		for _, forV := range el.validators.Iterate() { // subject
 			vid := voteID{
 				fromRoot:     root,
 				forValidator: forV,

--- a/poset/election/election.go
+++ b/poset/election/election.go
@@ -95,7 +95,7 @@ func (el *Election) Reset(validators *pos.Validators, frameToDecide idx.Frame) {
 func (el *Election) notDecidedRoots() []idx.StakerID {
 	notDecidedRoots := make([]idx.StakerID, 0, el.validators.Len())
 
-	for validator := range el.validators.Iterate() {
+	for _, validator := range el.validators.Iterate() {
 		if _, ok := el.decidedRoots[validator]; !ok {
 			notDecidedRoots = append(notDecidedRoots, validator)
 		}

--- a/poset/election/election_test.go
+++ b/poset/election/election_test.go
@@ -1,6 +1,7 @@
 package election
 
 import (
+	"github.com/Fantom-foundation/go-lachesis/utils"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/inter"
 	"github.com/Fantom-foundation/go-lachesis/inter/idx"
 	"github.com/Fantom-foundation/go-lachesis/inter/pos"
-	"github.com/Fantom-foundation/go-lachesis/utils"
 )
 
 type fakeEdge struct {
@@ -199,7 +199,7 @@ func testProcessRoot(
 	vertices := make(map[hash.Event]Slot)
 	edges := make(map[fakeEdge]bool)
 
-	peers, _, _ := inter.ASCIIschemeForEach(dag, inter.ForEachEvent{
+	nodes, _, _ := inter.ASCIIschemeForEach(dag, inter.ForEachEvent{
 		Process: func(root *inter.Event, name string) {
 			// store all the events
 			ordered = append(ordered, root)
@@ -237,10 +237,11 @@ func testProcessRoot(
 		},
 	})
 
-	builder := pos.NewBuilder()
-	for _, peer := range peers {
-		builder.Set(peer, stakes[utils.NameOf(peer)])
+	validatorsBuilder := pos.NewBuilder()
+	for _, node := range nodes {
+		validatorsBuilder.Set(node, stakes[utils.NameOf(node)])
 	}
+	validators := validatorsBuilder.Build()
 
 	forklessCauseFn := func(a hash.Event, b hash.Event) bool {
 		edge := fakeEdge{
@@ -260,7 +261,7 @@ func testProcessRoot(
 	}
 	ordered = unordered.ByParents()
 
-	election := New(builder.Build(), 0, forklessCauseFn, getFrameRootsFn)
+	election := New(validators, 0, forklessCauseFn, getFrameRootsFn)
 
 	// processing:
 	var alreadyDecided bool

--- a/poset/election/election_test.go
+++ b/poset/election/election_test.go
@@ -237,9 +237,9 @@ func testProcessRoot(
 		},
 	})
 
-	validators := pos.NewValidators()
+	builder := pos.NewBuilder()
 	for _, peer := range peers {
-		validators.Set(peer, stakes[utils.NameOf(peer)])
+		builder.Set(peer, stakes[utils.NameOf(peer)])
 	}
 
 	forklessCauseFn := func(a hash.Event, b hash.Event) bool {
@@ -260,7 +260,7 @@ func testProcessRoot(
 	}
 	ordered = unordered.ByParents()
 
-	election := New(validators, 0, forklessCauseFn, getFrameRootsFn)
+	election := New(builder.Build(), 0, forklessCauseFn, getFrameRootsFn)
 
 	// processing:
 	var alreadyDecided bool

--- a/poset/election/sort_roots.go
+++ b/poset/election/sort_roots.go
@@ -35,7 +35,7 @@ func (s sortedRoots) Less(i, j int) bool {
 func (el *Election) chooseAtropos() (*Res, error) {
 	finalRoots := make(sortedRoots, 0, el.validators.Len())
 	// fill yesRoots
-	for validator := range el.validators.Iterate() {
+	for _, validator := range el.validators.Iterate() {
 		stake := el.validators.Get(validator)
 		vote, ok := el.decidedRoots[validator]
 		if !ok {

--- a/poset/input_test.go
+++ b/poset/input_test.go
@@ -1,6 +1,7 @@
 package poset
 
 import (
+	lru "github.com/hashicorp/golang-lru"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/rlp"
@@ -23,12 +24,15 @@ type EventStore struct {
 	table struct {
 		Events kvdb.KeyValueStore `table:"e"`
 	}
+	cache struct {
+		Events *lru.Cache `cache:"-"` // store by pointer
+	}
 
 	logger.Instance
 }
 
 // NewEventStore creates store over memory map.
-func NewEventStore(db kvdb.KeyValueStore) *EventStore {
+func NewEventStore(db kvdb.KeyValueStore, cacheSize int) *EventStore {
 	if db == nil {
 		db = memorydb.New()
 	}
@@ -37,6 +41,8 @@ func NewEventStore(db kvdb.KeyValueStore) *EventStore {
 		physicalDB: db,
 		Instance:   logger.MakeInstance(),
 	}
+
+	s.cache.Events = s.makeCache(cacheSize)
 
 	table.MigrateTables(&s.table, s.physicalDB)
 
@@ -52,10 +58,15 @@ func (s *EventStore) Close() {
 // SetEvent stores event.
 func (s *EventStore) SetEvent(e *inter.Event) {
 	s.set(s.table.Events, e.Hash().Bytes(), e)
+	s.cache.Events.Add(e.Hash(), e)
 }
 
 // GetEvent returns stored event.
 func (s *EventStore) GetEvent(h hash.Event) *inter.Event {
+	if val, ok := s.cache.Events.Get(h); ok {
+		return val.(*inter.Event)
+	}
+
 	w, _ := s.get(s.table.Events, h.Bytes(), &inter.Event{}).(*inter.Event)
 	if w == nil {
 		return nil
@@ -86,7 +97,7 @@ func (s *EventStore) HasEvent(h hash.Event) bool {
 func TestEventStore(t *testing.T) {
 	logger.SetTestMode(t)
 
-	store := NewEventStore(nil)
+	store := NewEventStore(nil, 100)
 
 	t.Run("NotExisting", func(t *testing.T) {
 		assertar := assert.New(t)
@@ -153,4 +164,17 @@ func (s *EventStore) has(table kvdb.KeyValueStore, key []byte) bool {
 		s.Log.Crit("Failed to get key", "err", err)
 	}
 	return res
+}
+
+func (s *EventStore) makeCache(size int) *lru.Cache {
+	if size <= 0 {
+		return nil
+	}
+
+	cache, err := lru.New(size)
+	if err != nil {
+		s.Log.Crit("Error create LRU cache", "err", err)
+		return nil
+	}
+	return cache
 }

--- a/poset/store_test.go
+++ b/poset/store_test.go
@@ -44,7 +44,7 @@ func benchmarkStore(b *testing.B) {
 	lvl := leveldb.NewProducer(dir)
 	dbs := flushable.NewSyncedPool(lvl)
 
-	input := NewEventStore(dbs.GetDb("input"))
+	input := NewEventStore(dbs.GetDb("input"), 1000)
 	defer input.Close()
 
 	store := NewStore(dbs, DefaultStoreConfig())
@@ -56,11 +56,11 @@ func benchmarkStore(b *testing.B) {
 
 	p.callback.SelectValidatorsGroup = func(oldEpoch, newEpoch idx.Epoch) *pos.Validators {
 		if oldEpoch == 1 {
-			validators := p.Validators.Copy()
+			validators := p.Validators.Builder()
 			// move stake from node0 to node1
 			validators.Set(nodes[0], 0)
 			validators.Set(nodes[1], 2)
-			return validators
+			return validators.Build()
 		}
 		return p.Validators
 	}

--- a/poset/transaction_test.go
+++ b/poset/transaction_test.go
@@ -30,11 +30,11 @@ func TestPosetTxn(t *testing.T) {
 
 	p.callback.SelectValidatorsGroup = func(oldEpoch, newEpoch idx.Epoch) *pos.Validators {
 		if oldEpoch == 1 {
-			validators := p.Validators.Copy()
+			validators := p.Validators.Builder()
 			// move stake from node0 to node1
 			validators.Set(nodes[0], 0*x)
 			validators.Set(nodes[1], 2*x)
-			return validators
+			return validators.Build()
 		}
 		return p.Validators
 	}

--- a/vector/branches_info.go
+++ b/vector/branches_info.go
@@ -9,7 +9,6 @@ import (
 type branchesInfo struct {
 	BranchIDLastSeq     []idx.Event       // branchID -> highest e.Seq in the branch
 	BranchIDCreatorIdxs []idx.Validator   // branchID -> validator idx
-	BranchIDCreators    []idx.StakerID    // branchID -> validator addr
 	BranchIDByCreators  [][]idx.Validator // validator idx -> list of branch IDs
 }
 
@@ -42,10 +41,9 @@ func newInitialBranchesInfo(validators *pos.Validators) *branchesInfo {
 		BranchIDLastSeq:     branchIDLastSeq,
 		BranchIDCreatorIdxs: branchIDCreatorIdxs,
 		BranchIDByCreators:  branchIDByCreators,
-		BranchIDCreators:    branchIDCreators,
 	}
 }
 
 func (vi *Index) atLeastOneFork() bool {
-	return len(vi.bi.BranchIDCreators) > vi.validators.Len()
+	return len(vi.bi.BranchIDCreatorIdxs) > vi.validators.Len()
 }

--- a/vector/forkless_cause.go
+++ b/vector/forkless_cause.go
@@ -24,13 +24,13 @@ type kv struct {
 // This great property is the reason why this function exists,
 // providing the base for the BFT algorithm.
 func (vi *Index) ForklessCause(aID, bID hash.Event) bool {
-	if res, ok := vi.forklessCauseCache.Get(kv{aID, bID}); ok {
+	if res, ok := vi.cache.ForklessCause.Get(kv{aID, bID}); ok {
 		return res.(bool)
 	}
 
 	res := vi.forklessCause(aID, bID)
 
-	vi.forklessCauseCache.Add(kv{aID, bID}, res)
+	vi.cache.ForklessCause.Add(kv{aID, bID}, res)
 	return res
 }
 

--- a/vector/forkless_cause.go
+++ b/vector/forkless_cause.go
@@ -61,7 +61,7 @@ func (vi *Index) forklessCause(aID, bID hash.Event) bool {
 
 	yes := vi.validators.NewCounter()
 	// calculate forkless causing using the indexes
-	for branchIDint, creator := range vi.bi.BranchIDCreators {
+	for branchIDint, creatorIdx := range vi.bi.BranchIDCreatorIdxs {
 		branchID := idx.Validator(branchIDint)
 
 		// bLowestAfter := vi.GetLowestAfterSeq_(bID, branchID)   // lowest event from creator on branchID, which observes B
@@ -73,7 +73,7 @@ func (vi *Index) forklessCause(aID, bID hash.Event) bool {
 		if bLowestAfter <= aHighestBefore.Seq && bLowestAfter != 0 && !aHighestBefore.IsForkDetected() {
 			// we may count the same creator multiple times (on different branches)!
 			// so not every call increases the counter
-			yes.Count(creator)
+			yes.CountByIdx(creatorIdx)
 		}
 	}
 	return yes.HasQuorum()

--- a/vector/forkless_cause_test.go
+++ b/vector/forkless_cause_test.go
@@ -490,20 +490,23 @@ func testForksDetected(vi *Index, head *inter.EventHeaderData) (cheaters map[idx
 	cheaters = map[idx.StakerID]bool{}
 	visited := hash.EventsSet{}
 	detected := map[eventSlot]int{}
-	err = vi.dfsSubgraph(head, func(e *inter.EventHeaderData) (godeeper bool) {
+	onWalk := func(id hash.Event) (godeeper bool) {
 		// ensure visited once
-		if visited.Contains(e.Hash()) {
+		if visited.Contains(id) {
 			return false
 		}
-		visited.Add(e.Hash())
+		visited.Add(id)
 
+		e := vi.getEvent(id)
 		slot := eventSlot{
 			seq:     e.Seq,
 			creator: e.Creator,
 		}
 		detected[slot]++
 		return true
-	})
+	}
+	onWalk(head.Hash())
+	err = vi.dfsSubgraph(head, onWalk)
 	for s, count := range detected {
 		if count > 1 {
 			cheaters[s.creator] = true

--- a/vector/forkless_cause_test.go
+++ b/vector/forkless_cause_test.go
@@ -730,7 +730,7 @@ func TestRandomForks(t *testing.T) {
 					vi.Add(&a.EventHeaderData)
 				}
 
-				vi.forklessCauseCache.Purge() // disable cache
+				vi.cache.ForklessCause.Purge() // disable cache
 				for _, a := range processedArr {
 					res := vi.MedianTime(a.Hash(), inter.Timestamp(testTime/2))
 					assertar.Equal(medianTimeMap[a.Hash()], res, "%s %d", a.Hash().String(), reorderTry)

--- a/vector/index.go
+++ b/vector/index.go
@@ -78,8 +78,8 @@ func DefaultIndexConfig() IndexConfig {
 // NewIndex creates Index instance.
 func NewIndex(config IndexConfig, validators *pos.Validators, db kvdb.KeyValueStore, getEvent func(hash.Event) *inter.EventHeaderData) *Index {
 	vi := &Index{
-		Instance:           logger.MakeInstance(),
-		cfg:                config,
+		Instance: logger.MakeInstance(),
+		cfg:      config,
 	}
 	vi.cache.ForklessCause, _ = lru.New(vi.cfg.Caches.ForklessCause)
 	vi.cache.HighestBeforeSeq, _ = lru.New(vi.cfg.Caches.HighestBeforeSeq)

--- a/vector/index.go
+++ b/vector/index.go
@@ -17,8 +17,6 @@ const (
 	highestBeforeSeqCacheSize   = 1000
 	highestBeforeTimeCacheSize  = 1000
 	lowestAfterSeqCacheSize     = 1000
-	eventBranchCacheSize        = 1000
-	branchesInfoCacheSize       = 1000
 	dfsSubgraphVisitedCacheSize = 1000
 )
 
@@ -28,8 +26,6 @@ type IndexCacheConfig struct {
 	HighestBeforeSeq   int `json:"highestBeforeSeq"`
 	HighestBeforeTime  int `json:"highestBeforeTime"`
 	LowestAfterSeq     int `json:"lowestAfterSeq"`
-	EventBranch        int `json:"eventBranch"`
-	BranchesInfo       int `json:"branchesInfo"`
 	DfsSubgraphVisited int `json:"dfsSubgraphVisited"`
 }
 
@@ -61,9 +57,6 @@ type Index struct {
 		HighestBeforeSeq  *lru.Cache
 		HighestBeforeTime *lru.Cache
 		LowestAfterSeq    *lru.Cache
-
-		EventBranch  *lru.Cache
-		BranchesInfo *lru.Cache
 	}
 
 	forklessCauseCache *lru.Cache
@@ -81,8 +74,6 @@ func DefaultIndexConfig() IndexConfig {
 			HighestBeforeSeq:   highestBeforeSeqCacheSize,
 			HighestBeforeTime:  highestBeforeTimeCacheSize,
 			LowestAfterSeq:     lowestAfterSeqCacheSize,
-			EventBranch:        eventBranchCacheSize,
-			BranchesInfo:       branchesInfoCacheSize,
 			DfsSubgraphVisited: dfsSubgraphVisitedCacheSize,
 		},
 	}
@@ -100,8 +91,6 @@ func NewIndex(config IndexConfig, validators *pos.Validators, db kvdb.KeyValueSt
 	vi.cache.HighestBeforeSeq, _ = lru.New(vi.cfg.Caches.HighestBeforeSeq)
 	vi.cache.HighestBeforeTime, _ = lru.New(vi.cfg.Caches.HighestBeforeTime)
 	vi.cache.LowestAfterSeq, _ = lru.New(vi.cfg.Caches.LowestAfterSeq)
-	vi.cache.BranchesInfo, _ = lru.New(vi.cfg.Caches.BranchesInfo)
-	vi.cache.EventBranch, _ = lru.New(vi.cfg.Caches.EventBranch)
 	vi.Reset(validators, db, getEvent)
 
 	return vi
@@ -125,8 +114,6 @@ func (vi *Index) cleanCaches() {
 	vi.cache.HighestBeforeSeq.Purge()
 	vi.cache.HighestBeforeTime.Purge()
 	vi.cache.LowestAfterSeq.Purge()
-	vi.cache.BranchesInfo.Purge()
-	vi.cache.EventBranch.Purge()
 }
 
 // Add calculates vector clocks for the event and saves into DB.

--- a/vector/index_test.go
+++ b/vector/index_test.go
@@ -38,10 +38,11 @@ func BenchmarkIndex_Add(b *testing.B) {
 			ordered = append(ordered, e)
 		},
 	})
-	validators := pos.NewValidators()
+	validatorsBuilder := pos.NewBuilder()
 	for _, peer := range nodes {
-		validators.Set(peer, 1)
+		validatorsBuilder.Set(peer, 1)
 	}
+	validators := validatorsBuilder.Build()
 	events := make(map[hash.Event]*inter.EventHeaderData)
 	getEvent := func(id hash.Event) *inter.EventHeaderData {
 		return events[id]

--- a/vector/median_time.go
+++ b/vector/median_time.go
@@ -32,7 +32,7 @@ func (vi *Index) MedianTime(id hash.Event, genesisTime inter.Timestamp) inter.Ti
 	for creatorIdxI := range vi.validators.IDs() {
 		creatorIdx := idx.Validator(creatorIdxI)
 		highest := medianTimeIndex{}
-		highest.stake = vi.validators.GetByIdx(creatorIdx)
+		highest.stake = vi.validators.GetStakeByIdx(creatorIdx)
 		highest.claimedTime = times.Get(creatorIdx)
 		seq := beforeSeq.Get(creatorIdx)
 

--- a/vector/median_time.go
+++ b/vector/median_time.go
@@ -29,7 +29,7 @@ func (vi *Index) MedianTime(id hash.Event, genesisTime inter.Timestamp) inter.Ti
 	honestTotalStake := pos.Stake(0) // isn't equal to validators.TotalStake(), because doesn't count cheaters
 	highests := make([]medianTimeIndex, 0, len(vi.validatorIdxs))
 	// convert []HighestBefore -> []medianTimeIndex
-	for creatorIdxI, _ := range vi.validators.IDs() {
+	for creatorIdxI := range vi.validators.IDs() {
 		creatorIdx := idx.Validator(creatorIdxI)
 		highest := medianTimeIndex{}
 		highest.stake = vi.validators.GetByIdx(creatorIdx)

--- a/vector/median_time.go
+++ b/vector/median_time.go
@@ -1,6 +1,7 @@
 package vector
 
 import (
+	"github.com/Fantom-foundation/go-lachesis/inter/idx"
 	"sort"
 
 	"github.com/Fantom-foundation/go-lachesis/hash"
@@ -28,9 +29,10 @@ func (vi *Index) MedianTime(id hash.Event, genesisTime inter.Timestamp) inter.Ti
 	honestTotalStake := pos.Stake(0) // isn't equal to validators.TotalStake(), because doesn't count cheaters
 	highests := make([]medianTimeIndex, 0, len(vi.validatorIdxs))
 	// convert []HighestBefore -> []medianTimeIndex
-	for creator, creatorIdx := range vi.validatorIdxs {
+	for creatorIdxI, _ := range vi.validators.IDs() {
+		creatorIdx := idx.Validator(creatorIdxI)
 		highest := medianTimeIndex{}
-		highest.stake = vi.validators.Get(creator)
+		highest.stake = vi.validators.GetByIdx(creatorIdx)
 		highest.claimedTime = times.Get(creatorIdx)
 		seq := beforeSeq.Get(creatorIdx)
 

--- a/vector/median_time_test.go
+++ b/vector/median_time_test.go
@@ -16,12 +16,13 @@ func TestMedianTimeOnIndex(t *testing.T) {
 	logger.SetTestMode(t)
 
 	peers := inter.GenNodes(5)
-	validators := pos.NewValidators()
+	validatorsBuilder := pos.NewBuilder()
 
 	weights := []pos.Stake{5, 4, 3, 2, 1}
 	for i, peer := range peers {
-		validators.Set(peer, weights[i])
+		validatorsBuilder.Set(peer, weights[i])
 	}
+	validators := validatorsBuilder.Build()
 
 	vi := NewIndex(DefaultIndexConfig(), validators, memorydb.New(), nil)
 
@@ -174,10 +175,11 @@ func testMedianTime(t *testing.T, dag string, weights []pos.Stake, claimedTimes 
 		},
 	})
 
-	validators := pos.NewValidators()
+	validatorsBuilder := pos.NewBuilder()
 	for i, peer := range peers {
-		validators.Set(peer, weights[i])
+		validatorsBuilder.Set(peer, weights[i])
 	}
+	validators := validatorsBuilder.Build()
 
 	events := make(map[hash.Event]*inter.EventHeaderData)
 	getEvent := func(id hash.Event) *inter.EventHeaderData {

--- a/vector/median_time_test.go
+++ b/vector/median_time_test.go
@@ -15,14 +15,9 @@ import (
 func TestMedianTimeOnIndex(t *testing.T) {
 	logger.SetTestMode(t)
 
-	peers := inter.GenNodes(5)
-	validatorsBuilder := pos.NewBuilder()
-
+	nodes := inter.GenNodes(5)
 	weights := []pos.Stake{5, 4, 3, 2, 1}
-	for i, peer := range peers {
-		validatorsBuilder.Set(peer, weights[i])
-	}
-	validators := validatorsBuilder.Build()
+	validators := pos.ArrayToValidators(nodes, weights)
 
 	vi := NewIndex(DefaultIndexConfig(), validators, memorydb.New(), nil)
 
@@ -165,7 +160,7 @@ func testMedianTime(t *testing.T, dag string, weights []pos.Stake, claimedTimes 
 	assertar := assert.New(t)
 
 	var ordered []*inter.Event
-	peers, _, named := inter.ASCIIschemeForEach(dag, inter.ForEachEvent{
+	nodes, _, named := inter.ASCIIschemeForEach(dag, inter.ForEachEvent{
 		Build: func(e *inter.Event, name string) *inter.Event {
 			e.ClaimedTime = claimedTimes[name]
 			return e
@@ -175,11 +170,7 @@ func testMedianTime(t *testing.T, dag string, weights []pos.Stake, claimedTimes 
 		},
 	})
 
-	validatorsBuilder := pos.NewBuilder()
-	for i, peer := range peers {
-		validatorsBuilder.Set(peer, weights[i])
-	}
-	validators := validatorsBuilder.Build()
+	validators := pos.ArrayToValidators(nodes, weights)
 
 	events := make(map[hash.Event]*inter.EventHeaderData)
 	getEvent := func(id hash.Event) *inter.EventHeaderData {

--- a/vector/store_branches_info.go
+++ b/vector/store_branches_info.go
@@ -34,28 +34,18 @@ func (vi *Index) getRlp(table kvdb.KeyValueStore, key []byte, to interface{}) in
 }
 
 func (vi *Index) setBranchesInfo(info *branchesInfo) {
-	key := []byte("current")
+	key := []byte("c")
 
 	vi.setRlp(vi.table.BranchesInfo, key, info)
-
-	vi.cache.BranchesInfo.Add(string(key), *info)
 }
 
 func (vi *Index) getBranchesInfo() *branchesInfo {
-	key := []byte("current")
-
-	wInterface, okGet := vi.cache.BranchesInfo.Get(string(key))
-	wVal, okType := wInterface.(branchesInfo)
-	if okGet && okType {
-		return &wVal
-	}
+	key := []byte("c")
 
 	w, exists := vi.getRlp(vi.table.BranchesInfo, key, &branchesInfo{}).(*branchesInfo)
 	if !exists {
 		return nil
 	}
-
-	vi.cache.BranchesInfo.Add(string(key), *w)
 
 	return w
 }

--- a/vector/store_vectors.go
+++ b/vector/store_vectors.go
@@ -25,40 +25,34 @@ func (vi *Index) setBytes(table kvdb.KeyValueStore, id hash.Event, b []byte) {
 
 // GetLowestAfterSeq reads the vector from DB
 func (vi *Index) GetLowestAfterSeq(id hash.Event) LowestAfterSeq {
-	bVal, okGet := vi.cache.LowestAfterSeq.Get(id)
-	b, okType := bVal.(LowestAfterSeq)
-	if !okGet || !okType || b == nil {
-		b = vi.getBytes(vi.table.LowestAfterSeq, id)
-
-		vi.cache.LowestAfterSeq.Add(id, b)
+	if bVal, okGet := vi.cache.LowestAfterSeq.Get(id); okGet {
+		return bVal.(LowestAfterSeq)
 	}
 
+	b := vi.getBytes(vi.table.LowestAfterSeq, id)
+	vi.cache.LowestAfterSeq.Add(id, LowestAfterSeq(b))
 	return b
 }
 
 // GetHighestBeforeSeq reads the vector from DB
 func (vi *Index) GetHighestBeforeSeq(id hash.Event) HighestBeforeSeq {
-	bVal, okGet := vi.cache.HighestBeforeSeq.Get(id)
-	b, okType := bVal.(HighestBeforeSeq)
-	if !okGet || !okType || b == nil {
-		b = vi.getBytes(vi.table.HighestBeforeSeq, id)
-
-		vi.cache.HighestBeforeSeq.Add(id, b)
+	if bVal, okGet := vi.cache.HighestBeforeSeq.Get(id); okGet {
+		return bVal.(HighestBeforeSeq)
 	}
 
+	b := vi.getBytes(vi.table.HighestBeforeSeq, id)
+	vi.cache.HighestBeforeSeq.Add(id, HighestBeforeSeq(b))
 	return b
 }
 
 // GetHighestBeforeTime reads the vector from DB
 func (vi *Index) GetHighestBeforeTime(id hash.Event) HighestBeforeTime {
-	bVal, okGet := vi.cache.HighestBeforeTime.Get(id)
-	b, okType := bVal.(HighestBeforeTime)
-	if !okGet || !okType || b == nil {
-		b = vi.getBytes(vi.table.HighestBeforeTime, id)
-
-		vi.cache.HighestBeforeTime.Add(id, b)
+	if bVal, okGet := vi.cache.HighestBeforeTime.Get(id); okGet {
+		return bVal.(HighestBeforeTime)
 	}
 
+	b := vi.getBytes(vi.table.HighestBeforeTime, id)
+	vi.cache.HighestBeforeTime.Add(id, HighestBeforeTime(b))
 	return b
 }
 
@@ -81,22 +75,14 @@ func (vi *Index) SetHighestBefore(id hash.Event, seq HighestBeforeSeq, time High
 // setEventBranchID stores the event's global branch ID
 func (vi *Index) setEventBranchID(id hash.Event, branchID idx.Validator) {
 	vi.setBytes(vi.table.EventBranch, id, branchID.Bytes())
-
-	vi.cache.EventBranch.Add(id, branchID.Bytes())
 }
 
 // getEventBranchID reads the event's global branch ID
 func (vi *Index) getEventBranchID(id hash.Event) idx.Validator {
-	bVal, okGet := vi.cache.EventBranch.Get(id)
-	b, okType := bVal.([]byte)
-	if !okGet || !okType || b == nil {
-		b = vi.getBytes(vi.table.EventBranch, id)
-		if b == nil {
-			vi.Log.Crit("Failed to read event's branch ID (inconsistent DB)")
-			return 0
-		}
-
-		vi.cache.EventBranch.Add(id, b)
+	b := vi.getBytes(vi.table.EventBranch, id)
+	if b == nil {
+		vi.Log.Crit("Failed to read event's branch ID (inconsistent DB)")
+		return 0
 	}
 	branchID := idx.BytesToValidator(b)
 	return branchID

--- a/vector/traversal.go
+++ b/vector/traversal.go
@@ -9,7 +9,7 @@ import (
 
 // dfsSubgraph iterates all the event which are observed by head, and accepted by a filter
 func (vi *Index) dfsSubgraph(head *inter.EventHeaderData, walk func(*inter.EventHeaderData) (godeeper bool)) error {
-	stack := make(hash.EventsStack, 0, vi.validators.Len())
+	stack := make(hash.EventsStack, 0, vi.validators.Len() * 5)
 	visitedCache := make(map[hash.Event]bool)
 
 	headHash := head.Hash()


### PR DESCRIPTION
- optimize and refactor validators group structure (pos.Validators)
- use validator indexes instead of IDs in vector module
- rm excessive caching in vector module
- poset/test_store.go shows more accurate performance