### PR TITLE
Optimize p2p

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -875,7 +875,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNr rpc.Bl
 	if args.Gas != nil && uint64(*args.Gas) >= params.TxGas {
 		hi = uint64(*args.Gas)
 	} else {
-		hi = lachesisparams.MaxGasPowerUsed/2
+		hi = lachesisparams.MaxGasPowerUsed / 2
 	}
 	if gasCap != nil && hi > gasCap.Uint64() {
 		log.Warn("Caller gas above allowance, capping", "requested", hi, "cap", gasCap)

--- a/gossip/apply_genesis.go
+++ b/gossip/apply_genesis.go
@@ -105,6 +105,7 @@ func (s *Store) applyGenesis(net *lachesis.Config) (genesisAtropos hash.Event, g
 	}
 	s.SetTotalSupply(totalSupply)
 
+	validatorsArr := []sfctype.SfcStakerAndID{}
 	for _, validator := range net.Genesis.Alloc.Validators {
 		staker := &sfctype.SfcStaker{
 			Address:      validator.Address,
@@ -114,8 +115,12 @@ func (s *Store) applyGenesis(net *lachesis.Config) (genesisAtropos hash.Event, g
 			DelegatedMe:  big.NewInt(0),
 		}
 		s.SetSfcStaker(validator.ID, staker)
-		s.SetEpochValidator(1, validator.ID, staker)
+		validatorsArr = append(validatorsArr, sfctype.SfcStakerAndID{
+			StakerID: validator.ID,
+			Staker:   staker,
+		})
 	}
+	s.SetEpochValidators(1, validatorsArr)
 
 	return genesisAtropos, genesisState, nil
 }

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -10,6 +10,13 @@ import (
 )
 
 type (
+	// ProtocolConfig is config for p2p protocol
+	ProtocolConfig struct {
+		// 0/M means "optimize only for throughput", N/0 means "optimize only for latency", N/M is a balanced mode
+
+		LatencyImportance    int
+		ThroughputImportance int
+	}
 	// Config for the gossip service.
 	Config struct {
 		Net     lachesis.Config
@@ -17,9 +24,10 @@ type (
 		TxPool  evmcore.TxPoolConfig
 		StoreConfig
 
+		TxIndex bool // Whether to disable indexing transactions and receipts or not
+
 		// Protocol options
-		TxIndex         bool // Whether to disable indexing transactions and receipts or not
-		ForcedBroadcast bool
+		Protocol ProtocolConfig
 
 		// Gas Price Oracle options
 		GPO gasprice.Config
@@ -70,8 +78,12 @@ func DefaultConfig(network lachesis.Config) Config {
 		TxPool:      evmcore.DefaultTxPoolConfig(),
 		StoreConfig: DefaultStoreConfig(),
 
-		TxIndex:         true,
-		ForcedBroadcast: true,
+		TxIndex: true,
+
+		Protocol: ProtocolConfig{
+			LatencyImportance:    60,
+			ThroughputImportance: 40,
+		},
 
 		GPO: gasprice.Config{
 			Blocks:     20,

--- a/gossip/consensus_callbacks.go
+++ b/gossip/consensus_callbacks.go
@@ -154,7 +154,7 @@ func (s *Service) applyNewState(
 	appHash := block.TxHash
 
 	log.Info("New block", "index", block.Index, "atropos", block.Atropos, "fee", totalFee, "gasUsed",
-		evmBlock.GasUsed, "skipped_txs", len(block.SkippedTxs), "txs", len(evmBlock.Transactions), "elapsed", time.Since(start))
+		evmBlock.GasUsed, "skipped_txs", len(block.SkippedTxs), "txs", len(evmBlock.Transactions), "t", time.Since(start))
 
 	return block, evmBlock, receipts, txPositions, appHash
 }

--- a/gossip/consensus_callbacks.go
+++ b/gossip/consensus_callbacks.go
@@ -23,7 +23,7 @@ import (
 func (s *Service) processEvent(realEngine Consensus, e *inter.Event) error {
 	// s.engineMu is locked here
 
-	if s.store.HasEvent(e.Hash()) { // sanity check
+	if s.store.HasEventHeader(e.Hash()) { // sanity check
 		return eventcheck.ErrAlreadyConnectedEvent
 	}
 

--- a/gossip/emitter.go
+++ b/gossip/emitter.go
@@ -593,7 +593,7 @@ func (em *Emitter) EmitEvent() *inter.Event {
 	}
 	em.gasRate.Mark(int64(e.GasPowerUsed))
 	em.prevEmittedTime = time.Now() // record time after connecting, to add the event processing time
-	em.Log.Info("New event emitted", "event", e.String(), "txs", e.Transactions.Len(), "elapsed", time.Since(e.ClaimedTime.Time()))
+	em.Log.Info("New event emitted", "event", e, "txs", e.Transactions.Len(), "elapsed", time.Since(e.ClaimedTime.Time()))
 
 	// metrics
 	for _, t := range e.Transactions {

--- a/gossip/emitter.go
+++ b/gossip/emitter.go
@@ -192,6 +192,9 @@ func (em *Emitter) memorizeTxTimes(txs types.Transactions) {
 
 func (em *Emitter) myStakerID() (idx.StakerID, bool) {
 	coinbase := em.GetValidator()
+	if coinbase == (common.Address{}) {
+		return 0, false // short circuit if zero address
+	}
 
 	validators := em.world.Store.GetEpochValidators(em.world.Engine.GetEpoch())
 	for _, it := range validators {

--- a/gossip/emitter.go
+++ b/gossip/emitter.go
@@ -595,8 +595,8 @@ func (em *Emitter) EmitEvent() *inter.Event {
 		em.world.OnEmitted(e)
 	}
 	em.gasRate.Mark(int64(e.GasPowerUsed))
-	em.prevEmittedTime = time.Now() // record time after connecting, to add the event processing time
-	em.Log.Info("New event emitted", "event", e, "txs", e.Transactions.Len(), "elapsed", time.Since(e.ClaimedTime.Time()))
+	em.prevEmittedTime = time.Now() // record time after connecting, to add the event processing time"
+	em.Log.Info("New event emitted", "id", e.Hash(), "parents", len(e.Parents), "by", e.Creator, "frame", inter.FmtFrame(e.Frame, e.IsRoot), "txs", e.Transactions.Len(), "t", time.Since(e.ClaimedTime.Time()))
 
 	// metrics
 	for _, t := range e.Transactions {

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -36,9 +36,6 @@ const (
 
 	// the maximum number of events in the ordering buffer
 	eventsBuffSize = 2048
-
-	// minimum number of peers to broadcast new events to
-	minBroadcastPeers = 4
 )
 
 func errResp(code errCode, format string, v ...interface{}) error {
@@ -170,6 +167,7 @@ func (pm *ProtocolManager) makeFetcher(checkers *eventcheck.Checkers) (*fetcher.
 	buffer := ordering.New(eventsBuffSize, ordering.Callback{
 
 		Process: func(e *inter.Event) error {
+			now := time.Now()
 			pm.engineMu.Lock()
 			defer pm.engineMu.Unlock()
 
@@ -181,8 +179,9 @@ func (pm *ProtocolManager) makeFetcher(checkers *eventcheck.Checkers) (*fetcher.
 			log.Info("New event", "event", e.String(), "txs", e.Transactions.Len(), "elapsed", time.Since(start))
 
 			// If the event is indeed in our own graph, announce it
-			if atomic.LoadUint32(&pm.synced) != 0 { // announce only fresh events
-				pm.BroadcastEvent(e, false)
+			if atomic.LoadUint32(&pm.synced) != 0 { // announce only if synced up
+				passedSinceEvent := now.Sub(e.ClaimedTime.Time())
+				pm.BroadcastEvent(e, passedSinceEvent)
 			}
 
 			return nil
@@ -674,34 +673,69 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 	return nil
 }
 
+func (pm *ProtocolManager) decideBroadcastAggressiveness(size int, passed time.Duration, peersNum int) int {
+	percents := 100
+	maxPercents := 1000000 * percents
+	latencyVsThroughputTradeoff := maxPercents
+	cfg := pm.config.Protocol
+	if cfg.ThroughputImportance != 0 {
+		latencyVsThroughputTradeoff = (cfg.LatencyImportance * percents) / cfg.ThroughputImportance
+	}
+
+	byteCost := time.Millisecond / 2
+	broadcastCost := passed + time.Duration(size)*byteCost
+	broadcastAllCostTarget := time.Duration(latencyVsThroughputTradeoff) * (700 * time.Millisecond) / time.Duration(percents)
+	broadcastSqrtCostTarget := broadcastAllCostTarget * 20
+
+	fullRecipients := 0
+	if latencyVsThroughputTradeoff >= maxPercents {
+		// edge case
+		fullRecipients = peersNum
+	} else if latencyVsThroughputTradeoff <= 0 {
+		// edge case
+		fullRecipients = 0
+	} else if broadcastCost <= broadcastAllCostTarget {
+		// if event is small or was created recently, always send to everyone full event
+		fullRecipients = peersNum
+	} else if broadcastCost <= broadcastSqrtCostTarget || passed == 0 {
+		// if event is big but was created recently, send full event to subset of peers
+		fullRecipients = int(math.Sqrt(float64(peersNum)))
+		if fullRecipients < 4 {
+			fullRecipients = 4
+		}
+	}
+	if fullRecipients > peersNum {
+		fullRecipients = peersNum
+	}
+	return fullRecipients
+}
+
 // BroadcastEvent will either propagate a event to a subset of it's peers, or
 // will only announce it's availability (depending what's requested).
-func (pm *ProtocolManager) BroadcastEvent(event *inter.Event, aggressive bool) int {
+func (pm *ProtocolManager) BroadcastEvent(event *inter.Event, passed time.Duration) int {
+	if passed < 0 {
+		passed = 0
+	}
 	id := event.Hash()
 	peers := pm.peers.PeersWithoutEvent(id)
-
-	// If propagation is requested, send to a subset of the peer
-	if aggressive {
-		// Send the event to a subset of our peers
-		transferLen := int(math.Sqrt(float64(len(peers))))
-		if transferLen < minBroadcastPeers {
-			transferLen = minBroadcastPeers
-		}
-		if transferLen > len(peers) {
-			transferLen = len(peers)
-		}
-		transfer := peers[:transferLen]
-		for _, peer := range transfer {
-			peer.AsyncSendEvents(inter.Events{event})
-		}
-		log.Trace("Propagated event", "hash", id, "recipients", len(transfer))
-		return transferLen
+	if len(peers) == 0 {
+		log.Trace("Event is already known to all peers", "hash", id)
+		return 0
 	}
-	// Announce it
-	for _, peer := range peers {
+
+	fullRecipients := pm.decideBroadcastAggressiveness(event.Size(), passed, len(peers))
+
+	// Broadcast of full event to a subset of peers
+	fullBroadcast := peers[:fullRecipients]
+	for _, peer := range fullBroadcast {
+		peer.AsyncSendEvents(inter.Events{event})
+	}
+	// Broadcast of event hash to the rest peers
+	hashBroadcast := peers[fullRecipients:]
+	for _, peer := range hashBroadcast {
 		peer.AsyncSendNewEventHashes(hash.Events{event.Hash()})
 	}
-	log.Trace("Announced event", "hash", id, "recipients", len(peers))
+	log.Trace("Broadcast event", "hash", id, "fullRecipients", len(fullBroadcast), "hashRecipients", len(hashBroadcast))
 	return len(peers)
 }
 
@@ -733,10 +767,7 @@ func (pm *ProtocolManager) emittedBroadcastLoop() {
 	for {
 		select {
 		case emitted := <-pm.emittedEventsCh:
-			if pm.config.ForcedBroadcast {
-				pm.BroadcastEvent(emitted, true) // No one knows the event, so be aggressive
-			}
-			pm.BroadcastEvent(emitted, false) // Only then announce to the rest
+			pm.BroadcastEvent(emitted, 0)
 		// Err() channel will be closed when unsubscribing.
 		case <-pm.txsSub.Err():
 			return

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -176,7 +176,7 @@ func (pm *ProtocolManager) makeFetcher(checkers *eventcheck.Checkers) (*fetcher.
 			if err != nil {
 				return err
 			}
-			log.Info("New event", "event", e.String(), "txs", e.Transactions.Len(), "elapsed", time.Since(start))
+			log.Info("New event", "id", e.Hash(), "parents", len(e.Parents), "by", e.Creator, "frame", inter.FmtFrame(e.Frame, e.IsRoot), "txs", e.Transactions.Len(), "t", time.Since(start))
 
 			// If the event is indeed in our own graph, announce it
 			if atomic.LoadUint32(&pm.synced) != 0 { // announce only if synced up

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -194,7 +194,11 @@ func (pm *ProtocolManager) makeFetcher(checkers *eventcheck.Checkers) (*fetcher.
 			}
 		},
 
-		Exists: func(id hash.Event) *inter.EventHeaderData {
+		Exists: func(id hash.Event) bool {
+			return pm.store.HasEventHeader(id)
+		},
+
+		Get: func(id hash.Event) *inter.EventHeaderData {
 			return pm.store.GetEventHeader(id.Epoch(), id)
 		},
 
@@ -218,7 +222,7 @@ func (pm *ProtocolManager) onlyNotConnectedEvents(ids hash.Events) hash.Events {
 
 	notConnected := make(hash.Events, 0, len(ids))
 	for _, id := range ids {
-		if pm.store.HasEvent(id) {
+		if pm.store.HasEventHeader(id) {
 			continue
 		}
 		notConnected.Add(id)
@@ -237,7 +241,7 @@ func (pm *ProtocolManager) onlyInterestedEvents(ids hash.Events) hash.Events {
 		if id.Epoch() != epoch {
 			continue
 		}
-		if pm.buffer.IsBuffered(id) || pm.store.HasEvent(id) {
+		if pm.buffer.IsBuffered(id) || pm.store.HasEventHeader(id) {
 			continue
 		}
 		interested.Add(id)

--- a/gossip/ordering/ordering_test.go
+++ b/gossip/ordering/ordering_test.go
@@ -32,7 +32,6 @@ func TestEventBuffer(t *testing.T) {
 
 		Process: func(e *inter.Event) error {
 			if _, ok := processed[e.Hash()]; ok {
-				t.Fatalf("%s already processed", e.String())
 				return nil
 			}
 			for _, p := range e.Parents {

--- a/gossip/ordering/ordering_test.go
+++ b/gossip/ordering/ordering_test.go
@@ -32,6 +32,7 @@ func TestEventBuffer(t *testing.T) {
 
 		Process: func(e *inter.Event) error {
 			if _, ok := processed[e.Hash()]; ok {
+				t.Fatalf("%s already processed", e.String())
 				return nil
 			}
 			for _, p := range e.Parents {
@@ -48,7 +49,11 @@ func TestEventBuffer(t *testing.T) {
 			t.Fatalf("%s unexpectedly dropped with %s", e.String(), err)
 		},
 
-		Exists: func(e hash.Event) *inter.EventHeaderData {
+		Exists: func(e hash.Event) bool {
+			return processed[e] != nil
+		},
+
+		Get: func(e hash.Event) *inter.EventHeaderData {
 			return processed[e]
 		},
 

--- a/gossip/packsdownloader/peer_downloader.go
+++ b/gossip/packsdownloader/peer_downloader.go
@@ -22,7 +22,7 @@ const (
 	// Shouldn't be high, because we do binary search, so stored packs are O(log_2(total packs)) + PeerProgress broadcasts
 	maxPeerPacks = 128
 	// Maximum number of parallel full pack requests to a peer
-	maxFetchingFullPacks = 2
+	maxFetchingFullPacks = 3
 
 	// maxQueuedFullPacks is the maximum number of inject batches to queue up before
 	// dropping incoming packs.
@@ -275,6 +275,12 @@ func (d *PeerPacksDownloader) tryToSync() {
 		// request a few packs in parallel
 		for i := index; i < index+maxFetchingFullPacks && i <= d.packsNum; i++ {
 			d.timedRequestFullPack(i, true)
+			if i+1 <= d.packsNum {
+				_, found := d.packInfos.Get(int(i + 1))
+				if !found {
+					d.timedRequestPackInfo(i + 1) // request new pack info in advance
+				}
+			}
 		}
 	} else {
 		d.timedRequestPackInfo(index)

--- a/gossip/peer.go
+++ b/gossip/peer.go
@@ -134,13 +134,13 @@ func (p *peer) broadcast() {
 			if err := p.SendEvents(events); err != nil {
 				return
 			}
-			p.Log().Trace("Propagated events", "count", len(events))
+			p.Log().Trace("Broadcast events", "count", len(events))
 
 		case ids := <-p.queuedAnns:
 			if err := p.SendNewEventHashes(ids); err != nil {
 				return
 			}
-			p.Log().Trace("Announced events", "count", len(ids))
+			p.Log().Trace("Broadcast event hashes", "count", len(ids))
 
 		case <-p.term:
 			return

--- a/gossip/sfc_index.go
+++ b/gossip/sfc_index.go
@@ -372,12 +372,6 @@ func (s *Service) processSfc(block *inter.Block, receipts types.Receipts, blockF
 		statedb.AddBalance(sfc.ContractAddress, rewards)
 
 		// Select new validators
-		for _, it := range s.GetActiveSfcStakers() {
-			// Note: cheaters are not active
-			if _, ok := cheatersSet[it.StakerID]; ok {
-				s.Log.Crit("Cheaters must be deactivated")
-			}
-			s.store.SetEpochValidator(epoch+1, it.StakerID, it.Staker)
-		}
+		s.store.SetEpochValidators(epoch+1, s.GetActiveSfcStakers())
 	}
 }

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -95,6 +95,7 @@ type Store struct {
 		Receipts      *lru.Cache `cache:"-"` // store by value
 		TxPositions   *lru.Cache `cache:"-"` // store by pointer
 		EpochStats    *lru.Cache `cache:"-"` // store by value
+		Validators    *lru.Cache `cache:"-"` // store by pointer
 		Stakers       *lru.Cache `cache:"-"` // store by pointer
 		Delegators    *lru.Cache `cache:"-"` // store by pointer
 		BlockDowntime *lru.Cache `cache:"-"` // store by pointer
@@ -163,6 +164,7 @@ func (s *Store) initCache() {
 	s.cache.Receipts = s.makeCache(s.cfg.ReceiptsCacheSize)
 	s.cache.TxPositions = s.makeCache(s.cfg.TxPositionsCacheSize)
 	s.cache.EpochStats = s.makeCache(s.cfg.EpochStatsCacheSize)
+	s.cache.Validators = s.makeCache(2)
 	s.cache.Stakers = s.makeCache(s.cfg.StakersCacheSize)
 	s.cache.Delegators = s.makeCache(s.cfg.DelegatorsCacheSize)
 	s.cache.BlockDowntime = s.makeCache(256)

--- a/gossip/store_epoch.go
+++ b/gossip/store_epoch.go
@@ -133,6 +133,16 @@ func (s *Store) GetEventHeader(epoch idx.Epoch, h hash.Event) *inter.EventHeader
 	return w
 }
 
+// HasEvent returns true if event exists.
+func (s *Store) HasEventHeader(h hash.Event) bool {
+	es := s.getEpochStore(h.Epoch())
+	if es == nil {
+		return false
+	}
+
+	return s.has(es.Headers, h.Bytes())
+}
+
 // DelEventHeader removes stored event header.
 func (s *Store) DelEventHeader(epoch idx.Epoch, h hash.Event) {
 	es := s.getEpochStore(epoch)

--- a/gossip/store_event.go
+++ b/gossip/store_event.go
@@ -99,10 +99,5 @@ func (s *Store) GetEventRLP(id hash.Event) rlp.RawValue {
 
 // HasEvent returns true if event exists.
 func (s *Store) HasEvent(h hash.Event) bool {
-	// Check in LRU cache first. Ff exists - return true.
-	if s.cache.Events != nil && s.cache.Events.Contains(h) {
-		return true
-	}
-
 	return s.has(s.table.Events, h.Bytes())
 }

--- a/hash/event_hash.go
+++ b/hash/event_hash.go
@@ -93,7 +93,7 @@ func (h Event) Epoch() idx.Epoch {
 
 // String returns human readable string representation.
 func (h Event) String() string {
-	return h.ShortID(4)
+	return h.ShortID(3)
 }
 
 // FullID returns human readable string representation with no information loss.

--- a/inter/event.go
+++ b/inter/event.go
@@ -83,12 +83,17 @@ func NewEvent() *Event {
 	}
 }
 
+// FmtFrame returns string representation.
+func FmtFrame(frame idx.Frame, isRoot bool) string {
+	if isRoot {
+		return fmt.Sprintf("%d:y", frame)
+	}
+	return fmt.Sprintf("%d:n", frame)
+}
+
 // String returns string representation.
 func (e *EventHeaderData) String() string {
-	if e.IsRoot {
-		return fmt.Sprintf("{id=%s, p=%s, v=%d, f=%d, root}", e.Hash().String(), e.Parents.String(), e.Creator, e.Frame)
-	}
-	return fmt.Sprintf("{id=%s, p=%s, v=%d, f=%d}", e.Hash().String(), e.Parents.String(), e.Creator, e.Frame)
+	return fmt.Sprintf("{id=%s, p=%s, by=%d, frame=%s}", e.Hash().ShortID(3), e.Parents.String(), e.Creator, FmtFrame(e.Frame, e.IsRoot))
 }
 
 // NoTransactions is used to check that event doesn't have transactions not having full event.

--- a/poset/input.go
+++ b/poset/input.go
@@ -17,11 +17,6 @@ type EventSource interface {
  * Poset's methods:
  */
 
-// HasEvent returns true if event exists.
-func (p *Poset) HasEvent(h hash.Event) bool {
-	return p.input.HasEvent(h)
-}
-
 // GetEvent returns event.
 func (p *Poset) GetEvent(h hash.Event) *Event {
 	e := p.input.GetEvent(h)

--- a/poset/poset.go
+++ b/poset/poset.go
@@ -69,7 +69,7 @@ func (p *Poset) LastBlock() (idx.Block, hash.Event) {
 // returns nil if event should be dropped
 func (p *Poset) Prepare(e *inter.Event) *inter.Event {
 	if err := epochcheck.New(&p.dag, p).Validate(e); err != nil {
-		p.Log.Error("Event prepare error", "err", err, "event", e.String())
+		p.Log.Error("Event prepare error", "err", err, "event", e)
 		return nil
 	}
 	id := e.Hash() // remember, because we change event here
@@ -203,7 +203,7 @@ func (p *Poset) ProcessEvent(e *inter.Event) (err error) {
 	if err != nil {
 		return
 	}
-	p.Log.Debug("Consensus: start event processing", "event", e.String())
+	p.Log.Debug("Consensus: start event processing", "event", e)
 
 	err = p.checkAndSaveEvent(e)
 	if err != nil {


### PR DESCRIPTION
- events are broadcast-ed as full events (not events hashes) in wider range of cases, depending on event size and time passed since it was created. This behavior is configurable using LatencyImportance and ThroughputImportance
- optimize packs fetching requests to speed up initial events downloading
- optimize DB operations to speed up event processing
- compact events logging