### PR TITLE
Optimization of events emitting

### DIFF
--- a/cmd/lachesis/main.go
+++ b/cmd/lachesis/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/debug"
 	"github.com/Fantom-foundation/go-lachesis/gossip"
 	"github.com/Fantom-foundation/go-lachesis/integration"
+	"github.com/Fantom-foundation/go-lachesis/utils/errlock"
 	_ "github.com/Fantom-foundation/go-lachesis/version"
 )
 
@@ -223,6 +224,10 @@ func lachesisMain(ctx *cli.Context) error {
 
 func makeFullNode(ctx *cli.Context) *node.Node {
 	cfg := makeAllConfigs(ctx)
+
+	// check errlock file
+	errlock.SetDefaultDatadir(cfg.Node.DataDir)
+	errlock.Check()
 
 	stack := makeConfigNode(ctx, &cfg.Node)
 

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -93,8 +93,9 @@ type Backend interface {
 	GetHeads(ctx context.Context, epoch rpc.BlockNumber) (hash.Events, error)
 	CurrentEpoch(ctx context.Context) idx.Epoch
 	GetEpochStats(ctx context.Context, requestedEpoch rpc.BlockNumber) (*sfctype.EpochStats, error)
+	TtfReport(ctx context.Context, untilBlock rpc.BlockNumber, maxBlocks idx.Block, mode string) (map[hash.Event]time.Duration, error)
 	ForEachEvent(ctx context.Context, epoch rpc.BlockNumber, onEvent func(event *inter.Event) bool) error
-	TtfReport(ctx context.Context, untilBlock rpc.BlockNumber, maxBlocks idx.Block) (map[hash.Event]time.Duration, error)
+	ValidatorTimeDrifts(ctx context.Context, epoch rpc.BlockNumber, maxEvents idx.Event) (map[idx.StakerID]map[hash.Event]time.Duration, error)
 
 	// Lachesis SFC API
 	GetValidators(ctx context.Context) *pos.Validators

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -20,6 +20,7 @@ package ethapi
 import (
 	"context"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -93,6 +94,7 @@ type Backend interface {
 	CurrentEpoch(ctx context.Context) idx.Epoch
 	GetEpochStats(ctx context.Context, requestedEpoch rpc.BlockNumber) (*sfctype.EpochStats, error)
 	ForEachEvent(ctx context.Context, epoch rpc.BlockNumber, onEvent func(event *inter.Event) bool) error
+	TtfReport(ctx context.Context, untilBlock rpc.BlockNumber, maxBlocks idx.Block) (map[hash.Event]time.Duration, error)
 
 	// Lachesis SFC API
 	GetValidators(ctx context.Context) *pos.Validators

--- a/ethapi/dag_api.go
+++ b/ethapi/dag_api.go
@@ -95,7 +95,7 @@ func (s *PublicDAGChainAPI) GetEpochStats(ctx context.Context, requestedEpoch rp
 	}, nil
 }
 
-func durationToRpc(t time.Duration) string {
+func durationToRPC(t time.Duration) string {
 	/*if t < 0 {
 		t = -t
 		return "-" + hexutil.Uint64(t).String()
@@ -105,7 +105,7 @@ func durationToRpc(t time.Duration) string {
 }
 
 func rpcEncodeEventsTimeStats(data map[hash.Event]time.Duration, verbosity hexutil.Uint64) (map[string]interface{}, error) {
-	resRpc := map[string]interface{}{}
+	resRPC := map[string]interface{}{}
 
 	hist := histogram.New(6)
 	if verbosity >= 2 {
@@ -138,26 +138,26 @@ func rpcEncodeEventsTimeStats(data map[hash.Event]time.Duration, verbosity hexut
 
 	if verbosity >= 0 {
 		stats := map[string]interface{}{}
-		stats["avg"] = durationToRpc(avgTtf)
-		stats["min"] = durationToRpc(minTtf)
-		stats["max"] = durationToRpc(maxTtf)
+		stats["avg"] = durationToRPC(avgTtf)
+		stats["min"] = durationToRPC(minTtf)
+		stats["max"] = durationToRPC(maxTtf)
 		stats["samples"] = hexutil.Uint64(len(data))
-		resRpc["stats"] = stats
+		resRPC["stats"] = stats
 	}
 	if verbosity >= 1 {
-		histRpc := make([]map[string]interface{}, len(hist.Bins()))
+		histRPC := make([]map[string]interface{}, len(hist.Bins()))
 		for i, bin := range hist.Bins() {
-			histRpc[i] = map[string]interface{}{}
-			histRpc[i]["count"] = hexutil.Uint64(bin.Count)
-			histRpc[i]["mean"] = durationToRpc(time.Duration(bin.Mean()))
+			histRPC[i] = map[string]interface{}{}
+			histRPC[i]["count"] = hexutil.Uint64(bin.Count)
+			histRPC[i]["mean"] = durationToRPC(time.Duration(bin.Mean()))
 		}
-		resRpc["histogram"] = histRpc
+		resRPC["histogram"] = histRPC
 	}
 	if verbosity >= 3 {
-		resRpc["raw"] = raw
+		resRPC["raw"] = raw
 	}
 
-	return resRpc, nil
+	return resRPC, nil
 }
 
 // TtfReport for a range of blocks
@@ -210,14 +210,14 @@ func (s *PublicDebugAPI) ValidatorVersions(ctx context.Context, epoch rpc.BlockN
 func (s *PublicDebugAPI) ValidatorTimeDrifts(ctx context.Context, epoch rpc.BlockNumber, maxEvents hexutil.Uint64, verbosity hexutil.Uint64) (map[hexutil.Uint64]map[string]interface{}, error) {
 	validatorsDrifts, err := s.b.ValidatorTimeDrifts(ctx, epoch, idx.Event(maxEvents))
 
-	resRpc := map[hexutil.Uint64]map[string]interface{}{}
+	resRPC := map[hexutil.Uint64]map[string]interface{}{}
 	for v, drifts := range validatorsDrifts {
-		vRpc, err := rpcEncodeEventsTimeStats(drifts, verbosity)
+		vRPC, err := rpcEncodeEventsTimeStats(drifts, verbosity)
 		if err != nil {
 			return nil, err
 		}
-		resRpc[hexutil.Uint64(v)] = vRpc
+		resRPC[hexutil.Uint64(v)] = vRPC
 	}
 
-	return resRpc, err
+	return resRPC, err
 }

--- a/ethapi/dag_api.go
+++ b/ethapi/dag_api.go
@@ -136,7 +136,7 @@ func rpcEncodeEventsTimeStats(data map[hash.Event]time.Duration, verbosity hexut
 		avgTtf /= time.Duration(len(data))
 	}
 
-	if verbosity >= 0 {
+	{
 		stats := map[string]interface{}{}
 		stats["avg"] = durationToRPC(avgTtf)
 		stats["min"] = durationToRPC(minTtf)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/allegro/bigcache v1.2.1 // indirect
 	github.com/aristanetworks/goarista v0.0.0-20191023202215-f096da5361bb // indirect
+	github.com/beorn7/perks v1.0.1
 	github.com/btcsuite/btcd v0.20.1-beta // indirect
 	github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40 // indirect
 	github.com/cespare/cp v1.1.1

--- a/gossip/api.go
+++ b/gossip/api.go
@@ -28,7 +28,8 @@ func (api *PublicEthereumAPI) Coinbase() (common.Address, error) {
 
 // Validator is the validator address
 func (api *PublicEthereumAPI) Validator() (common.Address, error) {
-	return api.s.emitter.GetValidator(), nil
+	_, addr := api.s.emitter.GetValidator()
+	return addr, nil
 }
 
 // Hashrate returns the POW hashrate

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -24,7 +24,9 @@ type (
 		TxPool  evmcore.TxPoolConfig
 		StoreConfig
 
-		TxIndex bool // Whether to disable indexing transactions and receipts or not
+		TxIndex             bool // Whether to enable indexing transactions and receipts or not
+		DecisiveEventsIndex bool // Whether to enable indexing events which decide blocks or not
+		EventLocalTimeIndex bool // Whether to enable indexing arrival time of events or not
 
 		// Protocol options
 		Protocol ProtocolConfig
@@ -78,7 +80,8 @@ func DefaultConfig(network lachesis.Config) Config {
 		TxPool:      evmcore.DefaultTxPoolConfig(),
 		StoreConfig: DefaultStoreConfig(),
 
-		TxIndex: true,
+		TxIndex:             true,
+		DecisiveEventsIndex: false,
 
 		Protocol: ProtocolConfig{
 			LatencyImportance:    60,

--- a/gossip/config_emitter.go
+++ b/gossip/config_emitter.go
@@ -64,6 +64,10 @@ func (cfg *EmitterConfig) RandomizeEmitTime(r *rand.Rand) *EmitterConfig {
 	if config.MaxEmitInterval > 10 {
 		config.MaxEmitInterval = config.MaxEmitInterval - config.MaxEmitInterval/10 + time.Duration(r.Int63n(int64(config.MaxEmitInterval/10)))
 	}
+	// value = value + 0.1 * random value
+	if config.SelfForkProtectionInterval > 10 {
+		config.SelfForkProtectionInterval = config.SelfForkProtectionInterval + time.Duration(r.Int63n(int64(config.SelfForkProtectionInterval/10)))
+	}
 	return &config
 }
 

--- a/gossip/config_emitter.go
+++ b/gossip/config_emitter.go
@@ -41,8 +41,9 @@ func DefaultEmitterConfig() EmitterConfig {
 	return EmitterConfig{
 		VersionToPublish: _params.VersionWithMeta(),
 
-		MinEmitInterval:            200 * time.Millisecond,
-		MaxEmitInterval:            12 * time.Minute,
+		MinEmitInterval: 200 * time.Millisecond,
+		MaxEmitInterval: 12 * time.Minute,
+
 		MaxGasRateGrowthFactor:     3.0,
 		MaxTxsFromSender:           TxTurnNonces,
 		SelfForkProtectionInterval: 30 * time.Minute, // should be at least 2x of MaxEmitInterval

--- a/gossip/config_emitter.go
+++ b/gossip/config_emitter.go
@@ -41,8 +41,8 @@ func DefaultEmitterConfig() EmitterConfig {
 	return EmitterConfig{
 		VersionToPublish: _params.VersionWithMeta(),
 
-		MinEmitInterval:            300 * time.Millisecond,
-		MaxEmitInterval:            10 * time.Minute,
+		MinEmitInterval:            200 * time.Millisecond,
+		MaxEmitInterval:            12 * time.Minute,
 		MaxGasRateGrowthFactor:     3.0,
 		MaxTxsFromSender:           TxTurnNonces,
 		SelfForkProtectionInterval: 30 * time.Minute, // should be at least 2x of MaxEmitInterval
@@ -59,9 +59,9 @@ func DefaultEmitterConfig() EmitterConfig {
 // RandomizeEmitTime and return new config
 func (cfg *EmitterConfig) RandomizeEmitTime(r *rand.Rand) *EmitterConfig {
 	config := *cfg
-	// value = value - 0.05 * value + 0.1 * random value
+	// value = value - 0.1 * value + 0.1 * random value
 	if config.MaxEmitInterval > 10 {
-		config.MaxEmitInterval = config.MaxEmitInterval - config.MaxEmitInterval/20 + time.Duration(r.Int63n(int64(config.MaxEmitInterval/10)))
+		config.MaxEmitInterval = config.MaxEmitInterval - config.MaxEmitInterval/10 + time.Duration(r.Int63n(int64(config.MaxEmitInterval/10)))
 	}
 	return &config
 }

--- a/gossip/config_emitter.go
+++ b/gossip/config_emitter.go
@@ -1,6 +1,7 @@
 package gossip
 
 import (
+	"math/rand"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -53,6 +54,16 @@ func DefaultEmitterConfig() EmitterConfig {
 		NoTxsThreshold:     params.EventGas * 30,
 		EmergencyThreshold: params.EventGas * 5,
 	}
+}
+
+// RandomizeEmitTime and return new config
+func (cfg *EmitterConfig) RandomizeEmitTime(r *rand.Rand) *EmitterConfig {
+	config := *cfg
+	// value = value - 0.05 * value + 0.1 * random value
+	if config.MaxEmitInterval > 10 {
+		config.MaxEmitInterval = config.MaxEmitInterval - config.MaxEmitInterval/20 + time.Duration(r.Int63n(int64(config.MaxEmitInterval/10)))
+	}
+	return &config
 }
 
 // FakeEmitterConfig returns the testing configurations for the events emitter.

--- a/gossip/consensus_callbacks.go
+++ b/gossip/consensus_callbacks.go
@@ -76,6 +76,7 @@ func (s *Service) processEvent(realEngine Consensus, e *inter.Event) error {
 		s.occurredTxs.Clear()
 
 		// notify about new epoch after event connection
+		s.emitter.OnNewEpoch(s.engine.GetValidators(), newEpoch)
 		s.feed.newEpoch.Send(newEpoch)
 	}
 

--- a/gossip/consensus_callbacks.go
+++ b/gossip/consensus_callbacks.go
@@ -27,6 +27,14 @@ func (s *Service) processEvent(realEngine Consensus, e *inter.Event) error {
 		return eventcheck.ErrAlreadyConnectedEvent
 	}
 
+	// Trace arrival time of events
+	if s.config.EventLocalTimeIndex {
+		s.store.SetEventReceivingTime(e.Hash(), inter.Timestamp(time.Now().UnixNano()))
+	}
+	if s.config.DecisiveEventsIndex {
+		s.currentEvent = e.Hash()
+	}
+
 	oldEpoch := e.Epoch
 
 	s.store.SetEvent(e)
@@ -325,6 +333,11 @@ func (s *Service) applyBlock(block *inter.Block, decidedFrame idx.Frame, cheater
 	s.feed.newBlock.Send(evmcore.ChainHeadNotify{Block: evmBlock})
 	s.feed.newTxs.Send(core.NewTxsEvent{Txs: evmBlock.Transactions})
 	s.feed.newLogs.Send(logs)
+
+	// Trace by which event this block was confirmed (only for API)
+	if s.config.DecisiveEventsIndex {
+		s.store.SetBlockDecidedBy(block.Index, s.currentEvent)
+	}
 
 	// trace confirmed transactions
 	confirmTxnsMeter.Inc(int64(evmBlock.Transactions.Len()))

--- a/gossip/emitter.go
+++ b/gossip/emitter.go
@@ -89,17 +89,18 @@ type selfForkProtection struct {
 
 // NewEmitter creation.
 func NewEmitter(
-	config *Config,
+	net *lachesis.Config,
+	config *EmitterConfig,
 	world EmitterWorld,
 ) *Emitter {
 
 	txTime, _ := lru.New(TxTimeBufferSize)
 	loggerInstance := logger.MakeInstance()
 	return &Emitter{
-		net:      &config.Net,
-		config:   &config.Emitter,
+		net:      net,
+		config:   config,
 		world:    world,
-		creator:  config.Emitter.Validator,
+		creator:  config.Validator,
 		gasRate:  metrics.NewMeterForced(),
 		txTime:   txTime,
 		Periodic: logger.Periodic{Instance: loggerInstance},

--- a/gossip/emitter.go
+++ b/gossip/emitter.go
@@ -570,12 +570,12 @@ func (em *Emitter) isSynced() (bool, string, time.Duration) {
 		return false, "synchronizing (not downloaded all the self-events)", em.config.SelfForkProtectionInterval - sinceLastExternalEvent
 	}
 	sinceBecameValidator := time.Since(em.syncStatus.becameValidatorTime)
-	if sinceBecameValidator < em.config.SelfForkProtectionInterval*2/3 {
-		return false, "synchronizing (just joined the validators group)", em.config.SelfForkProtectionInterval*2/3 - sinceBecameValidator
+	if sinceBecameValidator < em.config.SelfForkProtectionInterval {
+		return false, "synchronizing (just joined the validators group)", em.config.SelfForkProtectionInterval - sinceBecameValidator
 	}
 	syncedPassed := time.Since(em.syncStatus.syncedTime)
 	if syncedPassed < em.config.SelfForkProtectionInterval {
-		return false, "synchronized but waiting additional time", em.config.SelfForkProtectionInterval - syncedPassed
+		return false, "synchronized (waiting additional time)", em.config.SelfForkProtectionInterval - syncedPassed
 	}
 	connectedPassed := time.Since(em.syncStatus.connectedTime)
 	if connectedPassed < em.config.SelfForkProtectionInterval {

--- a/gossip/event_local_time.go
+++ b/gossip/event_local_time.go
@@ -1,0 +1,49 @@
+package gossip
+
+import (
+	"github.com/Fantom-foundation/go-lachesis/hash"
+	"github.com/Fantom-foundation/go-lachesis/inter"
+	"github.com/Fantom-foundation/go-lachesis/inter/idx"
+)
+
+// SetBlockDecidedBy stores event which decided block (off-chain data)
+func (s *Store) SetBlockDecidedBy(block idx.Block, event hash.Event) {
+	err := s.table.DecisiveEvents.Put(block.Bytes(), event.Bytes())
+	if err != nil {
+		s.Log.Crit("Failed to set key", "err", err)
+	}
+}
+
+// GetBlockDecidedBy get event which decided block (off-chain data)
+func (s *Store) GetBlockDecidedBy(block idx.Block) hash.Event {
+	idBytes, err := s.table.DecisiveEvents.Get(block.Bytes())
+	if err != nil {
+		s.Log.Crit("Failed to get key", "err", err)
+	}
+	if idBytes == nil {
+		return hash.Event{}
+	}
+
+	return hash.BytesToEvent(idBytes)
+}
+
+// SetEventReceivingTime stores local event time (off-chain data)
+func (s *Store) SetEventReceivingTime(e hash.Event, time inter.Timestamp) {
+	err := s.table.EventLocalTimes.Put(e.Bytes(), time.Bytes())
+	if err != nil {
+		s.Log.Crit("Failed to set key", "err", err)
+	}
+}
+
+// GetEventReceivingTime get local event time (off-chain data)
+func (s *Store) GetEventReceivingTime(e hash.Event) inter.Timestamp {
+	timeBytes, err := s.table.EventLocalTimes.Get(e.Bytes())
+	if err != nil {
+		s.Log.Crit("Failed to get key", "err", err)
+	}
+	if timeBytes == nil {
+		return 0
+	}
+
+	return inter.BytesToTimestamp(timeBytes)
+}

--- a/gossip/occuredtxs/txs_ring_buffer.go
+++ b/gossip/occuredtxs/txs_ring_buffer.go
@@ -111,7 +111,7 @@ func (s *Buffer) Clear() {
 	s.ring.Clear()
 }
 
-// Len is not safe for concurrent use
+// Len is safe for concurrent use
 func (s *Buffer) Len() int {
 	return s.ring.senders.Len()
 }

--- a/gossip/piecefunc/piecefunc.go
+++ b/gossip/piecefunc/piecefunc.go
@@ -1,0 +1,42 @@
+package piecefunc
+
+const (
+	// PercentUnit is used to define ratios with integers, it's 1.0
+	PercentUnit = 1e6
+)
+
+// Dot is a pair of numbers
+type Dot struct {
+	X uint64
+	Y uint64
+}
+
+// Mul is multiplication of ratios with integer numbers
+func Mul(a, b uint64) uint64 {
+	return a * b / PercentUnit
+}
+
+// Div is division of ratios with integer numbers
+func Div(a, b uint64) uint64 {
+	return a * PercentUnit / b
+}
+
+// Get calculates f(x), where f is a piecewise linear function defined by the pieces
+func Get(x uint64, pieces []Dot) uint64 {
+
+	// find a piece
+	p0 := len(pieces) - 2
+	for i, piece := range pieces {
+		if i >= 1 && i < len(pieces)-1 && piece.X > x {
+			p0 = i - 1
+			break
+		}
+	}
+
+	// linearly interpolate
+	p1 := p0 + 1
+
+	ratio := Div(x-pieces[p0].X, pieces[p1].X-pieces[p0].X)
+
+	return Mul(pieces[p0].Y, (PercentUnit-ratio)) + Mul(pieces[p1].Y, ratio)
+}

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/gossip/filters"
 	"github.com/Fantom-foundation/go-lachesis/gossip/gasprice"
 	"github.com/Fantom-foundation/go-lachesis/gossip/occuredtxs"
+	"github.com/Fantom-foundation/go-lachesis/hash"
 	"github.com/Fantom-foundation/go-lachesis/inter"
 	"github.com/Fantom-foundation/go-lachesis/inter/idx"
 	"github.com/Fantom-foundation/go-lachesis/lachesis"
@@ -96,10 +97,13 @@ type Service struct {
 	emitter             *Emitter
 	txpool              *evmcore.TxPool
 	occurredTxs         *occuredtxs.Buffer
-	blockParticipated   map[idx.StakerID]bool // validators who participated in last block
 	heavyCheckReader    HeavyCheckReader
 	gasPowerCheckReader GasPowerCheckReader
 	checkers            *eventcheck.Checkers
+
+	// global variables. TODO refactor to pass them as arguments if possible
+	blockParticipated map[idx.StakerID]bool // validators who participated in last block
+	currentEvent      hash.Event            // current event which is being processed
 
 	feed ServiceFeed
 

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -187,7 +188,11 @@ func makeCheckers(net *lachesis.Config, heavyCheckReader *HeavyCheckReader, gasP
 }
 
 func (s *Service) makeEmitter() *Emitter {
-	return NewEmitter(s.config,
+	// randomize event time to decrease peak load, and increase chance of catching double instances of validator
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	emitterCfg := s.config.Emitter.RandomizeEmitTime(r)
+
+	return NewEmitter(&s.config.Net, emitterCfg,
 		EmitterWorld{
 			Am:          s.AccountManager(),
 			Engine:      s.engine,

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -77,6 +77,8 @@ type Store struct {
 		DelegatorOldRewards        kvdb.KeyValueStore `table:"6"`
 		StakerOldRewards           kvdb.KeyValueStore `table:"7"`
 		StakerDelegatorsOldRewards kvdb.KeyValueStore `table:"8"`
+		DecisiveEvents             kvdb.KeyValueStore `table:"9"`
+		EventLocalTimes            kvdb.KeyValueStore `table:"!"`
 
 		Evm      ethdb.Database
 		EvmState state.Database

--- a/gossip/store_sfc_stakers.go
+++ b/gossip/store_sfc_stakers.go
@@ -19,6 +19,12 @@ func (s *Store) SetEpochValidators(epoch idx.Epoch, vv []sfctype.SfcStakerAndID)
 	s.cache.Validators.Add(epoch, vv)
 }
 
+// HasEpochValidator returns true if validator exists
+func (s *Store) HasEpochValidator(epoch idx.Epoch, stakerID idx.StakerID) bool {
+	key := append(epoch.Bytes(), stakerID.Bytes()...)
+	return s.has(s.table.Validators, key)
+}
+
 // SetSfcStaker stores SfcStaker
 func (s *Store) SetSfcStaker(stakerID idx.StakerID, v *sfctype.SfcStaker) {
 	s.set(s.table.Stakers, stakerID.Bytes(), v)

--- a/inter/pos/validators.go
+++ b/inter/pos/validators.go
@@ -151,6 +151,12 @@ func (vv *Validators) SortedIDs() []idx.StakerID {
 	return vv.cache.ids
 }
 
+// SortedStakes returns deterministically sorted stakes.
+// The order is the same as for Idxs().
+func (vv *Validators) SortedStakes() []Stake {
+	return vv.cache.stakes
+}
+
 // Idxs gets deterministic total order of validators.
 func (vv *Validators) Idxs() map[idx.StakerID]idx.Validator {
 	return vv.cache.indexes

--- a/inter/time.go
+++ b/inter/time.go
@@ -11,8 +11,8 @@ type (
 )
 
 // Bytes gets the byte representation of the index.
-func (v Timestamp) Bytes() []byte {
-	return bigendian.Int64ToBytes(uint64(v))
+func (t Timestamp) Bytes() []byte {
+	return bigendian.Int64ToBytes(uint64(t))
 }
 
 // BytesToTimestamp converts bytes to timestamp.

--- a/inter/time.go
+++ b/inter/time.go
@@ -1,6 +1,7 @@
 package inter
 
 import (
+	"github.com/Fantom-foundation/go-lachesis/common/bigendian"
 	"time"
 )
 
@@ -8,6 +9,16 @@ type (
 	// Timestamp is a logical time.
 	Timestamp uint64
 )
+
+// Bytes gets the byte representation of the index.
+func (v Timestamp) Bytes() []byte {
+	return bigendian.Int64ToBytes(uint64(v))
+}
+
+// BytesToTimestamp converts bytes to timestamp.
+func BytesToTimestamp(b []byte) Timestamp {
+	return Timestamp(bigendian.BytesToInt64(b))
+}
 
 func FromUnix(t int64) Timestamp {
 	return Timestamp(int64(t) * int64(time.Second))

--- a/lachesis/config.go
+++ b/lachesis/config.go
@@ -21,7 +21,7 @@ const (
 )
 
 var (
-	// PercentUnit is used to define ratios with integers
+	// PercentUnit is used to define ratios with integers, it's 1.0
 	PercentUnit = big.NewInt(1e6)
 )
 

--- a/utils/errlock/errlock.go
+++ b/utils/errlock/errlock.go
@@ -1,0 +1,58 @@
+package errlock
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/ethereum/go-ethereum/cmd/utils"
+)
+
+// Check if errlock is written
+func Check() {
+	locked, reason, eLockPath, _ := read(datadir)
+	if locked {
+		utils.Fatalf("Node isn't allowed to start due to a previous error. Please fix the issue and then delete file \"%s\". Error message:\n%s", eLockPath, reason)
+	}
+}
+
+var (
+	datadir string
+)
+
+func SetDefaultDatadir(dir string) {
+	datadir = dir
+}
+
+// Permanent error
+func Permanent(err error) {
+	eLockPath, _ := write(datadir, err.Error())
+	utils.Fatalf("Node is permanently stopping due to an issue. Please fix the issue and then delete file \"%s\". Error message:\n%s", eLockPath, err.Error())
+}
+
+// read errlock file
+func read(dir string) (bool, string, string, error) {
+	eLockPath := path.Join(dir, "errlock")
+
+	data, err := os.Open(eLockPath)
+	if err != nil {
+		return false, "", eLockPath, err
+	}
+	defer data.Close()
+
+	// read no more than N bytes
+	maxFileLen := 5000
+	eLockBytes := make([]byte, maxFileLen)
+	n, err := data.Read(eLockBytes)
+	if err != nil {
+		return true, "", eLockPath, err
+	}
+	return true, string(eLockBytes[:n]), eLockPath, nil
+}
+
+// write errlock file
+func write(dir string, eLockStr string) (string, error) {
+	eLockPath := path.Join(dir, "errlock")
+
+	return eLockPath, ioutil.WriteFile(eLockPath, []byte(eLockStr), 0666) // assume no custom encoding needed
+}

--- a/utils/errlock/errlock.go
+++ b/utils/errlock/errlock.go
@@ -20,6 +20,7 @@ var (
 	datadir string
 )
 
+// SetDefaultDatadir for errlock files
 func SetDefaultDatadir(dir string) {
 	datadir = dir
 }

--- a/version/version.go
+++ b/version/version.go
@@ -5,8 +5,8 @@ import (
 )
 
 func init() {
-	params.VersionMajor = 0       // Major version component of the current release
-	params.VersionMinor = 5       // Minor version component of the current release
-	params.VersionPatch = 0       // Patch version component of the current release
-	params.VersionMeta = "stable" // Version metadata to append to the version string
+	params.VersionMajor = 0    // Major version component of the current release
+	params.VersionMinor = 5    // Minor version component of the current release
+	params.VersionPatch = 0    // Patch version component of the current release
+	params.VersionMeta = "rc2" // Version metadata to append to the version string
 }


### PR DESCRIPTION
#### Optimize events emitting:
1. Except maximum and minimum emit interval, now there's third interval: confirming emit interval. Confirming emit interval is used when when there's no txs to originate, but at least 1 tx to confirm. Confirming emit interval is different depending on validator's stake, and determined by a piecewise linear function. It helps to (A) decrease number of events being emitted, because validators with smaller stakes aren't mandatory in consensus and hence they can emit at lower rate, (B) de-synchronize emitting of events, so validators don't emit them at the same time
2. Maximum interval between events is 10% randomized. It helps to (A) smooth out the load (because validators don't emit at the same time), (B) improve connectivity between events (validators are much more likely to receive previous events if they aren't all emitted at the same time), (C) increase chance of catching double instances of the same validator if they were launched at the same time, hence preventing doubesign due to faulty configuration (i.e. by accident)
3. Maximum interval between events is higher on nodes with higher stake, and lower on nodes with lower stake. Maximum difference is 11%. It helps nodes with higher stake to have a chance to catch up in their event frames with others (frame cannot advance more than 1 per event, so due to (1))
4. Default maximum emit interval is increased to 12 min, due to (2) and (3) changes
5. If presence of a double instance of the same validator is detected by an heuristic, then node will shut down (and also will refuse to restart unless errlock file is deleted), instead of pausing events emitting

#### API
- add RPC call to get TTF report (debug_ttfReport). It uses new index DecisiveEventsIndex, so it'll not be accessible unless new index is enabled in config and then DAGs are re-synced. It'll be more accurate if combined with index EventLocalTimeIndex
- add RPC call to get time drift of each validator (debug_validatorTimeDrifts). It uses new index EventLocalTimeIndex, so it'll not be accessible unless new index is enabled