### PR TITLE
app.Store

### DIFF
--- a/app/apply_genesis.go
+++ b/app/apply_genesis.go
@@ -1,0 +1,103 @@
+package app
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/Fantom-foundation/go-lachesis/evmcore"
+	"github.com/Fantom-foundation/go-lachesis/inter/sfctype"
+	"github.com/Fantom-foundation/go-lachesis/lachesis"
+)
+
+// ApplyGenesis writes initial state.
+func (s *Store) ApplyGenesis(net *lachesis.Config) (block *evmcore.EvmBlock, isNew bool, err error) {
+	stored := s.getGenesisState()
+	if stored != nil {
+		isNew = false
+
+		block, err = calcGenesisBlock(net)
+		if err != nil {
+			return
+		}
+
+		if block.Root != *stored {
+			err = fmt.Errorf("database contains incompatible state hash (have %s, new %s)", *stored, block.Root)
+		}
+
+		return
+	}
+	// if we'here, then it's first time genesis is applied
+	block, err = s.applyGenesis(net)
+	if err != nil {
+		return
+	}
+
+	s.setGenesisState(block.Root)
+	return
+}
+
+// calcGenesisBlock calcs hash of genesis state.
+func calcGenesisBlock(net *lachesis.Config) (*evmcore.EvmBlock, error) {
+	s := NewMemStore()
+	defer s.Close()
+
+	return s.applyGenesis(net)
+}
+
+func (s *Store) applyGenesis(net *lachesis.Config) (evmBlock *evmcore.EvmBlock, err error) {
+	evmBlock, err = evmcore.ApplyGenesis(s.table.Evm, net)
+	if err != nil {
+		return
+	}
+
+	// calc total pre-minted supply
+	totalSupply := big.NewInt(0)
+	for _, account := range net.Genesis.Alloc.Accounts {
+		totalSupply.Add(totalSupply, account.Balance)
+	}
+	s.SetTotalSupply(totalSupply)
+
+	validatorsArr := []sfctype.SfcStakerAndID{}
+	for _, validator := range net.Genesis.Alloc.Validators {
+		staker := &sfctype.SfcStaker{
+			Address:      validator.Address,
+			CreatedEpoch: 0,
+			CreatedTime:  net.Genesis.Time,
+			StakeAmount:  validator.Stake,
+			DelegatedMe:  big.NewInt(0),
+		}
+		s.SetSfcStaker(validator.ID, staker)
+		validatorsArr = append(validatorsArr, sfctype.SfcStakerAndID{
+			StakerID: validator.ID,
+			Staker:   staker,
+		})
+	}
+	s.SetEpochValidators(1, validatorsArr)
+
+	return
+}
+
+func (s *Store) setGenesisState(root common.Hash) {
+	key := []byte("genesis")
+
+	if err := s.table.Genesis.Put(key, root.Bytes()); err != nil {
+		s.Log.Crit("Failed to put key-value", "err", err)
+	}
+}
+
+func (s *Store) getGenesisState() *common.Hash {
+	key := []byte("genesis")
+
+	buf, err := s.table.Genesis.Get(key)
+	if err != nil {
+		s.Log.Crit("Failed to get key-value", "err", err)
+	}
+	if buf == nil {
+		return nil
+	}
+
+	root := common.BytesToHash(buf)
+	return &root
+}

--- a/app/config.go
+++ b/app/config.go
@@ -1,0 +1,31 @@
+package app
+
+type (
+	// StoreConfig is a config for store db.
+	StoreConfig struct {
+		// Cache size for Receipts.
+		ReceiptsCacheSize int
+		// Cache size for Stakers.
+		StakersCacheSize int
+		// Cache size for Delegators.
+		DelegatorsCacheSize int
+	}
+)
+
+// DefaultStoreConfig for product.
+func DefaultStoreConfig() StoreConfig {
+	return StoreConfig{
+		ReceiptsCacheSize:   100,
+		DelegatorsCacheSize: 4000,
+		StakersCacheSize:    4000,
+	}
+}
+
+// LiteStoreConfig is for tests or inmemory.
+func LiteStoreConfig() StoreConfig {
+	return StoreConfig{
+		ReceiptsCacheSize:   100,
+		DelegatorsCacheSize: 400,
+		StakersCacheSize:    400,
+	}
+}

--- a/app/scores.go
+++ b/app/scores.go
@@ -1,0 +1,12 @@
+package app
+
+import (
+	"github.com/Fantom-foundation/go-lachesis/inter"
+	"github.com/Fantom-foundation/go-lachesis/inter/idx"
+)
+
+// BlocksMissed is information about missed blocks from a staker
+type BlocksMissed struct {
+	Num    idx.Block
+	Period inter.Timestamp
+}

--- a/app/sfc_index.go
+++ b/app/sfc_index.go
@@ -1,0 +1,12 @@
+package app
+
+import (
+	"math/big"
+)
+
+// SfcConstants are constants which may be changed by SFC contract
+type SfcConstants struct {
+	ShortGasPowerAllocPerSec uint64
+	LongGasPowerAllocPerSec  uint64
+	BaseRewardPerSec         *big.Int
+}

--- a/app/store.go
+++ b/app/store.go
@@ -133,15 +133,18 @@ func (s *Store) Close() {
 
 // Commit changes.
 func (s *Store) Commit(flushID []byte, immediately bool) error {
+	// TODO: enable s.dbs (uncomment all the code) when database versioning is ready
+
 	if flushID == nil {
 		// if flushId not specified, use current time
 		buf := bytes.NewBuffer(nil)
 		buf.Write([]byte{0xbe, 0xee})                                    // 0xbeee eyecatcher that flushed time
 		buf.Write(bigendian.Int64ToBytes(uint64(time.Now().UnixNano()))) // current UnixNano time
-		flushID = buf.Bytes()
+		/*
+			flushID = buf.Bytes()
+		*/
 	}
 
-	// TODO: enable s.dbs when database versioning is ready
 	/*
 		if !immediately && !s.dbs.IsFlushNeeded() {
 			return nil
@@ -218,14 +221,6 @@ func (s *Store) get(table kvdb.KeyValueStore, key []byte, to interface{}) interf
 		s.Log.Crit("Failed to decode rlp", "err", err, "size", len(buf))
 	}
 	return to
-}
-
-func (s *Store) has(table kvdb.KeyValueStore, key []byte) bool {
-	res, err := table.Has(key)
-	if err != nil {
-		s.Log.Crit("Failed to get key", "err", err)
-	}
-	return res
 }
 
 func (s *Store) dropTable(it ethdb.Iterator, t kvdb.KeyValueStore) {

--- a/app/store.go
+++ b/app/store.go
@@ -1,0 +1,257 @@
+package app
+
+import (
+	"bytes"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/hashicorp/golang-lru"
+
+	"github.com/Fantom-foundation/go-lachesis/common/bigendian"
+	"github.com/Fantom-foundation/go-lachesis/kvdb"
+	"github.com/Fantom-foundation/go-lachesis/kvdb/flushable"
+	"github.com/Fantom-foundation/go-lachesis/kvdb/memorydb"
+	"github.com/Fantom-foundation/go-lachesis/kvdb/nokeyiserr"
+	"github.com/Fantom-foundation/go-lachesis/kvdb/table"
+	"github.com/Fantom-foundation/go-lachesis/logger"
+	"github.com/Fantom-foundation/go-lachesis/topicsdb"
+)
+
+// Store is a node persistent storage working over physical key-value database.
+type Store struct {
+	cfg StoreConfig
+
+	mainDb kvdb.KeyValueStore
+	table  struct {
+		Genesis kvdb.KeyValueStore `table:"G"`
+
+		// score economy tables
+		ActiveValidationScore  kvdb.KeyValueStore `table:"V"`
+		DirtyValidationScore   kvdb.KeyValueStore `table:"v"`
+		ActiveOriginationScore kvdb.KeyValueStore `table:"O"`
+		DirtyOriginationScore  kvdb.KeyValueStore `table:"o"`
+		BlockDowntime          kvdb.KeyValueStore `table:"m"`
+
+		// PoI economy tables
+		StakerPOIScore      kvdb.KeyValueStore `table:"s"`
+		AddressPOIScore     kvdb.KeyValueStore `table:"a"`
+		AddressFee          kvdb.KeyValueStore `table:"g"`
+		StakerDelegatorsFee kvdb.KeyValueStore `table:"d"`
+		AddressLastTxTime   kvdb.KeyValueStore `table:"X"`
+		TotalPoiFee         kvdb.KeyValueStore `table:"U"`
+
+		// gas power economy tables
+		GasPowerRefund kvdb.KeyValueStore `table:"R"`
+
+		// SFC-related economy tables
+		Validators   kvdb.KeyValueStore `table:"1"`
+		Stakers      kvdb.KeyValueStore `table:"2"`
+		Delegators   kvdb.KeyValueStore `table:"3"`
+		SfcConstants kvdb.KeyValueStore `table:"4"`
+		TotalSupply  kvdb.KeyValueStore `table:"5"`
+
+		// API-only tables
+		Receipts                   kvdb.KeyValueStore `table:"r"`
+		DelegatorOldRewards        kvdb.KeyValueStore `table:"6"`
+		StakerOldRewards           kvdb.KeyValueStore `table:"7"`
+		StakerDelegatorsOldRewards kvdb.KeyValueStore `table:"8"`
+
+		Evm      ethdb.Database
+		EvmState state.Database
+		EvmLogs  *topicsdb.Index
+	}
+
+	cache struct {
+		Receipts      *lru.Cache `cache:"-"` // store by value
+		Validators    *lru.Cache `cache:"-"` // store by pointer
+		Stakers       *lru.Cache `cache:"-"` // store by pointer
+		Delegators    *lru.Cache `cache:"-"` // store by pointer
+		BlockDowntime *lru.Cache `cache:"-"` // store by pointer
+	}
+
+	mutex struct {
+		Inc sync.Mutex
+	}
+
+	logger.Instance
+}
+
+// NewMemStore creates store over memory map.
+func NewMemStore() *Store {
+	mems := memorydb.NewProducer("")
+	dbs := flushable.NewSyncedPool(mems)
+	cfg := LiteStoreConfig()
+
+	return NewStore(dbs, cfg)
+}
+
+// NewStore creates store over key-value db.
+func NewStore(dbs *flushable.SyncedPool, cfg StoreConfig) *Store {
+	s := &Store{
+		cfg:      cfg,
+		mainDb:   dbs.GetDb("gossip-main"), // TODO: use "app-main" when database versioning is ready
+		Instance: logger.MakeInstance(),
+	}
+
+	table.MigrateTables(&s.table, s.mainDb)
+
+	evmTable := nokeyiserr.Wrap(table.New(s.mainDb, []byte("M"))) // ETH expects that "not found" is an error
+	s.table.Evm = rawdb.NewDatabase(evmTable)
+	s.table.EvmState = state.NewDatabaseWithCache(s.table.Evm, 16)
+	s.table.EvmLogs = topicsdb.New(table.New(s.mainDb, []byte("L")))
+
+	s.initCache()
+
+	return s
+}
+
+func (s *Store) initCache() {
+	s.cache.Receipts = s.makeCache(s.cfg.ReceiptsCacheSize)
+	s.cache.Validators = s.makeCache(2)
+	s.cache.Stakers = s.makeCache(s.cfg.StakersCacheSize)
+	s.cache.Delegators = s.makeCache(s.cfg.DelegatorsCacheSize)
+	s.cache.BlockDowntime = s.makeCache(256)
+}
+
+// Close leaves underlying database.
+func (s *Store) Close() {
+	setnil := func() interface{} {
+		return nil
+	}
+
+	table.MigrateTables(&s.table, nil)
+	table.MigrateCaches(&s.cache, setnil)
+
+	s.mainDb.Close()
+}
+
+// Commit changes.
+func (s *Store) Commit(flushID []byte, immediately bool) error {
+	if flushID == nil {
+		// if flushId not specified, use current time
+		buf := bytes.NewBuffer(nil)
+		buf.Write([]byte{0xbe, 0xee})                                    // 0xbeee eyecatcher that flushed time
+		buf.Write(bigendian.Int64ToBytes(uint64(time.Now().UnixNano()))) // current UnixNano time
+		flushID = buf.Bytes()
+	}
+
+	// TODO: enable s.dbs when database versioning is ready
+	/*
+		if !immediately && !s.dbs.IsFlushNeeded() {
+			return nil
+		}
+	*/
+
+	// Flush trie on the DB
+	err := s.table.EvmState.TrieDB().Cap(0)
+	if err != nil {
+		s.Log.Error("Failed to flush trie DB into main DB", "err", err)
+	}
+	return err
+
+	// Flush the DBs
+	/*
+		return s.dbs.Flush(flushID)
+	*/
+
+}
+
+// StateDB returns state database.
+func (s *Store) StateDB(from common.Hash) *state.StateDB {
+	db, err := state.New(common.Hash(from), s.table.EvmState)
+	if err != nil {
+		s.Log.Crit("Failed to open state", "err", err)
+	}
+	return db
+}
+
+// StateDB returns state database.
+func (s *Store) IndexLogs(recs ...*types.Log) {
+	err := s.table.EvmLogs.Push(recs...)
+	if err != nil {
+		s.Log.Crit("DB logs index", "err", err)
+	}
+}
+
+func (s *Store) EvmTable() ethdb.Database {
+	return s.table.Evm
+}
+
+func (s *Store) EvmLogs() *topicsdb.Index {
+	return s.table.EvmLogs
+}
+
+/*
+ * Utils:
+ */
+
+// set RLP value
+func (s *Store) set(table kvdb.KeyValueStore, key []byte, val interface{}) {
+	buf, err := rlp.EncodeToBytes(val)
+	if err != nil {
+		s.Log.Crit("Failed to encode rlp", "err", err)
+	}
+
+	if err := table.Put(key, buf); err != nil {
+		s.Log.Crit("Failed to put key-value", "err", err)
+	}
+}
+
+// get RLP value
+func (s *Store) get(table kvdb.KeyValueStore, key []byte, to interface{}) interface{} {
+	buf, err := table.Get(key)
+	if err != nil {
+		s.Log.Crit("Failed to get key-value", "err", err)
+	}
+	if buf == nil {
+		return nil
+	}
+
+	err = rlp.DecodeBytes(buf, to)
+	if err != nil {
+		s.Log.Crit("Failed to decode rlp", "err", err, "size", len(buf))
+	}
+	return to
+}
+
+func (s *Store) has(table kvdb.KeyValueStore, key []byte) bool {
+	res, err := table.Has(key)
+	if err != nil {
+		s.Log.Crit("Failed to get key", "err", err)
+	}
+	return res
+}
+
+func (s *Store) dropTable(it ethdb.Iterator, t kvdb.KeyValueStore) {
+	keys := make([][]byte, 0, 500) // don't write during iteration
+
+	for it.Next() {
+		keys = append(keys, it.Key())
+	}
+
+	for i := range keys {
+		err := t.Delete(keys[i])
+		if err != nil {
+			s.Log.Crit("Failed to erase key-value", "err", err)
+		}
+	}
+}
+
+func (s *Store) makeCache(size int) *lru.Cache {
+	if size <= 0 {
+		return nil
+	}
+
+	cache, err := lru.New(size)
+	if err != nil {
+		s.Log.Crit("Error create LRU cache", "err", err)
+		return nil
+	}
+	return cache
+}

--- a/app/store_poi.go
+++ b/app/store_poi.go
@@ -1,4 +1,4 @@
-package gossip
+package app
 
 import (
 	"math/big"

--- a/app/store_receipts.go
+++ b/app/store_receipts.go
@@ -1,4 +1,4 @@
-package gossip
+package app
 
 /*
 	In LRU cache data stored like value

--- a/app/store_receipts_test.go
+++ b/app/store_receipts_test.go
@@ -1,4 +1,4 @@
-package gossip
+package app
 
 import (
 	"testing"

--- a/app/store_refund.go
+++ b/app/store_refund.go
@@ -1,4 +1,4 @@
-package gossip
+package app
 
 import (
 	"github.com/Fantom-foundation/go-lachesis/common/bigendian"

--- a/app/store_rewards_history.go
+++ b/app/store_rewards_history.go
@@ -1,4 +1,4 @@
-package gossip
+package app
 
 import (
 	"math/big"

--- a/app/store_scores.go
+++ b/app/store_scores.go
@@ -1,4 +1,4 @@
-package gossip
+package app
 
 import (
 	"math/big"

--- a/app/store_sfc_constants.go
+++ b/app/store_sfc_constants.go
@@ -1,4 +1,4 @@
-package gossip
+package app
 
 import "github.com/Fantom-foundation/go-lachesis/inter/idx"
 

--- a/app/store_sfc_delegators.go
+++ b/app/store_sfc_delegators.go
@@ -1,4 +1,4 @@
-package gossip
+package app
 
 import (
 	"github.com/ethereum/go-ethereum/common"

--- a/app/store_sfc_stakers.go
+++ b/app/store_sfc_stakers.go
@@ -1,4 +1,4 @@
-package gossip
+package app
 
 import (
 	"github.com/ethereum/go-ethereum/ethdb"

--- a/app/store_test.go
+++ b/app/store_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/Fantom-foundation/go-lachesis/kvdb"
 	"github.com/Fantom-foundation/go-lachesis/kvdb/flushable"
-	"github.com/Fantom-foundation/go-lachesis/kvdb/leveldb"
 	"github.com/Fantom-foundation/go-lachesis/kvdb/memorydb"
 )
 
@@ -21,14 +20,6 @@ func nonCachedStore() *Store {
 	mems := memorydb.NewProducer("", withDelay)
 	dbs := flushable.NewSyncedPool(mems)
 	cfg := StoreConfig{}
-
-	return NewStore(dbs, cfg)
-}
-
-func realStore(dir string) *Store {
-	disk := leveldb.NewProducer(dir)
-	dbs := flushable.NewSyncedPool(disk)
-	cfg := LiteStoreConfig()
 
 	return NewStore(dbs, cfg)
 }

--- a/app/store_test.go
+++ b/app/store_test.go
@@ -1,0 +1,44 @@
+package app
+
+import (
+	"time"
+
+	"github.com/Fantom-foundation/go-lachesis/kvdb"
+	"github.com/Fantom-foundation/go-lachesis/kvdb/flushable"
+	"github.com/Fantom-foundation/go-lachesis/kvdb/leveldb"
+	"github.com/Fantom-foundation/go-lachesis/kvdb/memorydb"
+)
+
+func cachedStore() *Store {
+	mems := memorydb.NewProducer("", withDelay)
+	dbs := flushable.NewSyncedPool(mems)
+	cfg := LiteStoreConfig()
+
+	return NewStore(dbs, cfg)
+}
+
+func nonCachedStore() *Store {
+	mems := memorydb.NewProducer("", withDelay)
+	dbs := flushable.NewSyncedPool(mems)
+	cfg := StoreConfig{}
+
+	return NewStore(dbs, cfg)
+}
+
+func realStore(dir string) *Store {
+	disk := leveldb.NewProducer(dir)
+	dbs := flushable.NewSyncedPool(disk)
+	cfg := LiteStoreConfig()
+
+	return NewStore(dbs, cfg)
+}
+
+func withDelay(db kvdb.KeyValueStore) kvdb.KeyValueStore {
+	mem, ok := db.(*memorydb.Database)
+	if ok {
+		mem.SetDelay(time.Millisecond)
+
+	}
+
+	return db
+}

--- a/app/store_total_supply.go
+++ b/app/store_total_supply.go
@@ -1,4 +1,4 @@
-package gossip
+package app
 
 import (
 	"math/big"

--- a/cmd/lachesis/main.go
+++ b/cmd/lachesis/main.go
@@ -226,7 +226,7 @@ func makeFullNode(ctx *cli.Context) *node.Node {
 
 	stack := makeConfigNode(ctx, &cfg.Node)
 
-	engine, gdb := integration.MakeEngine(cfg.Node.DataDir, &cfg.Lachesis)
+	engine, adb, gdb := integration.MakeEngine(cfg.Node.DataDir, &cfg.Lachesis)
 	metrics.SetDataDir(cfg.Node.DataDir)
 
 	// configure emitter
@@ -241,7 +241,7 @@ func makeFullNode(ctx *cli.Context) *node.Node {
 	// the factory method approach is to support service restarts without relying on the
 	// individual implementations' support for such operations.
 	gossipService := func(ctx *node.ServiceContext) (node.Service, error) {
-		return gossip.NewService(ctx, &cfg.Lachesis, gdb, engine)
+		return gossip.NewService(ctx, &cfg.Lachesis, gdb, engine, adb)
 	}
 
 	if err := stack.Register(gossipService); err != nil {

--- a/gossip/checker_helpers.go
+++ b/gossip/checker_helpers.go
@@ -3,10 +3,9 @@ package gossip
 import (
 	"sync/atomic"
 
-	"github.com/Fantom-foundation/go-lachesis/app"
-
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/Fantom-foundation/go-lachesis/app"
 	"github.com/Fantom-foundation/go-lachesis/eventcheck/gaspowercheck"
 	"github.com/Fantom-foundation/go-lachesis/inter/idx"
 	"github.com/Fantom-foundation/go-lachesis/inter/pos"

--- a/gossip/checker_helpers.go
+++ b/gossip/checker_helpers.go
@@ -3,6 +3,8 @@ package gossip
 import (
 	"sync/atomic"
 
+	"github.com/Fantom-foundation/go-lachesis/app"
+
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/Fantom-foundation/go-lachesis/eventcheck/gaspowercheck"
@@ -37,9 +39,9 @@ func gasPowerBounds(initialAlloc, minAlloc, maxAlloc, customAlloc uint64) uint64
 }
 
 // ReadGasPowerContext reads current validation context for gaspowercheck
-func ReadGasPowerContext(s *Store, validators *pos.Validators, epoch idx.Epoch, cfg *lachesis.EconomyConfig) *gaspowercheck.ValidationContext {
+func ReadGasPowerContext(s *Store, a *app.Store, validators *pos.Validators, epoch idx.Epoch, cfg *lachesis.EconomyConfig) *gaspowercheck.ValidationContext {
 	// engineMu is locked here
-	sfcConstants := s.GetSfcConstants(epoch - 1)
+	sfcConstants := a.GetSfcConstants(epoch - 1)
 
 	short := cfg.ShortGasPower
 	shortAllocPerSec := gasPowerBounds(short.InitialAllocPerSec, short.MinAllocPerSec, short.MaxAllocPerSec, sfcConstants.ShortGasPowerAllocPerSec)
@@ -68,7 +70,7 @@ func ReadGasPowerContext(s *Store, validators *pos.Validators, epoch idx.Epoch, 
 		Validators:           validators,
 		PrevEpochLastHeaders: s.GetLastHeaders(epoch - 1),
 		PrevEpochEndTime:     s.GetEpochStats(epoch - 1).End,
-		PrevEpochRefunds:     s.GetGasPowerRefunds(epoch - 1),
+		PrevEpochRefunds:     a.GetGasPowerRefunds(epoch - 1),
 		Configs: [2]gaspowercheck.Config{
 			idx.ShortTermGas: shortTermConfig,
 			idx.LongTermGas:  longTermConfig,
@@ -95,9 +97,9 @@ func (r *HeavyCheckReader) GetEpochPubKeys() (map[idx.StakerID]common.Address, i
 }
 
 // ReadEpochPubKeys is the same as GetEpochValidators, but returns only addresses
-func ReadEpochPubKeys(s *Store, epoch idx.Epoch) *ValidatorsPubKeys {
+func ReadEpochPubKeys(a *app.Store, epoch idx.Epoch) *ValidatorsPubKeys {
 	addrs := make(map[idx.StakerID]common.Address)
-	for _, it := range s.GetEpochValidators(epoch) {
+	for _, it := range a.GetEpochValidators(epoch) {
 		addrs[it.StakerID] = it.Staker.Address
 	}
 	return &ValidatorsPubKeys{

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -61,6 +61,14 @@ type (
 		TxPositionsCacheSize int
 		// Cache size for EpochStats.
 		EpochStatsCacheSize int
+
+		// NOTE: fields for config-file back compatibility
+		// Cache size for Receipts.
+		ReceiptsCacheSize int
+		// Cache size for Stakers.
+		StakersCacheSize int
+		// Cache size for Delegators.
+		DelegatorsCacheSize int
 	}
 )
 

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -57,16 +57,10 @@ type (
 		BlockCacheSize int
 		// Cache size for PackInfos.
 		PackInfosCacheSize int
-		// Cache size for Receipts.
-		ReceiptsCacheSize int
 		// Cache size for TxPositions.
 		TxPositionsCacheSize int
 		// Cache size for EpochStats.
 		EpochStatsCacheSize int
-		// Cache size for Stakers.
-		StakersCacheSize int
-		// Cache size for Delegators.
-		DelegatorsCacheSize int
 	}
 )
 
@@ -114,11 +108,8 @@ func DefaultStoreConfig() StoreConfig {
 		EventsHeadersCacheSize: 10000,
 		BlockCacheSize:         100,
 		PackInfosCacheSize:     100,
-		ReceiptsCacheSize:      100,
 		TxPositionsCacheSize:   1000,
 		EpochStatsCacheSize:    100,
-		DelegatorsCacheSize:    4000,
-		StakersCacheSize:       4000,
 	}
 }
 
@@ -129,10 +120,7 @@ func LiteStoreConfig() StoreConfig {
 		EventsHeadersCacheSize: 1000,
 		BlockCacheSize:         100,
 		PackInfosCacheSize:     100,
-		ReceiptsCacheSize:      100,
 		TxPositionsCacheSize:   100,
 		EpochStatsCacheSize:    100,
-		DelegatorsCacheSize:    400,
-		StakersCacheSize:       400,
 	}
 }

--- a/gossip/consensus_callbacks.go
+++ b/gossip/consensus_callbacks.go
@@ -58,8 +58,8 @@ func (s *Service) processEvent(realEngine Consensus, e *inter.Event) error {
 
 	if newEpoch != oldEpoch {
 		// notify event checkers about new validation data
-		s.heavyCheckReader.Addrs.Store(ReadEpochPubKeys(s.store, newEpoch))
-		s.gasPowerCheckReader.Ctx.Store(ReadGasPowerContext(s.store, s.engine.GetValidators(), newEpoch, &s.config.Net.Economy))
+		s.heavyCheckReader.Addrs.Store(ReadEpochPubKeys(s.app, newEpoch))
+		s.gasPowerCheckReader.Ctx.Store(ReadGasPowerContext(s.store, s.app, s.engine.GetValidators(), newEpoch, &s.config.Net.Economy))
 
 		// sealings/prunings
 		s.packsOnNewEpoch(oldEpoch, newEpoch)
@@ -72,6 +72,11 @@ func (s *Service) processEvent(realEngine Consensus, e *inter.Event) error {
 	}
 
 	immediately := (newEpoch != oldEpoch)
+
+	err := s.app.Commit(e.Hash().Bytes(), immediately)
+	if err != nil {
+		return err
+	}
 	return s.store.Commit(e.Hash().Bytes(), immediately)
 }
 
@@ -111,7 +116,7 @@ func (s *Service) applyNewState(
 
 	// Get stateDB
 	stateHash := s.store.GetBlock(block.Index - 1).Root
-	statedb := s.store.StateDB(stateHash)
+	statedb := s.app.StateDB(stateHash)
 
 	// Process EVM txs
 	block, evmBlock, totalFee, receipts := s.executeEvmTransactions(block, evmBlock, statedb)
@@ -260,11 +265,7 @@ func (s *Service) executeEvmTransactions(
 	}
 
 	for _, r := range receipts {
-
-		err := s.store.table.EvmLogs.Push(r.Logs...)
-		if err != nil {
-			s.Log.Crit("DB logs index", "err", err)
-		}
+		s.app.IndexLogs(r.Logs...)
 	}
 
 	return block, evmBlock, totalFee, receipts
@@ -310,7 +311,7 @@ func (s *Service) applyBlock(block *inter.Block, decidedFrame idx.Frame, cheater
 		}
 
 		if receipts.Len() != 0 {
-			s.store.SetReceipts(block.Index, receipts)
+			s.app.SetReceipts(block.Index, receipts)
 		}
 	}
 
@@ -345,7 +346,7 @@ func (s *Service) selectValidatorsGroup(oldEpoch, newEpoch idx.Epoch) (newValida
 	// s.engineMu is locked here
 
 	builder := pos.NewBuilder()
-	for _, it := range s.store.GetEpochValidators(newEpoch) {
+	for _, it := range s.app.GetEpochValidators(newEpoch) {
 		builder.Set(it.StakerID, pos.BalanceToStake(it.Staker.CalcTotalStake()))
 	}
 

--- a/gossip/emitter.go
+++ b/gossip/emitter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/hashicorp/golang-lru"
 
+	"github.com/Fantom-foundation/go-lachesis/app"
 	"github.com/Fantom-foundation/go-lachesis/common/bigendian"
 	"github.com/Fantom-foundation/go-lachesis/eventcheck"
 	"github.com/Fantom-foundation/go-lachesis/eventcheck/basiccheck"
@@ -40,6 +41,7 @@ const (
 // EmitterWorld is emitter's external world
 type EmitterWorld struct {
 	Store       *Store
+	App         *app.Store
 	Engine      Consensus
 	EngineMu    *sync.RWMutex
 	Txpool      txPool
@@ -198,7 +200,7 @@ func (em *Emitter) myStakerID() (idx.StakerID, bool) {
 		return 0, false // short circuit if zero address
 	}
 
-	validators := em.world.Store.GetEpochValidators(em.world.Engine.GetEpoch())
+	validators := em.world.App.GetEpochValidators(em.world.Engine.GetEpoch())
 	for _, it := range validators {
 		if it.Staker.Address == coinbase {
 			return it.StakerID, true

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Fantom-foundation/go-lachesis/inter/pos"
-
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
@@ -30,6 +28,7 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/hash"
 	"github.com/Fantom-foundation/go-lachesis/inter"
 	"github.com/Fantom-foundation/go-lachesis/inter/idx"
+	"github.com/Fantom-foundation/go-lachesis/inter/pos"
 	"github.com/Fantom-foundation/go-lachesis/inter/sfctype"
 	"github.com/Fantom-foundation/go-lachesis/lachesis/genesis/sfc"
 	"github.com/Fantom-foundation/go-lachesis/lachesis/genesis/sfc/sfcpos"

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Fantom-foundation/go-lachesis/inter/pos"
 	"math/big"
 	"strconv"
 	"strings"
+
+	"github.com/Fantom-foundation/go-lachesis/inter/pos"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -99,7 +100,7 @@ func (b *EthAPIBackend) StateAndHeaderByNumber(ctx context.Context, number rpc.B
 	if header == nil {
 		return nil, nil, errors.New("header not found")
 	}
-	stateDb := b.svc.store.StateDB(header.Root)
+	stateDb := b.svc.app.StateDB(header.Root)
 	return stateDb, header, nil
 }
 
@@ -280,7 +281,7 @@ func (b *EthAPIBackend) GetReceiptsByNumber(ctx context.Context, number rpc.Bloc
 		number = rpc.BlockNumber(header.Number.Uint64())
 	}
 
-	receipts := b.svc.store.GetReceipts(idx.Block(number))
+	receipts := b.svc.app.GetReceipts(idx.Block(number))
 	return receipts, nil
 }
 
@@ -427,7 +428,7 @@ func (b *EthAPIBackend) SuggestPrice(ctx context.Context) (*big.Int, error) {
 }
 
 func (b *EthAPIBackend) ChainDb() ethdb.Database {
-	return b.svc.store.table.Evm
+	return b.svc.app.EvmTable()
 }
 
 func (b *EthAPIBackend) AccountManager() *accounts.Manager {
@@ -443,7 +444,7 @@ func (b *EthAPIBackend) RPCGasCap() *big.Int {
 }
 
 func (b *EthAPIBackend) EvmLogIndex() *topicsdb.Index {
-	return b.svc.store.table.EvmLogs
+	return b.svc.app.EvmLogs()
 }
 
 // CurrentEpoch returns current epoch number.
@@ -475,7 +476,7 @@ func (b *EthAPIBackend) GetEpochStats(ctx context.Context, requestedEpoch rpc.Bl
 
 	// read total reward weights from SFC contract
 	header := b.state.CurrentHeader()
-	statedb := b.svc.store.StateDB(header.Root)
+	statedb := b.svc.app.StateDB(header.Root)
 
 	epochPosition := sfcpos.EpochSnapshot(epoch)
 	stats.TotalBaseRewardWeight = statedb.GetState(sfc.ContractAddress, epochPosition.TotalBaseRewardWeight()).Big()
@@ -486,35 +487,35 @@ func (b *EthAPIBackend) GetEpochStats(ctx context.Context, requestedEpoch rpc.Bl
 
 // GetValidationScore returns staker's ValidationScore.
 func (b *EthAPIBackend) GetValidationScore(ctx context.Context, stakerID idx.StakerID) (*big.Int, error) {
-	if !b.svc.store.HasSfcStaker(stakerID) {
+	if !b.svc.app.HasSfcStaker(stakerID) {
 		return nil, nil
 	}
-	return b.svc.store.GetActiveValidationScore(stakerID), nil
+	return b.svc.app.GetActiveValidationScore(stakerID), nil
 }
 
 // GetOriginationScore returns staker's OriginationScore.
 func (b *EthAPIBackend) GetOriginationScore(ctx context.Context, stakerID idx.StakerID) (*big.Int, error) {
-	if !b.svc.store.HasSfcStaker(stakerID) {
+	if !b.svc.app.HasSfcStaker(stakerID) {
 		return nil, nil
 	}
-	return b.svc.store.GetActiveOriginationScore(stakerID), nil
+	return b.svc.app.GetActiveOriginationScore(stakerID), nil
 }
 
 // GetStakerPoI returns staker's PoI.
 func (b *EthAPIBackend) GetStakerPoI(ctx context.Context, stakerID idx.StakerID) (*big.Int, error) {
-	if !b.svc.store.HasSfcStaker(stakerID) {
+	if !b.svc.app.HasSfcStaker(stakerID) {
 		return nil, nil
 	}
-	return b.svc.store.GetStakerPOI(stakerID), nil
+	return b.svc.app.GetStakerPOI(stakerID), nil
 }
 
 // GetRewardWeights returns staker's reward weights.
 func (b *EthAPIBackend) GetRewardWeights(ctx context.Context, stakerID idx.StakerID) (*big.Int, *big.Int, error) {
-	if !b.svc.store.HasSfcStaker(stakerID) {
+	if !b.svc.app.HasSfcStaker(stakerID) {
 		return nil, nil, nil
 	}
 	header := b.state.CurrentHeader()
-	statedb := b.svc.store.StateDB(header.Root)
+	statedb := b.svc.app.StateDB(header.Root)
 
 	// read reward weight from SFC contract
 	epoch := b.svc.engine.GetEpoch()
@@ -528,13 +529,13 @@ func (b *EthAPIBackend) GetRewardWeights(ctx context.Context, stakerID idx.Stake
 
 // GetDowntime returns staker's Downtime.
 func (b *EthAPIBackend) GetDowntime(ctx context.Context, stakerID idx.StakerID) (idx.Block, inter.Timestamp, error) {
-	missed := b.svc.store.GetBlocksMissed(stakerID)
+	missed := b.svc.app.GetBlocksMissed(stakerID)
 	return missed.Num, missed.Period, nil
 }
 
 // GetStaker returns SFC staker's info
 func (b *EthAPIBackend) GetStaker(ctx context.Context, stakerID idx.StakerID) (*sfctype.SfcStaker, error) {
-	staker := b.svc.store.GetSfcStaker(stakerID)
+	staker := b.svc.app.GetSfcStaker(stakerID)
 	if staker == nil {
 		return nil, nil
 	}
@@ -545,7 +546,7 @@ func (b *EthAPIBackend) GetStaker(ctx context.Context, stakerID idx.StakerID) (*
 // GetStakerID returns SFC staker's Id by address
 func (b *EthAPIBackend) GetStakerID(ctx context.Context, addr common.Address) (idx.StakerID, error) {
 	header := b.state.CurrentHeader()
-	statedb := b.svc.store.StateDB(header.Root)
+	statedb := b.svc.app.StateDB(header.Root)
 
 	position := sfcpos.StakerID(addr)
 	stakerID256 := statedb.GetState(sfc.ContractAddress, position)
@@ -559,7 +560,7 @@ func (b *EthAPIBackend) GetStakers(ctx context.Context) ([]sfctype.SfcStakerAndI
 	defer b.svc.engineMu.RUnlock()
 
 	stakers := make([]sfctype.SfcStakerAndID, 0, 200)
-	b.svc.store.ForEachSfcStaker(func(it sfctype.SfcStakerAndID) {
+	b.svc.app.ForEachSfcStaker(func(it sfctype.SfcStakerAndID) {
 		it.Staker.IsValidator = b.svc.engine.GetValidators().Exists(it.StakerID)
 		stakers = append(stakers, it)
 	})
@@ -573,7 +574,7 @@ func (b *EthAPIBackend) GetDelegatorsOf(ctx context.Context, stakerID idx.Staker
 
 	delegators := make([]sfctype.SfcDelegatorAndAddr, 0, 200)
 	// TODO add additional DB index
-	b.svc.store.ForEachSfcDelegator(func(it sfctype.SfcDelegatorAndAddr) {
+	b.svc.app.ForEachSfcDelegator(func(it sfctype.SfcDelegatorAndAddr) {
 		if it.Delegator.ToStakerID == stakerID {
 			delegators = append(delegators, it)
 		}
@@ -583,20 +584,20 @@ func (b *EthAPIBackend) GetDelegatorsOf(ctx context.Context, stakerID idx.Staker
 
 // GetDelegator returns SFC delegator info
 func (b *EthAPIBackend) GetDelegator(ctx context.Context, addr common.Address) (*sfctype.SfcDelegator, error) {
-	return b.svc.store.GetSfcDelegator(addr), nil
+	return b.svc.app.GetSfcDelegator(addr), nil
 }
 
 // GetDelegatorClaimedRewards returns sum of claimed rewards in past, by this delegator
 func (b *EthAPIBackend) GetDelegatorClaimedRewards(ctx context.Context, addr common.Address) (*big.Int, error) {
-	return b.svc.store.GetDelegatorClaimedRewards(addr), nil
+	return b.svc.app.GetDelegatorClaimedRewards(addr), nil
 }
 
 // GetStakerClaimedRewards returns sum of claimed rewards in past, by this staker
 func (b *EthAPIBackend) GetStakerClaimedRewards(ctx context.Context, stakerID idx.StakerID) (*big.Int, error) {
-	return b.svc.store.GetStakerClaimedRewards(stakerID), nil
+	return b.svc.app.GetStakerClaimedRewards(stakerID), nil
 }
 
 // GetStakerDelegatorsClaimedRewards returns sum of claimed rewards in past, by this delegators of this staker
 func (b *EthAPIBackend) GetStakerDelegatorsClaimedRewards(ctx context.Context, stakerID idx.StakerID) (*big.Int, error) {
-	return b.svc.store.GetStakerDelegatorsClaimedRewards(stakerID), nil
+	return b.svc.app.GetStakerDelegatorsClaimedRewards(stakerID), nil
 }

--- a/gossip/evm_state_reader.go
+++ b/gossip/evm_state_reader.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/Fantom-foundation/go-lachesis/app"
 	"github.com/Fantom-foundation/go-lachesis/evmcore"
 	"github.com/Fantom-foundation/go-lachesis/hash"
 	"github.com/Fantom-foundation/go-lachesis/inter/idx"
@@ -19,6 +20,7 @@ type EvmStateReader struct {
 	engine   Consensus
 
 	store *Store
+	app   *app.Store
 }
 
 func (s *Service) GetEvmStateReader() *EvmStateReader {
@@ -27,6 +29,7 @@ func (s *Service) GetEvmStateReader() *EvmStateReader {
 		engineMu:    s.engineMu,
 		engine:      s.engine,
 		store:       s.store,
+		app:         s.app,
 	}
 }
 
@@ -109,5 +112,5 @@ func (r *EvmStateReader) getBlock(h hash.Event, n idx.Block, readTxs bool) *evmc
 }
 
 func (r *EvmStateReader) StateAt(root common.Hash) (*state.StateDB, error) {
-	return r.store.StateDB(root), nil
+	return r.app.StateDB(root), nil
 }

--- a/gossip/handler_test.go
+++ b/gossip/handler_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Fantom-foundation/go-lachesis/app"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/node"
@@ -139,17 +141,22 @@ func testBroadcastEvent(t *testing.T, totalPeers int, forcedAggressiveBroadcast 
 	config.Emitter.SelfForkProtectionInterval = 0
 	config.TxPool.Journal = ""
 
-	var (
-		store       = NewMemStore()
-		engineStore = poset.NewMemStore()
-	)
-
 	// create stores
-	genesisAtropos, genesisEvmState, _, err := store.ApplyGenesis(&net)
-	assertar.NoError(err)
-
+	app := app.NewMemStore()
+	state, _, err := app.ApplyGenesis(&net)
+	if !assertar.NoError(err) {
+		return
+	}
+	store := NewMemStore()
+	genesisAtropos, genesisEvmState, _, err := store.ApplyGenesis(&net, state)
+	if !assertar.NoError(err) {
+		return
+	}
+	engineStore := poset.NewMemStore()
 	err = engineStore.ApplyGenesis(&net.Genesis, genesisAtropos, genesisEvmState)
-	assertar.NoError(err)
+	if !assertar.NoError(err) {
+		return
+	}
 
 	// create consensus engine
 	engine := poset.New(net.Dag, engineStore, store)
@@ -160,7 +167,7 @@ func testBroadcastEvent(t *testing.T, totalPeers int, forcedAggressiveBroadcast 
 	ctx := &node.ServiceContext{
 		AccountManager: mockAccountManager(net.Genesis.Alloc.Accounts, creator),
 	}
-	svc, err := NewService(ctx, &config, store, engine)
+	svc, err := NewService(ctx, &config, store, engine, app)
 	assertar.NoError(err)
 
 	// start PM
@@ -262,10 +269,10 @@ func mockAccountManager(accs genesis.Accounts, unlock ...common.Address) *accoun
 	)
 }
 
-func mockCheckers(epoch idx.Epoch, net *lachesis.Config, engine Consensus, store *Store) *eventcheck.Checkers {
+func mockCheckers(epoch idx.Epoch, net *lachesis.Config, engine Consensus, s *Store, a *app.Store) *eventcheck.Checkers {
 	heavyCheckReader := &HeavyCheckReader{}
-	heavyCheckReader.Addrs.Store(ReadEpochPubKeys(store, epoch))
+	heavyCheckReader.Addrs.Store(ReadEpochPubKeys(a, epoch))
 	gasPowerCheckReader := &GasPowerCheckReader{}
-	gasPowerCheckReader.Ctx.Store(ReadGasPowerContext(store, engine.GetValidators(), engine.GetEpoch(), &net.Economy))
-	return makeCheckers(net, heavyCheckReader, gasPowerCheckReader, engine, store)
+	gasPowerCheckReader.Ctx.Store(ReadGasPowerContext(s, a, engine.GetValidators(), engine.GetEpoch(), &net.Economy))
+	return makeCheckers(net, heavyCheckReader, gasPowerCheckReader, engine, s)
 }

--- a/gossip/handler_test.go
+++ b/gossip/handler_test.go
@@ -6,14 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Fantom-foundation/go-lachesis/app"
-
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/Fantom-foundation/go-lachesis/app"
 	"github.com/Fantom-foundation/go-lachesis/eventcheck"
 	"github.com/Fantom-foundation/go-lachesis/hash"
 	"github.com/Fantom-foundation/go-lachesis/inter"

--- a/gossip/helper_test.go
+++ b/gossip/helper_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 
+	"github.com/Fantom-foundation/go-lachesis/app"
 	"github.com/Fantom-foundation/go-lachesis/hash"
 	"github.com/Fantom-foundation/go-lachesis/inter"
 	"github.com/Fantom-foundation/go-lachesis/inter/pos"
@@ -23,11 +24,8 @@ import (
 // newTestProtocolManager creates a new protocol manager for testing purposes,
 // with the given number of events already known from each node
 func newTestProtocolManager(nodesNum int, eventsNum int, newtx chan<- []*types.Transaction, onNewEvent func(e *inter.Event)) (*ProtocolManager, *Store, error) {
-	var (
-		store = NewMemStore()
-	)
-
 	net := lachesis.FakeNetConfig(genesis.FakeAccounts(0, nodesNum, big.NewInt(0), pos.StakeToBalance(1)))
+
 	config := DefaultConfig(net)
 	config.TxPool.Journal = ""
 
@@ -37,7 +35,14 @@ func newTestProtocolManager(nodesNum int, eventsNum int, newtx chan<- []*types.T
 		return nil, nil, err
 	}
 
-	_, _, _, err = store.ApplyGenesis(&net)
+	app := app.NewMemStore()
+	state, _, err := app.ApplyGenesis(&net)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	store := NewMemStore()
+	_, _, _, err = store.ApplyGenesis(&net, state)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -50,7 +55,7 @@ func newTestProtocolManager(nodesNum int, eventsNum int, newtx chan<- []*types.T
 		nil,
 		&dummyTxPool{added: newtx},
 		new(sync.RWMutex),
-		mockCheckers(1, &net, engine, store),
+		mockCheckers(1, &net, engine, store, app),
 		store,
 		engine,
 		nil,

--- a/integration/assembly.go
+++ b/integration/assembly.go
@@ -9,21 +9,28 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/Fantom-foundation/go-lachesis/app"
 	"github.com/Fantom-foundation/go-lachesis/gossip"
 	"github.com/Fantom-foundation/go-lachesis/kvdb/flushable"
 	"github.com/Fantom-foundation/go-lachesis/poset"
 )
 
 // MakeEngine makes consensus engine from config.
-func MakeEngine(dataDir string, gossipCfg *gossip.Config) (*poset.Poset, *gossip.Store) {
+func MakeEngine(dataDir string, gossipCfg *gossip.Config) (*poset.Poset, *app.Store, *gossip.Store) {
 	dbs := flushable.NewSyncedPool(dbProducer(dataDir))
 
+	adb := app.NewStore(dbs, app.DefaultStoreConfig())
 	gdb := gossip.NewStore(dbs, gossipCfg.StoreConfig)
 	cdb := poset.NewStore(dbs, poset.DefaultStoreConfig())
 
 	// write genesis
 
-	genesisAtropos, genesisState, isNew, err := gdb.ApplyGenesis(&gossipCfg.Net)
+	state, isNew, err := adb.ApplyGenesis(&gossipCfg.Net)
+	if err != nil {
+		utils.Fatalf("Failed to write App genesis state: %v", err)
+	}
+
+	genesisAtropos, genesisState, isNew, err := gdb.ApplyGenesis(&gossipCfg.Net, state)
 	if err != nil {
 		utils.Fatalf("Failed to write Gossip genesis state: %v", err)
 	}
@@ -47,7 +54,7 @@ func MakeEngine(dataDir string, gossipCfg *gossip.Config) (*poset.Poset, *gossip
 	// create consensus
 	engine := poset.New(gossipCfg.Net.Dag, cdb, gdb)
 
-	return engine, gdb
+	return engine, adb, gdb
 }
 
 // SetAccountKey sets key into accounts manager and unlocks it with pswd.

--- a/integration/assembly.go
+++ b/integration/assembly.go
@@ -19,7 +19,12 @@ import (
 func MakeEngine(dataDir string, gossipCfg *gossip.Config) (*poset.Poset, *app.Store, *gossip.Store) {
 	dbs := flushable.NewSyncedPool(dbProducer(dataDir))
 
-	adb := app.NewStore(dbs, app.DefaultStoreConfig())
+	appStoreConfig := app.StoreConfig{
+		ReceiptsCacheSize:   gossipCfg.ReceiptsCacheSize,
+		DelegatorsCacheSize: gossipCfg.DelegatorsCacheSize,
+		StakersCacheSize:    gossipCfg.StakersCacheSize,
+	}
+	adb := app.NewStore(dbs, appStoreConfig)
 	gdb := gossip.NewStore(dbs, gossipCfg.StoreConfig)
 	cdb := poset.NewStore(dbs, poset.DefaultStoreConfig())
 

--- a/integration/assembly.go
+++ b/integration/assembly.go
@@ -30,7 +30,7 @@ func MakeEngine(dataDir string, gossipCfg *gossip.Config) (*poset.Poset, *app.St
 
 	// write genesis
 
-	state, isNew, err := adb.ApplyGenesis(&gossipCfg.Net)
+	state, _, err := adb.ApplyGenesis(&gossipCfg.Net)
 	if err != nil {
 		utils.Fatalf("Failed to write App genesis state: %v", err)
 	}

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -13,7 +13,7 @@ import (
 func NewIntegration(ctx *adapters.ServiceContext, network lachesis.Config) *gossip.Service {
 	gossipCfg := gossip.DefaultConfig(network)
 
-	engine, gdb := MakeEngine(ctx.Config.DataDir, &gossipCfg)
+	engine, adb, gdb := MakeEngine(ctx.Config.DataDir, &gossipCfg)
 
 	coinbase := SetAccountKey(
 		ctx.NodeContext.AccountManager,
@@ -25,7 +25,7 @@ func NewIntegration(ctx *adapters.ServiceContext, network lachesis.Config) *goss
 	gossipCfg.Emitter.MaxEmitInterval = 3 * time.Second
 	gossipCfg.Emitter.SelfForkProtectionInterval = 0
 
-	svc, err := gossip.NewService(ctx.NodeContext, &gossipCfg, gdb, engine)
+	svc, err := gossip.NewService(ctx.NodeContext, &gossipCfg, gdb, engine, adb)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Application-related fields are moved from gossip.Store to new app.Store.
It is still compatible with prev db stucture.

We are trying to split a solid gossip to consensus (poset + p2p + mempool) and application (EVM + SFC-economy). Potentially, consensus will be able to work with another ABCI-application.