### PR TITLE
Separate off-chain DB

### DIFF
--- a/cmd/db-check/events.go
+++ b/cmd/db-check/events.go
@@ -11,7 +11,10 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/kvdb/table"
 )
 
-func checkEvents(db kvdb.KeyValueStore) {
+func checkEvents(p kvdb.DbProducer) {
+	db := p.OpenDb("gossip-main")
+	defer db.Close()
+
 	t := table.New(db, []byte("e"))
 
 	it := t.NewIterator()

--- a/cmd/db-check/main.go
+++ b/cmd/db-check/main.go
@@ -19,9 +19,9 @@ func main() {
 	}
 
 	p := leveldb.NewProducer(dir)
-	db := p.OpenDb("gossip-main")
-	defer db.Close()
 
-	//checkPacks(db)
-	checkEvents(db)
+	//checkPacks(p)
+	//checkEvents(p)
+	checkAfterMigration(p)
+
 }

--- a/cmd/db-check/migrations.go
+++ b/cmd/db-check/migrations.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/Fantom-foundation/go-lachesis/kvdb"
+	"github.com/Fantom-foundation/go-lachesis/kvdb/table"
+)
+
+func checkAfterMigration(p kvdb.DbProducer) {
+	mainDb := p.OpenDb("gossip-main")
+	defer mainDb.Close()
+
+	old1 := table.New(mainDb, []byte("p"))
+	printData("old1", old1, []byte("serverPool"))
+
+	old2 := table.New(mainDb, []byte("Z"))
+	printData("old2", old2, nil)
+
+	servDb := p.OpenDb("gossip-serv")
+	defer servDb.Close()
+
+	dst := table.New(servDb, []byte("Z"))
+	printData("dst", dst, nil)
+}
+
+func printData(dsc string, src kvdb.KeyValueStore, prefix []byte) error {
+	fmt.Println(">>>> " + dsc)
+
+	it := src.NewIteratorWithPrefix(prefix)
+	defer it.Release()
+
+	for i := 0; it.Next(); i++ {
+		fmt.Printf("%d) %s - %#v\n", i, string(it.Key()), it.Value())
+	}
+
+	return nil
+}

--- a/cmd/db-check/migrations.go
+++ b/cmd/db-check/migrations.go
@@ -12,16 +12,23 @@ func checkAfterMigration(p kvdb.DbProducer) {
 	defer mainDb.Close()
 
 	old1 := table.New(mainDb, []byte("p"))
-	printData("old1", old1, []byte("serverPool"))
+	mustPrintData("old1", old1, []byte("serverPool"))
 
 	old2 := table.New(mainDb, []byte("Z"))
-	printData("old2", old2, nil)
+	mustPrintData("old2", old2, nil)
 
 	servDb := p.OpenDb("gossip-serv")
 	defer servDb.Close()
 
 	dst := table.New(servDb, []byte("Z"))
-	printData("dst", dst, nil)
+	mustPrintData("dst", dst, nil)
+}
+
+func mustPrintData(dsc string, src kvdb.KeyValueStore, prefix []byte) {
+	err := printData(dsc, src, prefix)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func printData(dsc string, src kvdb.KeyValueStore, prefix []byte) error {
@@ -34,5 +41,5 @@ func printData(dsc string, src kvdb.KeyValueStore, prefix []byte) error {
 		fmt.Printf("%d) %s - %#v\n", i, string(it.Key()), it.Value())
 	}
 
-	return nil
+	return it.Error()
 }

--- a/cmd/db-check/packs.go
+++ b/cmd/db-check/packs.go
@@ -12,7 +12,10 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/kvdb/table"
 )
 
-func checkPacks(db kvdb.KeyValueStore) {
+func checkPacks(p kvdb.DbProducer) {
+	db := p.OpenDb("gossip-main")
+	defer db.Close()
+
 	t := table.New(db, []byte("p"))
 
 	it := t.NewIterator()

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -151,7 +151,7 @@ func NewService(ctx *node.ServiceContext, config *Config, store *Store, engine C
 
 	// create server pool
 	trustedNodes := []string{}
-	svc.serverPool = newServerPool(store.table.Peers, svc.done, &svc.wg, trustedNodes)
+	svc.serverPool = newServerPool(store.service.Peers, svc.done, &svc.wg, trustedNodes)
 
 	// create tx pool
 	stateReader := svc.GetEvmStateReader()

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -217,24 +217,29 @@ func (s *Store) dropTable(it ethdb.Iterator, t kvdb.KeyValueStore) {
 	}
 }
 
-func (s *Store) move(src, dst kvdb.KeyValueStore, prefix []byte) error {
+func (s *Store) move(src, dst kvdb.KeyValueStore, prefix []byte) (err error) {
 	keys := make([][]byte, 0, 500) // don't write during iteration
 
 	it := src.NewIteratorWithPrefix(prefix)
 	defer it.Release()
 
 	for it.Next() {
-		err := dst.Put(it.Key(), it.Value())
+		err = dst.Put(it.Key(), it.Value())
 		if err != nil {
-			return err
+			return
 		}
 		keys = append(keys, it.Key())
 	}
 
+	err = it.Error()
+	if err != nil {
+		return
+	}
+
 	for _, key := range keys {
-		err := src.Delete(key)
+		err = src.Delete(key)
 		if err != nil {
-			return err
+			return
 		}
 	}
 

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -110,6 +110,9 @@ func NewStore(dbs *flushable.SyncedPool, cfg StoreConfig) *Store {
 
 	s.migrate()
 
+	// for compability with db before commit 591ede6
+	s.rmPrefix(s.table.PackInfos, "serverPool")
+
 	return s
 }
 
@@ -200,6 +203,13 @@ func (s *Store) has(table kvdb.KeyValueStore, key []byte) bool {
 		s.Log.Crit("Failed to get key", "err", err)
 	}
 	return res
+}
+
+func (s *Store) rmPrefix(t kvdb.KeyValueStore, prefix string) {
+	it := t.NewIteratorWithPrefix([]byte(prefix))
+	defer it.Release()
+
+	s.dropTable(it, t)
 }
 
 func (s *Store) dropTable(it ethdb.Iterator, t kvdb.KeyValueStore) {

--- a/gossip/store_migration.go
+++ b/gossip/store_migration.go
@@ -23,8 +23,17 @@ func (s *Store) migrations() *migration.Migration {
 		Begin("lachesis-gossip-store").
 		Next("service db",
 			func() error {
-				old := table.New(s.mainDb, []byte("Z"))
 				dst := s.service.Peers
-				return s.move(old, dst)
+
+				old1 := s.table.PackInfos
+				err := s.move(old1, dst, []byte("serverPool"))
+				if err != nil {
+					return err
+				}
+
+				old2 := table.New(s.mainDb, []byte("Z"))
+				err = s.move(old2, dst, nil)
+
+				return err
 			})
 }

--- a/gossip/store_migration.go
+++ b/gossip/store_migration.go
@@ -2,6 +2,7 @@ package gossip
 
 import (
 	"github.com/Fantom-foundation/go-lachesis/kvdb"
+	"github.com/Fantom-foundation/go-lachesis/kvdb/table"
 	"github.com/Fantom-foundation/go-lachesis/utils/migration"
 )
 
@@ -15,9 +16,15 @@ func (s *Store) migrate() {
 	if err != nil {
 		s.Log.Crit("gossip store commit", "err", err)
 	}
-
 }
 
 func (s *Store) migrations() *migration.Migration {
-	return migration.Begin("lachesis-gossip-store")
+	return migration.
+		Begin("lachesis-gossip-store").
+		Next("service db",
+			func() error {
+				old := table.New(s.mainDb, []byte("Z"))
+				dst := s.service.Peers
+				return s.move(old, dst)
+			})
 }

--- a/utils/migration/migration.go
+++ b/utils/migration/migration.go
@@ -52,6 +52,7 @@ func (m *Migration) Id() string {
 
 func (m *Migration) Exec(curr IdProducer) error {
 	if m.exec == nil {
+		// only 1st empty migration
 		return nil
 	}
 
@@ -68,9 +69,10 @@ func (m *Migration) Exec(curr IdProducer) error {
 
 	err = m.exec()
 	if err != nil {
-		log.Error(m.name+" migration failed", "err", err)
+		log.Error("'"+m.name+"' migration failed", "err", err)
 		return err
 	}
+	log.Warn("'" + m.name + "' migration has been applied")
 
 	curr.SetId(myId)
 	return nil


### PR DESCRIPTION
Use a different DB for storing off-chain info, such as peers saving in `gossip/serverpool.go`.
First using of db migrations.