### PR TITLE
Switch to v1.9.8-ftm-0.4 go-etehereum with toMoniker method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,4 +69,4 @@ require (
 
 replace gopkg.in/urfave/cli.v1 => github.com/urfave/cli v1.20.0
 
-replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum v1.9.8-ftm-0.3
+replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum v1.9.8-ftm-0.4


### PR DESCRIPTION
Switch to new v1.9.8-ftm-0.4 version of go-ethereum