### PR TITLE
EthAPIBackend split

### DIFF
--- a/app/ethapi_backend.go
+++ b/app/ethapi_backend.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 
 	"github.com/Fantom-foundation/go-lachesis/inter"
@@ -29,6 +30,10 @@ func (b *EthAPIBackend) ChainDb() ethdb.Database {
 
 func (b *EthAPIBackend) EvmLogIndex() *topicsdb.Index {
 	return b.app.store.EvmLogs()
+}
+
+func (b *EthAPIBackend) GetReceipts(n idx.Block) types.Receipts {
+	return b.app.store.GetReceipts(n)
 }
 
 // GetValidationScore returns staker's ValidationScore.

--- a/app/ethapi_backend.go
+++ b/app/ethapi_backend.go
@@ -1,8 +1,13 @@
 package app
 
 import (
+	"context"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/ethdb"
 
+	"github.com/Fantom-foundation/go-lachesis/inter"
+	"github.com/Fantom-foundation/go-lachesis/inter/idx"
 	"github.com/Fantom-foundation/go-lachesis/topicsdb"
 )
 
@@ -22,4 +27,34 @@ func (b *EthAPIBackend) ChainDb() ethdb.Database {
 
 func (b *EthAPIBackend) EvmLogIndex() *topicsdb.Index {
 	return b.app.store.EvmLogs()
+}
+
+// GetValidationScore returns staker's ValidationScore.
+func (b *EthAPIBackend) GetValidationScore(ctx context.Context, stakerID idx.StakerID) (*big.Int, error) {
+	if !b.app.store.HasSfcStaker(stakerID) {
+		return nil, nil
+	}
+	return b.app.store.GetActiveValidationScore(stakerID), nil
+}
+
+// GetOriginationScore returns staker's OriginationScore.
+func (b *EthAPIBackend) GetOriginationScore(ctx context.Context, stakerID idx.StakerID) (*big.Int, error) {
+	if !b.app.store.HasSfcStaker(stakerID) {
+		return nil, nil
+	}
+	return b.app.store.GetActiveOriginationScore(stakerID), nil
+}
+
+// GetStakerPoI returns staker's PoI.
+func (b *EthAPIBackend) GetStakerPoI(ctx context.Context, stakerID idx.StakerID) (*big.Int, error) {
+	if !b.app.store.HasSfcStaker(stakerID) {
+		return nil, nil
+	}
+	return b.app.store.GetStakerPOI(stakerID), nil
+}
+
+// GetDowntime returns staker's Downtime.
+func (b *EthAPIBackend) GetDowntime(ctx context.Context, stakerID idx.StakerID) (idx.Block, inter.Timestamp, error) {
+	missed := b.app.store.GetBlocksMissed(stakerID)
+	return missed.Num, missed.Period, nil
 }

--- a/app/ethapi_backend.go
+++ b/app/ethapi_backend.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 
 	"github.com/Fantom-foundation/go-lachesis/inter"
 	"github.com/Fantom-foundation/go-lachesis/inter/idx"
+	"github.com/Fantom-foundation/go-lachesis/inter/sfctype"
 	"github.com/Fantom-foundation/go-lachesis/topicsdb"
 )
 
@@ -57,4 +59,24 @@ func (b *EthAPIBackend) GetStakerPoI(ctx context.Context, stakerID idx.StakerID)
 func (b *EthAPIBackend) GetDowntime(ctx context.Context, stakerID idx.StakerID) (idx.Block, inter.Timestamp, error) {
 	missed := b.app.store.GetBlocksMissed(stakerID)
 	return missed.Num, missed.Period, nil
+}
+
+// GetDelegator returns SFC delegator info
+func (b *EthAPIBackend) GetDelegator(ctx context.Context, addr common.Address) (*sfctype.SfcDelegator, error) {
+	return b.app.store.GetSfcDelegator(addr), nil
+}
+
+// GetDelegatorClaimedRewards returns sum of claimed rewards in past, by this delegator
+func (b *EthAPIBackend) GetDelegatorClaimedRewards(ctx context.Context, addr common.Address) (*big.Int, error) {
+	return b.app.store.GetDelegatorClaimedRewards(addr), nil
+}
+
+// GetStakerClaimedRewards returns sum of claimed rewards in past, by this staker
+func (b *EthAPIBackend) GetStakerClaimedRewards(ctx context.Context, stakerID idx.StakerID) (*big.Int, error) {
+	return b.app.store.GetStakerClaimedRewards(stakerID), nil
+}
+
+// GetStakerDelegatorsClaimedRewards returns sum of claimed rewards in past, by this delegators of this staker
+func (b *EthAPIBackend) GetStakerDelegatorsClaimedRewards(ctx context.Context, stakerID idx.StakerID) (*big.Int, error) {
+	return b.app.store.GetStakerDelegatorsClaimedRewards(stakerID), nil
 }

--- a/app/ethapi_backend.go
+++ b/app/ethapi_backend.go
@@ -85,3 +85,23 @@ func (b *EthAPIBackend) GetStakerClaimedRewards(ctx context.Context, stakerID id
 func (b *EthAPIBackend) GetStakerDelegatorsClaimedRewards(ctx context.Context, stakerID idx.StakerID) (*big.Int, error) {
 	return b.app.store.GetStakerDelegatorsClaimedRewards(stakerID), nil
 }
+
+// HasSfcStaker provides store's method.
+func (b *EthAPIBackend) HasSfcStaker(stakerID idx.StakerID) bool {
+	return b.app.store.HasSfcStaker(stakerID)
+}
+
+// GetSfcStaker provides store's method.
+func (b *EthAPIBackend) GetSfcStaker(stakerID idx.StakerID) *sfctype.SfcStaker {
+	return b.app.store.GetSfcStaker(stakerID)
+}
+
+// ForEachSfcStaker provides store's method.
+func (b *EthAPIBackend) ForEachSfcStaker(do func(sfctype.SfcStakerAndID)) {
+	b.app.store.ForEachSfcStaker(do)
+}
+
+// ForEachSfcDelegator provides store's method.
+func (b *EthAPIBackend) ForEachSfcDelegator(do func(sfctype.SfcDelegatorAndAddr)) {
+	b.app.store.ForEachSfcDelegator(do)
+}

--- a/app/ethapi_backend.go
+++ b/app/ethapi_backend.go
@@ -1,5 +1,11 @@
 package app
 
+import (
+	"github.com/ethereum/go-ethereum/ethdb"
+
+	"github.com/Fantom-foundation/go-lachesis/topicsdb"
+)
+
 // EthAPIBackend provides methods for ethapi.Backend
 type EthAPIBackend struct {
 	app *App
@@ -8,4 +14,12 @@ type EthAPIBackend struct {
 // EthAPIBackend getter
 func (a *App) EthAPIBackend() *EthAPIBackend {
 	return &EthAPIBackend{a}
+}
+
+func (b *EthAPIBackend) ChainDb() ethdb.Database {
+	return b.app.store.EvmTable()
+}
+
+func (b *EthAPIBackend) EvmLogIndex() *topicsdb.Index {
+	return b.app.store.EvmLogs()
 }

--- a/app/ethapi_backend.go
+++ b/app/ethapi_backend.go
@@ -1,0 +1,11 @@
+package app
+
+// EthAPIBackend provides methods for ethapi.Backend
+type EthAPIBackend struct {
+	app *App
+}
+
+// EthAPIBackend getter
+func (a *App) EthAPIBackend() *EthAPIBackend {
+	return &EthAPIBackend{a}
+}

--- a/app/provided_store.go
+++ b/app/provided_store.go
@@ -50,26 +50,6 @@ func (a App) HasEpochValidator(epoch idx.Epoch, stakerID idx.StakerID) bool {
 	return a.store.HasEpochValidator(epoch, stakerID)
 }
 
-//  provides store's method.
-func (a App) GetActiveValidationScore(stakerID idx.StakerID) *big.Int {
-	return a.store.GetActiveValidationScore(stakerID)
-}
-
-// GetActiveOriginationScore provides store's method.
-func (a App) GetActiveOriginationScore(stakerID idx.StakerID) *big.Int {
-	return a.store.GetActiveOriginationScore(stakerID)
-}
-
-//  provides store's method.
-func (a App) GetStakerPOI(stakerID idx.StakerID) *big.Int {
-	return a.store.GetStakerPOI(stakerID)
-}
-
-// GetBlocksMissed provides store's method.
-func (a App) GetBlocksMissed(stakerID idx.StakerID) BlocksMissed {
-	return a.store.GetBlocksMissed(stakerID)
-}
-
 // GetSfcStaker provides store's method.
 func (a App) GetSfcStaker(stakerID idx.StakerID) *sfctype.SfcStaker {
 	return a.store.GetSfcStaker(stakerID)

--- a/app/provided_store.go
+++ b/app/provided_store.go
@@ -1,8 +1,6 @@
 package app
 
 import (
-	"math/big"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -63,24 +61,4 @@ func (a App) ForEachSfcStaker(do func(sfctype.SfcStakerAndID)) {
 // ForEachSfcDelegator provides store's method.
 func (a App) ForEachSfcDelegator(do func(sfctype.SfcDelegatorAndAddr)) {
 	a.store.ForEachSfcDelegator(do)
-}
-
-// GetSfcDelegator provides store's method.
-func (a App) GetSfcDelegator(addr common.Address) *sfctype.SfcDelegator {
-	return a.store.GetSfcDelegator(addr)
-}
-
-// GetDelegatorClaimedRewards provides store's method.
-func (a App) GetDelegatorClaimedRewards(addr common.Address) *big.Int {
-	return a.store.GetDelegatorClaimedRewards(addr)
-}
-
-// GetStakerClaimedRewards provides store's method.
-func (a App) GetStakerClaimedRewards(stakerID idx.StakerID) *big.Int {
-	return a.store.GetStakerClaimedRewards(stakerID)
-}
-
-// GetStakerDelegatorsClaimedRewards provides store's method.
-func (a App) GetStakerDelegatorsClaimedRewards(stakerID idx.StakerID) *big.Int {
-	return a.store.GetStakerDelegatorsClaimedRewards(stakerID)
 }

--- a/app/provided_store.go
+++ b/app/provided_store.go
@@ -28,11 +28,6 @@ func (a App) SetReceipts(n idx.Block, receipts types.Receipts) {
 	a.store.SetReceipts(n, receipts)
 }
 
-//  provides store's method.
-func (a App) GetReceipts(n idx.Block) types.Receipts {
-	return a.store.GetReceipts(n)
-}
-
 // StateDB provides store's method.
 func (a App) StateDB(from common.Hash) *state.StateDB {
 	return a.store.StateDB(from)

--- a/app/provided_store.go
+++ b/app/provided_store.go
@@ -13,6 +13,11 @@ import (
  * NOTE: all the methods are temporary and will be refactored during Tendermint implementation.
  */
 
+// HasEpochValidator provides store's method.
+func (a App) HasEpochValidator(epoch idx.Epoch, stakerID idx.StakerID) bool {
+	return a.store.HasEpochValidator(epoch, stakerID)
+}
+
 // GetEpochValidators provides store's method.
 func (a App) GetEpochValidators(epoch idx.Epoch) []sfctype.SfcStakerAndID {
 	return a.store.GetEpochValidators(epoch)
@@ -31,29 +36,4 @@ func (a App) SetReceipts(n idx.Block, receipts types.Receipts) {
 // StateDB provides store's method.
 func (a App) StateDB(from common.Hash) *state.StateDB {
 	return a.store.StateDB(from)
-}
-
-// HasSfcStaker provides store's method.
-func (a App) HasSfcStaker(stakerID idx.StakerID) bool {
-	return a.store.HasSfcStaker(stakerID)
-}
-
-// HasEpochValidator provides store's method.
-func (a App) HasEpochValidator(epoch idx.Epoch, stakerID idx.StakerID) bool {
-	return a.store.HasEpochValidator(epoch, stakerID)
-}
-
-// GetSfcStaker provides store's method.
-func (a App) GetSfcStaker(stakerID idx.StakerID) *sfctype.SfcStaker {
-	return a.store.GetSfcStaker(stakerID)
-}
-
-// ForEachSfcStaker provides store's method.
-func (a App) ForEachSfcStaker(do func(sfctype.SfcStakerAndID)) {
-	a.store.ForEachSfcStaker(do)
-}
-
-// ForEachSfcDelegator provides store's method.
-func (a App) ForEachSfcDelegator(do func(sfctype.SfcDelegatorAndAddr)) {
-	a.store.ForEachSfcDelegator(do)
 }

--- a/app/provided_store.go
+++ b/app/provided_store.go
@@ -6,11 +6,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethdb"
 
 	"github.com/Fantom-foundation/go-lachesis/inter/idx"
 	"github.com/Fantom-foundation/go-lachesis/inter/sfctype"
-	"github.com/Fantom-foundation/go-lachesis/topicsdb"
 )
 
 /*
@@ -40,16 +38,6 @@ func (a App) GetReceipts(n idx.Block) types.Receipts {
 // StateDB provides store's method.
 func (a App) StateDB(from common.Hash) *state.StateDB {
 	return a.store.StateDB(from)
-}
-
-// EvmTable provides store's method.
-func (a App) EvmTable() ethdb.Database {
-	return a.store.EvmTable()
-}
-
-//  provides store's method.
-func (a App) EvmLogs() *topicsdb.Index {
-	return a.store.EvmLogs()
 }
 
 // HasSfcStaker provides store's method.

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -124,7 +124,7 @@ const (
 type stateReader interface {
 	CurrentBlock() *EvmBlock
 	GetBlock(hash common.Hash, number uint64) *EvmBlock
-	StateAt(root common.Hash) (*state.StateDB, error)
+	StateAt(root common.Hash) *state.StateDB
 
 	SubscribeNewBlock(ch chan<- ChainHeadNotify) notify.Subscription
 }
@@ -1135,11 +1135,8 @@ func (pool *TxPool) reset(oldHead, newHead *EvmHeader) {
 	if newHead == nil {
 		newHead = pool.chain.CurrentBlock().Header() // Special case during testing
 	}
-	statedb, err := pool.chain.StateAt(newHead.Root)
-	if err != nil {
-		log.Error("Failed to reset txpool state", "err", err)
-		return
-	}
+	statedb := pool.chain.StateAt(newHead.Root)
+
 	pool.currentState = statedb
 	pool.pendingNonces = newTxNoncer(statedb)
 	pool.currentMaxGas = newHead.GasLimit

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -75,8 +75,8 @@ func (bc *testBlockChain) GetBlock(hash common.Hash, number uint64) *EvmBlock {
 	return bc.CurrentBlock()
 }
 
-func (bc *testBlockChain) StateAt(common.Hash) (*state.StateDB, error) {
-	return bc.statedb, nil
+func (bc *testBlockChain) StateAt(common.Hash) *state.StateDB {
+	return bc.statedb
 }
 
 func (bc *testBlockChain) SubscribeNewBlock(ch chan<- ChainHeadNotify) notify.Subscription {

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -480,7 +480,7 @@ func (b *EthAPIBackend) GetEpochStats(ctx context.Context, requestedEpoch rpc.Bl
 
 // GetRewardWeights returns staker's reward weights.
 func (b *EthAPIBackend) GetRewardWeights(ctx context.Context, stakerID idx.StakerID) (*big.Int, *big.Int, error) {
-	if !b.svc.abciApp.HasSfcStaker(stakerID) {
+	if !b.HasSfcStaker(stakerID) {
 		return nil, nil, nil
 	}
 	header := b.state.CurrentHeader()
@@ -498,7 +498,7 @@ func (b *EthAPIBackend) GetRewardWeights(ctx context.Context, stakerID idx.Stake
 
 // GetStaker returns SFC staker's info
 func (b *EthAPIBackend) GetStaker(ctx context.Context, stakerID idx.StakerID) (*sfctype.SfcStaker, error) {
-	staker := b.svc.abciApp.GetSfcStaker(stakerID)
+	staker := b.GetSfcStaker(stakerID)
 	if staker == nil {
 		return nil, nil
 	}
@@ -523,7 +523,7 @@ func (b *EthAPIBackend) GetStakers(ctx context.Context) ([]sfctype.SfcStakerAndI
 	defer b.svc.engineMu.RUnlock()
 
 	stakers := make([]sfctype.SfcStakerAndID, 0, 200)
-	b.svc.abciApp.ForEachSfcStaker(func(it sfctype.SfcStakerAndID) {
+	b.ForEachSfcStaker(func(it sfctype.SfcStakerAndID) {
 		it.Staker.IsValidator = b.svc.engine.GetValidators().Exists(it.StakerID)
 		stakers = append(stakers, it)
 	})
@@ -537,7 +537,7 @@ func (b *EthAPIBackend) GetDelegatorsOf(ctx context.Context, stakerID idx.Staker
 
 	delegators := make([]sfctype.SfcDelegatorAndAddr, 0, 200)
 	// TODO add additional DB index
-	b.svc.abciApp.ForEachSfcDelegator(func(it sfctype.SfcDelegatorAndAddr) {
+	b.ForEachSfcDelegator(func(it sfctype.SfcDelegatorAndAddr) {
 		if it.Delegator.ToStakerID == stakerID {
 			delegators = append(delegators, it)
 		}

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -102,7 +102,8 @@ func (b *EthAPIBackend) StateAndHeaderByNumber(ctx context.Context, number rpc.B
 	if header == nil {
 		return nil, nil, errors.New("header not found")
 	}
-	stateDb := b.svc.abciApp.StateDB(header.Root)
+
+	stateDb := b.state.StateAt(header.Root)
 	return stateDb, header, nil
 }
 
@@ -478,7 +479,7 @@ func (b *EthAPIBackend) GetEpochStats(ctx context.Context, requestedEpoch rpc.Bl
 
 	// read total reward weights from SFC contract
 	header := b.state.CurrentHeader()
-	statedb := b.svc.abciApp.StateDB(header.Root)
+	statedb := b.state.StateAt(header.Root)
 
 	epochPosition := sfcpos.EpochSnapshot(epoch)
 	stats.TotalBaseRewardWeight = statedb.GetState(sfc.ContractAddress, epochPosition.TotalBaseRewardWeight()).Big()
@@ -517,7 +518,7 @@ func (b *EthAPIBackend) GetRewardWeights(ctx context.Context, stakerID idx.Stake
 		return nil, nil, nil
 	}
 	header := b.state.CurrentHeader()
-	statedb := b.svc.abciApp.StateDB(header.Root)
+	statedb := b.state.StateAt(header.Root)
 
 	// read reward weight from SFC contract
 	epoch := b.svc.engine.GetEpoch()
@@ -548,7 +549,7 @@ func (b *EthAPIBackend) GetStaker(ctx context.Context, stakerID idx.StakerID) (*
 // GetStakerID returns SFC staker's Id by address
 func (b *EthAPIBackend) GetStakerID(ctx context.Context, addr common.Address) (idx.StakerID, error) {
 	header := b.state.CurrentHeader()
-	statedb := b.svc.abciApp.StateDB(header.Root)
+	statedb := b.state.StateAt(header.Root)
 
 	position := sfcpos.StakerID(addr)
 	stakerID256 := statedb.GetState(sfc.ContractAddress, position)

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -282,12 +282,12 @@ func (b *EthAPIBackend) GetReceiptsByNumber(ctx context.Context, number rpc.Bloc
 		number = rpc.BlockNumber(header.Number.Uint64())
 	}
 
-	receipts := b.svc.abciApp.GetReceipts(idx.Block(number))
+	receipts := b.GetReceipts(idx.Block(number))
 	return receipts, nil
 }
 
-// GetReceipts retrieves the receipts for all transactions in a given block.
-func (b *EthAPIBackend) GetReceipts(ctx context.Context, block common.Hash) (types.Receipts, error) {
+// GetReceiptsByHash returns receipts by block hash.
+func (b *EthAPIBackend) GetReceiptsByHash(ctx context.Context, block common.Hash) (types.Receipts, error) {
 	number := b.svc.store.GetBlockIndex(hash.Event(block))
 	if number == nil {
 		return nil, nil
@@ -297,7 +297,7 @@ func (b *EthAPIBackend) GetReceipts(ctx context.Context, block common.Hash) (typ
 }
 
 func (b *EthAPIBackend) GetLogs(ctx context.Context, block common.Hash) ([][]*types.Log, error) {
-	receipts, err := b.GetReceipts(ctx, block)
+	receipts, err := b.GetReceiptsByHash(ctx, block)
 	if receipts == nil || err != nil {
 		return nil, err
 	}

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	errors2 "github.com/pkg/errors"
 
+	"github.com/Fantom-foundation/go-lachesis/app"
 	"github.com/Fantom-foundation/go-lachesis/ethapi"
 	"github.com/Fantom-foundation/go-lachesis/evmcore"
 	"github.com/Fantom-foundation/go-lachesis/gossip/gasprice"
@@ -41,10 +42,11 @@ var ErrNotImplemented = func(name string) error { return errors.New(name + " met
 
 // EthAPIBackend implements ethapi.Backend.
 type EthAPIBackend struct {
-	extRPCEnabled bool
+	*app.EthAPIBackend
 	svc           *Service
 	state         *EvmStateReader
 	gpo           *gasprice.Oracle
+	extRPCEnabled bool
 }
 
 // ChainConfig returns the active chain configuration.

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -478,30 +478,6 @@ func (b *EthAPIBackend) GetEpochStats(ctx context.Context, requestedEpoch rpc.Bl
 	return stats, nil
 }
 
-// GetValidationScore returns staker's ValidationScore.
-func (b *EthAPIBackend) GetValidationScore(ctx context.Context, stakerID idx.StakerID) (*big.Int, error) {
-	if !b.svc.abciApp.HasSfcStaker(stakerID) {
-		return nil, nil
-	}
-	return b.svc.abciApp.GetActiveValidationScore(stakerID), nil
-}
-
-// GetOriginationScore returns staker's OriginationScore.
-func (b *EthAPIBackend) GetOriginationScore(ctx context.Context, stakerID idx.StakerID) (*big.Int, error) {
-	if !b.svc.abciApp.HasSfcStaker(stakerID) {
-		return nil, nil
-	}
-	return b.svc.abciApp.GetActiveOriginationScore(stakerID), nil
-}
-
-// GetStakerPoI returns staker's PoI.
-func (b *EthAPIBackend) GetStakerPoI(ctx context.Context, stakerID idx.StakerID) (*big.Int, error) {
-	if !b.svc.abciApp.HasSfcStaker(stakerID) {
-		return nil, nil
-	}
-	return b.svc.abciApp.GetStakerPOI(stakerID), nil
-}
-
 // GetRewardWeights returns staker's reward weights.
 func (b *EthAPIBackend) GetRewardWeights(ctx context.Context, stakerID idx.StakerID) (*big.Int, *big.Int, error) {
 	if !b.svc.abciApp.HasSfcStaker(stakerID) {
@@ -518,12 +494,6 @@ func (b *EthAPIBackend) GetRewardWeights(ctx context.Context, stakerID idx.Stake
 	txRewardWeight256 := statedb.GetState(sfc.ContractAddress, validatorPosition.TxRewardWeight())
 
 	return new(big.Int).SetBytes(baseRewardWeight256.Bytes()), new(big.Int).SetBytes(txRewardWeight256.Bytes()), nil
-}
-
-// GetDowntime returns staker's Downtime.
-func (b *EthAPIBackend) GetDowntime(ctx context.Context, stakerID idx.StakerID) (idx.Block, inter.Timestamp, error) {
-	missed := b.svc.abciApp.GetBlocksMissed(stakerID)
-	return missed.Num, missed.Period, nil
 }
 
 // GetStaker returns SFC staker's info

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -545,26 +545,6 @@ func (b *EthAPIBackend) GetDelegatorsOf(ctx context.Context, stakerID idx.Staker
 	return delegators, nil
 }
 
-// GetDelegator returns SFC delegator info
-func (b *EthAPIBackend) GetDelegator(ctx context.Context, addr common.Address) (*sfctype.SfcDelegator, error) {
-	return b.svc.abciApp.GetSfcDelegator(addr), nil
-}
-
-// GetDelegatorClaimedRewards returns sum of claimed rewards in past, by this delegator
-func (b *EthAPIBackend) GetDelegatorClaimedRewards(ctx context.Context, addr common.Address) (*big.Int, error) {
-	return b.svc.abciApp.GetDelegatorClaimedRewards(addr), nil
-}
-
-// GetStakerClaimedRewards returns sum of claimed rewards in past, by this staker
-func (b *EthAPIBackend) GetStakerClaimedRewards(ctx context.Context, stakerID idx.StakerID) (*big.Int, error) {
-	return b.svc.abciApp.GetStakerClaimedRewards(stakerID), nil
-}
-
-// GetStakerDelegatorsClaimedRewards returns sum of claimed rewards in past, by this delegators of this staker
-func (b *EthAPIBackend) GetStakerDelegatorsClaimedRewards(ctx context.Context, stakerID idx.StakerID) (*big.Int, error) {
-	return b.svc.abciApp.GetStakerDelegatorsClaimedRewards(stakerID), nil
-}
-
 // GetEventTime returns estimation of when event was created
 func (b *EthAPIBackend) GetEventTime(ctx context.Context, id hash.Event, arrivalTime bool) inter.Timestamp {
 	var t inter.Timestamp

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/ethdb"
 	notify "github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
@@ -34,7 +33,6 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/inter/sfctype"
 	"github.com/Fantom-foundation/go-lachesis/lachesis/genesis/sfc"
 	"github.com/Fantom-foundation/go-lachesis/lachesis/genesis/sfc/sfcpos"
-	"github.com/Fantom-foundation/go-lachesis/topicsdb"
 	"github.com/Fantom-foundation/go-lachesis/tracing"
 )
 
@@ -430,10 +428,6 @@ func (b *EthAPIBackend) SuggestPrice(ctx context.Context) (*big.Int, error) {
 	return b.gpo.SuggestPrice(ctx)
 }
 
-func (b *EthAPIBackend) ChainDb() ethdb.Database {
-	return b.svc.abciApp.EvmTable()
-}
-
 func (b *EthAPIBackend) AccountManager() *accounts.Manager {
 	return b.svc.AccountManager()
 }
@@ -444,10 +438,6 @@ func (b *EthAPIBackend) ExtRPCEnabled() bool {
 
 func (b *EthAPIBackend) RPCGasCap() *big.Int {
 	return b.svc.config.RPCGasCap
-}
-
-func (b *EthAPIBackend) EvmLogIndex() *topicsdb.Index {
-	return b.svc.abciApp.EvmLogs()
 }
 
 // CurrentEpoch returns current epoch number.

--- a/gossip/evm_state_reader.go
+++ b/gossip/evm_state_reader.go
@@ -111,6 +111,6 @@ func (r *EvmStateReader) getBlock(h hash.Event, n idx.Block, readTxs bool) *evmc
 	return evmBlock
 }
 
-func (r *EvmStateReader) StateAt(root common.Hash) (*state.StateDB, error) {
-	return r.app.StateDB(root), nil
+func (r *EvmStateReader) StateAt(root common.Hash) *state.StateDB {
+	return r.app.StateDB(root)
 }

--- a/gossip/evm_state_reader_test.go
+++ b/gossip/evm_state_reader_test.go
@@ -58,8 +58,7 @@ func TestGetGenesisBlock(t *testing.T) {
 	assertar.Equal(net.Genesis.Time, genesisBlock.Time)
 	assertar.Empty(genesisBlock.Transactions)
 
-	statedb, err := reader.StateAt(genesisBlock.Root)
-	assertar.NoError(err)
+	statedb := reader.StateAt(genesisBlock.Root)
 	for addr, account := range net.Genesis.Alloc.Accounts {
 		assertar.Equal(account.Balance.String(), statedb.GetBalance(addr).String())
 		assertar.Equal(account.Code, statedb.GetCode(addr))

--- a/gossip/filters/filter.go
+++ b/gossip/filters/filter.go
@@ -37,7 +37,7 @@ type Backend interface {
 	ChainDb() ethdb.Database
 	HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*evmcore.EvmHeader, error)
 	HeaderByHash(ctx context.Context, blockHash common.Hash) (*evmcore.EvmHeader, error)
-	GetReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error)
+	GetReceiptsByHash(ctx context.Context, blockHash common.Hash) (types.Receipts, error)
 	GetLogs(ctx context.Context, blockHash common.Hash) ([][]*types.Log, error)
 
 	SubscribeNewBlockEvent(ch chan<- evmcore.ChainHeadNotify) notify.Subscription
@@ -191,7 +191,7 @@ func (f *Filter) checkMatches(ctx context.Context, header *evmcore.EvmHeader) (l
 	if len(logs) > 0 {
 		// We have matching logs, check if we need to resolve full logs via the light client
 		if logs[0].TxHash == hash.Zero {
-			receipts, err := f.backend.GetReceipts(ctx, header.Hash)
+			receipts, err := f.backend.GetReceiptsByHash(ctx, header.Hash)
 			if err != nil {
 				return nil, err
 			}

--- a/gossip/filters/filter_system_test.go
+++ b/gossip/filters/filter_system_test.go
@@ -98,7 +98,7 @@ func (b *testBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*evmc
 	return eh, nil
 }
 
-func (b *testBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {
+func (b *testBackend) GetReceiptsByHash(ctx context.Context, hash common.Hash) (types.Receipts, error) {
 	if number := rawdb.ReadHeaderNumber(b.db, hash); number != nil {
 		return rawdb.ReadReceipts(b.db, hash, *number, params.TestChainConfig), nil
 	}

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -170,7 +170,7 @@ func NewService(ctx *node.ServiceContext, config *Config, store *Store, engine C
 	svc.pm, err = NewProtocolManager(config, &svc.feed, svc.txpool, svc.engineMu, svc.checkers, store, svc.engine, svc.serverPool)
 
 	// create API backend
-	svc.EthAPI = &EthAPIBackend{config.ExtRPCEnabled, svc, stateReader, nil}
+	svc.EthAPI = &EthAPIBackend{svc.abciApp.EthAPIBackend(), svc, stateReader, nil, config.ExtRPCEnabled}
 	svc.EthAPI.gpo = gasprice.NewOracle(svc.EthAPI, svc.config.GPO)
 
 	return svc, err


### PR DESCRIPTION
Split of EthAPIBackend to the gossip.EthAPIBackend and app.EthAPIBackend.

Note: app.EthAPIBackend's methods aren't described by Tendermint ABCI, but are needed to provide Ethereum API.
