### PR TITLE
in the migration for kv store added logic to enable or disable the log

### DIFF
--- a/app/apply_genesis.go
+++ b/app/apply_genesis.go
@@ -41,7 +41,7 @@ func (s *Store) ApplyGenesis(net *lachesis.Config) (block *evmcore.EvmBlock, isN
 
 // calcGenesisBlock calcs hash of genesis state.
 func calcGenesisBlock(net *lachesis.Config) (*evmcore.EvmBlock, error) {
-	s := NewMemStore()
+	s := NewMemStore(false)
 	defer s.Close()
 
 	return s.applyGenesis(net)

--- a/app/store.go
+++ b/app/store.go
@@ -84,16 +84,16 @@ type Store struct {
 }
 
 // NewMemStore creates store over memory map.
-func NewMemStore() *Store {
+func NewMemStore(migrationLoggingIsEnabled bool) *Store {
 	mems := memorydb.NewProducer("")
 	dbs := flushable.NewSyncedPool(mems)
 	cfg := LiteStoreConfig()
 
-	return NewStore(dbs, cfg)
+	return NewStore(dbs, cfg, migrationLoggingIsEnabled)
 }
 
 // NewStore creates store over key-value db.
-func NewStore(dbs *flushable.SyncedPool, cfg StoreConfig) *Store {
+func NewStore(dbs *flushable.SyncedPool, cfg StoreConfig, migrationLoggingIsEnabled bool) *Store {
 	s := &Store{
 		cfg:      cfg,
 		mainDb:   dbs.GetDb("app-main"),
@@ -109,7 +109,7 @@ func NewStore(dbs *flushable.SyncedPool, cfg StoreConfig) *Store {
 
 	s.initCache()
 
-	s.migrate(dbs)
+	s.migrate(dbs, migrationLoggingIsEnabled)
 
 	return s
 }

--- a/app/store_migration.go
+++ b/app/store_migration.go
@@ -12,10 +12,10 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/utils/migration"
 )
 
-func (s *Store) migrate(dbs *flushable.SyncedPool) {
+func (s *Store) migrate(dbs *flushable.SyncedPool, loggingIsEnabled bool) {
 	versions := kvdb.NewIDStore(s.table.Version)
 	err := s.migrations(dbs).Exec(versions)
-	if err != nil {
+	if err != nil && !loggingIsEnabled {
 		s.Log.Crit("app store migrations", "err", err)
 	}
 }

--- a/app/store_test.go
+++ b/app/store_test.go
@@ -13,7 +13,7 @@ func cachedStore() *Store {
 	dbs := flushable.NewSyncedPool(mems)
 	cfg := LiteStoreConfig()
 
-	return NewStore(dbs, cfg)
+	return NewStore(dbs, cfg, true)
 }
 
 func nonCachedStore() *Store {
@@ -21,7 +21,7 @@ func nonCachedStore() *Store {
 	dbs := flushable.NewSyncedPool(mems)
 	cfg := StoreConfig{}
 
-	return NewStore(dbs, cfg)
+	return NewStore(dbs, cfg, true)
 }
 
 func withDelay(db kvdb.KeyValueStore) kvdb.KeyValueStore {

--- a/gossip/evm_state_reader_test.go
+++ b/gossip/evm_state_reader_test.go
@@ -31,7 +31,7 @@ func TestGetGenesisBlock(t *testing.T) {
 	accountWithCode.Storage[common.Hash{}] = common.BytesToHash(common.Big1.Bytes())
 	net.Genesis.Alloc.Accounts[addrWithStorage] = accountWithCode
 
-	adb := app.NewMemStore()
+	adb := app.NewMemStore(true)
 	state, _, err := adb.ApplyGenesis(&net)
 	if !assertar.NoError(err) {
 		return
@@ -79,7 +79,7 @@ func TestGetBlock(t *testing.T) {
 
 	net := lachesis.FakeNetConfig(genesis.FakeAccounts(0, 5, big.NewInt(0), pos.StakeToBalance(1)))
 
-	app := app.NewMemStore()
+	app := app.NewMemStore(true)
 	state, _, err := app.ApplyGenesis(&net)
 	if !assertar.NoError(err) {
 		return

--- a/gossip/handler_test.go
+++ b/gossip/handler_test.go
@@ -141,7 +141,7 @@ func testBroadcastEvent(t *testing.T, totalPeers int, forcedAggressiveBroadcast 
 	config.TxPool.Journal = ""
 
 	// create stores
-	adb := app.NewMemStore()
+	adb := app.NewMemStore(true)
 	state, _, err := adb.ApplyGenesis(&net)
 	if !assertar.NoError(err) {
 		return

--- a/gossip/helper_test.go
+++ b/gossip/helper_test.go
@@ -35,7 +35,7 @@ func newTestProtocolManager(nodesNum int, eventsNum int, newtx chan<- []*types.T
 		return nil, nil, err
 	}
 
-	adb := app.NewMemStore()
+	adb := app.NewMemStore(true)
 	state, _, err := adb.ApplyGenesis(&net)
 	if err != nil {
 		return nil, nil, err

--- a/integration/assembly.go
+++ b/integration/assembly.go
@@ -25,7 +25,7 @@ func MakeEngine(dataDir string, gossipCfg *gossip.Config) (*poset.Poset, *app.St
 		DelegatorsCacheSize: gossipCfg.DelegatorsCacheSize,
 		StakersCacheSize:    gossipCfg.StakersCacheSize,
 	}
-	adb := app.NewStore(dbs, appStoreConfig)
+	adb := app.NewStore(dbs, appStoreConfig, true)
 	gdb := gossip.NewStore(dbs, gossipCfg.StoreConfig)
 	cdb := poset.NewStore(dbs, poset.DefaultStoreConfig())
 


### PR DESCRIPTION
Apply of migrations to an empty database is logged, in order not to mislead users,added a functionality to disable logging in those places where it is necessary. This PR contains changes that affect logging in `Store.migrate()` - app package.