### PR TITLE
App's own stateReader

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -59,7 +59,7 @@ func (a *App) InitChain(current idx.Epoch, last idx.Block) {
 
 // BeginBlock is a prototype of ABCIApplication.BeginBlock
 func (a *App) BeginBlock(
-	block *inter.Block, evmBlock *evmcore.EvmBlock, cheaters inter.Cheaters, stateHash common.Hash, stateReader evmcore.DummyChain,
+	block *inter.Block, evmBlock *evmcore.EvmBlock, cheaters inter.Cheaters, stateHash common.Hash,
 ) {
 	a.store.SetBlock(blockInfo(block))
 	block.SkippedTxs = make([]uint, 0, len(evmBlock.Transactions))
@@ -67,7 +67,7 @@ func (a *App) BeginBlock(
 		block:        block,
 		evmBlock:     evmBlock,
 		statedb:      a.store.StateDB(stateHash),
-		evmProcessor: evmcore.NewStateProcessor(a.config.Net.EvmChainConfig(), stateReader),
+		evmProcessor: evmcore.NewStateProcessor(a.config.Net.EvmChainConfig(), a.BlockChain()),
 		sealEpoch:    a.shouldSealEpoch(block, cheaters),
 		gp:           new(evmcore.GasPool),
 		totalFee:     big.NewInt(0),

--- a/app/block_info.go
+++ b/app/block_info.go
@@ -5,23 +5,34 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/Fantom-foundation/go-lachesis/evmcore"
+	"github.com/Fantom-foundation/go-lachesis/hash"
 	"github.com/Fantom-foundation/go-lachesis/inter"
 	"github.com/Fantom-foundation/go-lachesis/inter/idx"
 )
 
 // BlockInfo includes only necessary information about inter.Block
 type BlockInfo struct {
-	Index idx.Block
-	Root  common.Hash
-	Time  inter.Timestamp
+	Index      idx.Block
+	Hash       hash.Event
+	ParentHash hash.Event
+	Root       common.Hash
+	Time       inter.Timestamp
 }
 
 func blockInfo(b *inter.Block) *BlockInfo {
 	return &BlockInfo{
-		Index: b.Index,
-		Root:  b.Root,
-		Time:  b.Time,
+		Index:      b.Index,
+		Hash:       b.Atropos,
+		ParentHash: b.PrevHash,
+		Root:       b.Root,
+		Time:       b.Time,
 	}
+}
+
+// BlockChain dummy reader.
+func (a *App) BlockChain() evmcore.DummyChain {
+	return a.store
 }
 
 // LastBlock returns last block info.

--- a/app/store_block.go
+++ b/app/store_block.go
@@ -1,6 +1,12 @@
 package app
 
 import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/Fantom-foundation/go-lachesis/evmcore"
+	"github.com/Fantom-foundation/go-lachesis/hash"
 	"github.com/Fantom-foundation/go-lachesis/inter/idx"
 )
 
@@ -33,4 +39,21 @@ func (s *Store) GetBlock(n idx.Block) *BlockInfo {
 	}
 
 	return block
+}
+
+// GetHeader implements evmcore.DummyChain interface to be used during transaction processing.
+// Only Number and ParentHash of header are filled.
+func (s *Store) GetHeader(h common.Hash, n uint64) *evmcore.EvmHeader {
+	info := s.GetBlock(idx.Block(n))
+	if info == nil {
+		return nil
+	}
+	if (h != common.Hash{}) && (info.Hash != hash.Event(h)) {
+		return nil
+	}
+
+	return &evmcore.EvmHeader{
+		Number:     big.NewInt(int64(info.Index)),
+		ParentHash: common.Hash(info.ParentHash),
+	}
 }

--- a/gossip/consensus_callbacks.go
+++ b/gossip/consensus_callbacks.go
@@ -117,7 +117,7 @@ func (s *Service) applyNewState(
 	}
 
 	stateHash := s.store.GetBlock(block.Index - 1).Root
-	s.abciApp.BeginBlock(block, evmBlock, cheaters, stateHash, s.GetEvmStateReader())
+	s.abciApp.BeginBlock(block, evmBlock, cheaters, stateHash)
 
 	for i, tx := range evmBlock.Transactions {
 		s.abciApp.DeliverTx(tx, i)


### PR DESCRIPTION
App stores its own evmcore.DummyChain and does not depend on gossip.stateReader.
It causes a overhead of db size, but is a way to Tendermint.