### PR TITLE
Emitter selfForkProtection fix

### DIFF
--- a/gossip/emitter.go
+++ b/gossip/emitter.go
@@ -334,9 +334,8 @@ func (em *Emitter) createEvent(poolTxs, trustedTxs map[common.Address]types.Tran
 		// not a validator
 		return nil
 	}
-	validators := em.world.Engine.GetValidators()
 
-	if synced, _, _ := em.logSyncStatus(em.isSynced()); !synced {
+	if synced := em.logSyncStatus(em.isSynced()); !synced {
 		// I'm reindexing my old events, so don't create events until connect all the existing self-events
 		return nil
 	}
@@ -402,6 +401,7 @@ func (em *Emitter) createEvent(poolTxs, trustedTxs map[common.Address]types.Tran
 	}
 
 	// calc initial GasPower
+	validators := em.world.Engine.GetValidators()
 	event.GasPowerUsed = basiccheck.CalcGasPowerUsed(event, &em.net.Dag)
 	availableGasPower, err := em.world.Checkers.Gaspowercheck.CalcGasPower(&event.EventHeaderData, selfParentHeader)
 	if err != nil {
@@ -536,27 +536,32 @@ func (em *Emitter) OnNewEpoch(newValidators *pos.Validators, newEpoch idx.Epoch)
 
 // OnNewEvent tracks new events to find out am I properly synced or not
 func (em *Emitter) OnNewEvent(e *inter.Event) {
-	now := time.Now()
-	myStakerID := em.myStakerID
-	if em.myStakerID != 0 && em.syncStatus.prevLocalEmittedID != e.Hash() {
-		if e.Creator == myStakerID {
-			// event was emitted by me on another instance
-			em.syncStatus.prevExternalEmittedTime = now
-
-			passedSinceEvent := time.Since(inter.MaxTimestamp(e.ClaimedTime, e.MedianTime).Time())
-			threshold := em.intervals.SelfForkProtection
-			if threshold > time.Minute {
-				threshold = time.Minute
-			}
-			if passedSinceEvent <= threshold {
-				reason := "Received a recent event (event id=%s) from this validator (staker id=%d) which wasn't created on this node.\n" +
-					"This external event was created %s, %s ago at the time of this error.\n" +
-					"It means that a duplicating instance of the same validator is running simultaneously, which will eventually lead to a doublesign.\n" +
-					"For now, doublesign was prevented by one of the heuristics, but next time you (and your delegators) may lose the stake."
-				errlock.Permanent(fmt.Errorf(reason, e.Hash().String(), myStakerID, e.ClaimedTime.Time().Local().String(), passedSinceEvent.String()))
-			}
-		}
+	if em.myStakerID == 0 || em.myStakerID != e.Creator {
+		return
 	}
+	if em.syncStatus.prevLocalEmittedID == e.Hash() {
+		return
+	}
+
+	// event was emitted by me on another instance
+	em.syncStatus.prevExternalEmittedTime = time.Now()
+	if synced, _, _ := em.isSynced(); !synced {
+		return
+	}
+
+	passedSinceEvent := time.Since(inter.MaxTimestamp(e.ClaimedTime, e.MedianTime).Time())
+	threshold := em.intervals.SelfForkProtection
+	if threshold > time.Minute {
+		threshold = time.Minute
+	}
+	if passedSinceEvent <= threshold {
+		reason := "Received a recent event (event id=%s) from this validator (staker id=%d) which wasn't created on this node.\n" +
+			"This external event was created %s, %s ago at the time of this error.\n" +
+			"It means that a duplicating instance of the same validator is running simultaneously, which will eventually lead to a doublesign.\n" +
+			"For now, doublesign was prevented by one of the heuristics, but next time you (and your delegators) may lose the stake."
+		errlock.Permanent(fmt.Errorf(reason, e.Hash().String(), em.myStakerID, e.ClaimedTime.Time().Local().String(), passedSinceEvent.String()))
+	}
+
 }
 
 func (em *Emitter) isSynced() (bool, string, time.Duration) {
@@ -589,15 +594,17 @@ func (em *Emitter) isSynced() (bool, string, time.Duration) {
 	return true, "", 0
 }
 
-func (em *Emitter) logSyncStatus(synced bool, reason string, wait time.Duration) (bool, string, time.Duration) {
-	if !synced {
-		if wait == 0 {
-			em.Periodic.Info(25*time.Second, "Emitting is paused", "reason", reason)
-		} else {
-			em.Periodic.Info(25*time.Second, "Emitting is paused", "reason", reason, "wait", wait)
-		}
+func (em *Emitter) logSyncStatus(synced bool, reason string, wait time.Duration) bool {
+	if synced {
+		return true
 	}
-	return synced, reason, wait
+
+	if wait == 0 {
+		em.Periodic.Info(25*time.Second, "Emitting is paused", "reason", reason)
+	} else {
+		em.Periodic.Info(25*time.Second, "Emitting is paused", "reason", reason, "wait", wait)
+	}
+	return false
 }
 
 // return true if event is in epoch tail (unlikely to confirm)

--- a/gossip/emitter.go
+++ b/gossip/emitter.go
@@ -250,12 +250,10 @@ func (em *Emitter) isMyTxTurn(txHash common.Hash, sender common.Address, account
 	return validatorsArr[turns[roundIndex]] == me
 }
 
-func (em *Emitter) addTxs(e *inter.Event, poolTxs map[common.Address]types.Transactions, flags ...bool) *inter.Event {
+func (em *Emitter) addTxs(e *inter.Event, poolTxs map[common.Address]types.Transactions, trusted bool) *inter.Event {
 	if poolTxs == nil || len(poolTxs) == 0 {
 		return e
 	}
-
-	trusted := utils.ParseFlag(flags, 0, false)
 
 	maxGasUsed := em.maxGasPowerToUse(e)
 
@@ -331,16 +329,7 @@ func (em *Emitter) findBestParents(epoch idx.Epoch, myStakerID idx.StakerID) (*h
 }
 
 // createEvent is not safe for concurrent use.
-func (em *Emitter) createEvent(txs ...map[common.Address]types.Transactions) *inter.Event {
-	var poolTxs map[common.Address]types.Transactions
-	var trustedTxs map[common.Address]types.Transactions
-	if len(txs) > 0 {
-		poolTxs = txs[0]
-	}
-	if len(txs) > 1 {
-		trustedTxs = txs[1]
-	}
-
+func (em *Emitter) createEvent(poolTxs, trustedTxs map[common.Address]types.Transactions) *inter.Event {
 	if em.myStakerID == 0 {
 		// not a validator
 		return nil
@@ -428,7 +417,7 @@ func (em *Emitter) createEvent(txs ...map[common.Address]types.Transactions) *in
 	event.GasPowerLeft = *availableGasPower.Sub(event.GasPowerUsed)
 
 	// Add txs
-	event = em.addTxs(event, poolTxs)
+	event = em.addTxs(event, poolTxs, false)
 	event = em.addTxs(event, trustedTxs, true)
 
 	if !em.isAllowedToEmit(event, selfParentHeader) {

--- a/gossip/handler_test.go
+++ b/gossip/handler_test.go
@@ -221,7 +221,7 @@ func testBroadcastEvent(t *testing.T, totalPeers int, forcedAggressiveBroadcast 
 
 	// create new event, but send it from new peer
 	{
-		emitted := svc.emitter.createEvent(nil)
+		emitted := svc.emitter.createEvent(nil, nil)
 		assertar.NotNil(emitted)
 		assertar.NoError(p2p.Send(newPeer.app, NewEventHashesMsg, []hash.Event{emitted.Hash()})) // announce
 		// now PM should request it


### PR DESCRIPTION
Node doesn't detect a duplicating instance until synced to prevent false positive detection after quick restart.