### PR TITLE
fix of import/export commands

### DIFF
--- a/cmd/lachesis/import.go
+++ b/cmd/lachesis/import.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"gopkg.in/urfave/cli.v1"
 
+	"github.com/Fantom-foundation/go-lachesis/eventcheck/epochcheck"
 	"github.com/Fantom-foundation/go-lachesis/gossip"
 	"github.com/Fantom-foundation/go-lachesis/hash"
 	"github.com/Fantom-foundation/go-lachesis/inter"
@@ -121,10 +122,16 @@ func importFile(srv *gossip.Service, fn string) error {
 			break
 		}
 
-		if err = srv.ImportEvent(&e); err != nil {
+		err = srv.ImportEvent(&e)
+		switch err {
+		case nil:
+			log.Debug("event inserted", "event", e.Hash())
+		case epochcheck.ErrNotRelevant:
+			log.Debug("event skipped", "event", e.Hash())
+		default:
 			return err
 		}
-		log.Debug("event inserted", "event", e.Hash())
+
 	}
 
 	return nil


### PR DESCRIPTION
1. Commands `lachesis export` and `lachesis import` store and check genesis hash in export file.
It prevents event importing into incompatible DAG.
2. Command `lachesis import` ignores already existing event.