### PR TITLE
Fix of nil pointer exception at TxPool

### DIFF
--- a/gossip/tendermint.go
+++ b/gossip/tendermint.go
@@ -1,14 +1,11 @@
 package gossip
 
 import (
-	"math"
-
 	"github.com/ethereum/go-ethereum/common"
 	eth "github.com/ethereum/go-ethereum/core/types"
 	"github.com/tendermint/tendermint/abci/types"
 
 	"github.com/Fantom-foundation/go-lachesis/app"
-	"github.com/Fantom-foundation/go-lachesis/evmcore"
 	"github.com/Fantom-foundation/go-lachesis/inter"
 	"github.com/Fantom-foundation/go-lachesis/inter/idx"
 )
@@ -26,7 +23,7 @@ func (s *Service) initApp() {
 func beginBlockRequest(
 	cheaters inter.Cheaters,
 	stateHash common.Hash,
-	block *evmcore.EvmHeader,
+	block *inter.Block,
 	participated map[idx.StakerID]bool,
 ) types.RequestBeginBlock {
 
@@ -50,13 +47,13 @@ func beginBlockRequest(
 	}
 
 	req := types.RequestBeginBlock{
-		Hash: block.Hash.Bytes(),
+		Hash: block.Atropos.Bytes(),
 		Header: types.Header{
-			Height:        block.Number.Int64(),
+			Height:        int64(block.Index),
 			Time:          block.Time.Time(),
-			ConsensusHash: block.Hash.Bytes(),
+			ConsensusHash: block.Atropos.Bytes(),
 			LastBlockId: types.BlockID{
-				Hash: block.ParentHash.Bytes(),
+				Hash: block.PrevHash.Bytes(),
 			},
 			LastCommitHash: stateHash.Bytes(),
 		},
@@ -64,10 +61,6 @@ func beginBlockRequest(
 			Votes: votes,
 		},
 		ByzantineValidators: byzantines,
-	}
-
-	if block.GasLimit != math.MaxUint64 {
-		panic("we need to pass GasLimit throuth request")
 	}
 
 	return req


### PR DESCRIPTION
Makes new block storing before new block notification to prevent such panics:
```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xebef9d]
goroutine 646212 [running]:
github.com/Fantom-foundation/go-lachesis/evmcore.(*EvmBlock).NumberU64(...)
        /home/fabel/Work/fantom/go-lachesis/evmcore/dummy_block.go:113
github.com/Fantom-foundation/go-lachesis/evmcore.(*TxPool).reset(0xc01598b860, 0xc01651b2c0, 0xc0172ef380)
        /home/fabel/Work/fantom/go-lachesis/evmcore/tx_pool.go:1173 +0x27d
github.com/Fantom-foundation/go-lachesis/evmcore.(*TxPool).runReorg(0xc01598b860, 0xc0186f8060, 0xc01f5c0500, 0x0, 0xc0040e99b0)
        /home/fabel/Work/fantom/go-lachesis/evmcore/tx_pool.go:1086 +0x711
created by github.com/Fantom-foundation/go-lachesis/evmcore.(*TxPool).scheduleReorgLoop
        /home/fabel/Work/fantom/go-lachesis/evmcore/tx_pool.go:1021 +0x64f
```