### PR TITLE
State roots export

### DIFF
--- a/cmd/lachesis/debug.go
+++ b/cmd/lachesis/debug.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/ethereum/go-ethereum/cmd/utils"
+	"gopkg.in/urfave/cli.v1"
+
+	"github.com/Fantom-foundation/go-lachesis/inter/idx"
+	"github.com/Fantom-foundation/go-lachesis/utils/errlock"
+)
+
+var (
+	staterootsCommand = cli.Command{
+		Action:    utils.MigrateFlags(printStateRoots),
+		Name:      "stateroots",
+		Usage:     "Prints root hashes for states of blockchain",
+		ArgsUsage: "[<epochFrom> [<epochTo>]]",
+		Category:  "MISCELLANEOUS COMMANDS",
+		Description: `
+For debug purpose.
+Optional first and second arguments control the first and last epoch to export.`,
+	}
+)
+
+func printStateRoots(ctx *cli.Context) error {
+	cfg := makeAllConfigs(ctx)
+
+	// check errlock file
+	errlock.SetDefaultDatadir(cfg.Node.DataDir)
+	errlock.Check()
+
+	gdb := makeGossipStore(cfg.Node.DataDir, &cfg.Lachesis)
+	defer gdb.Close()
+
+	from := idx.Epoch(0)
+	if len(ctx.Args()) > 0 {
+		n, err := strconv.ParseUint(ctx.Args().Get(1), 10, 32)
+		if err != nil {
+			return err
+		}
+		from = idx.Epoch(n)
+	}
+	to := idx.Epoch(0)
+	if len(ctx.Args()) > 1 {
+		n, err := strconv.ParseUint(ctx.Args().Get(2), 10, 32)
+		if err != nil {
+			return err
+		}
+		to = idx.Epoch(n)
+	}
+
+	fmt.Printf("from %d epoch to %d\n", from, to)
+	// TODO: print
+
+	return nil
+}

--- a/cmd/lachesis/main.go
+++ b/cmd/lachesis/main.go
@@ -166,6 +166,7 @@ func init() {
 		// See chaincmd.go
 		importCommand,
 		exportCommand,
+		staterootsCommand,
 	}
 	sort.Sort(cli.CommandsByName(App.Commands))
 


### PR DESCRIPTION
Lachesis stateroots command prints root hashes for states of blockchain blocks. This data is useful for debugging and checking db compatible between lachesis releases.