### PR TITLE
Tx batches

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1614,6 +1614,32 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction, fl
 	return tx.Hash(), nil
 }
 
+// SubmitTxBatch is a helper function that submits batch of tx to txPool and logs a message.
+func SubmitTxBatch(ctx context.Context, b Backend, txs []*types.Transaction) (hashes []common.Hash, err error) {
+	err = b.SendTxBatch(ctx, txs)
+	if err != nil {
+		return
+	}
+
+	for _, tx := range txs {
+		if tx.To() == nil {
+			signer := types.MakeSigner(b.ChainConfig(), b.CurrentBlock().Number)
+			var from common.Address
+			from, err = types.Sender(signer, tx)
+			if err != nil {
+				return
+			}
+			addr := crypto.CreateAddress(from, tx.Nonce())
+			log.Info("Submitted contract creation", "fullhash", tx.Hash().Hex(), "contract", addr.Hex())
+		} else {
+			log.Info("Submitted transaction", "fullhash", tx.Hash().Hex(), "recipient", tx.To())
+		}
+		hashes = append(hashes, tx.Hash())
+	}
+
+	return
+}
+
 // SendTransaction creates a transaction for the given argument, sign it and submit it to the
 // transaction pool.
 func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args SendTxArgs) (common.Hash, error) {
@@ -1644,6 +1670,47 @@ func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args Sen
 		return common.Hash{}, err
 	}
 	return SubmitTransaction(ctx, s.b, signed)
+}
+
+// SendTxBatch creates a batch of transactions for the given argument, sign it and submit it to the
+// transaction pool.
+func (s *PublicTransactionPoolAPI) SendTxBatch(ctx context.Context, args []SendTxArgs) (hashes []common.Hash, err error) {
+	var (
+		txs    []*types.Transaction
+		wallet accounts.Wallet
+	)
+	for _, arg := range args {
+		// Look up the wallet containing the requested signer
+		account := accounts.Account{Address: arg.From}
+
+		wallet, err = s.b.AccountManager().Find(account)
+		if err != nil {
+			return
+		}
+
+		if arg.Nonce == nil {
+			// Hold the addresse's mutex around signing to prevent concurrent assignment of
+			// the same nonce to multiple accounts.
+			s.nonceLock.LockAddr(arg.From)
+			defer s.nonceLock.UnlockAddr(arg.From)
+		}
+
+		// Set some sanity defaults and terminate on failure
+		err = arg.setDefaults(ctx, s.b)
+		if err != nil {
+			return
+		}
+		// Assemble the transaction and sign with the wallet
+		tx := arg.toTransaction()
+		tx, err = wallet.SignTx(account, tx, s.b.ChainConfig().ChainID)
+		if err != nil {
+			return
+		}
+
+		txs = append(txs, tx)
+	}
+
+	return SubmitTxBatch(ctx, s.b, txs)
 }
 
 // FillTransaction fills the defaults (nonce, gas, gasPrice) on a given unsigned transaction,

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -81,6 +81,7 @@ type Backend interface {
 
 	// Transaction pool API
 	SendTx(ctx context.Context, signedTx *types.Transaction, flags ...bool) error
+	SendTxBatch(ctx context.Context, signedTxs []*types.Transaction) error
 	GetTransaction(ctx context.Context, txHash common.Hash) (*types.Transaction, uint64, uint64, error)
 	GetPoolTransactions() (types.Transactions, error)
 	GetPoolTransaction(txHash common.Hash) *types.Transaction

--- a/ethapi/backend_mock_test.go
+++ b/ethapi/backend_mock_test.go
@@ -303,6 +303,20 @@ func (mr *MockBackendMockRecorder) SendTx(ctx, signedTx interface{}, flags ...in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTx", reflect.TypeOf((*MockBackend)(nil).SendTx), varargs...)
 }
 
+// SendTxBatch mocks base method
+func (m *MockBackend) SendTxBatch(ctx context.Context, signedTxs []*types.Transaction) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendTxBatch", ctx, signedTxs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendTxBatch indicates an expected call of SendTxBatch
+func (mr *MockBackendMockRecorder) SendTxBatch(ctx, signedTxs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTxBatch", reflect.TypeOf((*MockBackend)(nil).SendTxBatch), ctx, signedTxs)
+}
+
 // GetTransaction mocks base method
 func (m *MockBackend) GetTransaction(ctx context.Context, txHash common.Hash) (*types.Transaction, uint64, uint64, error) {
 	m.ctrl.T.Helper()

--- a/evmcore/tx_cacher.go
+++ b/evmcore/tx_cacher.go
@@ -33,7 +33,7 @@ var senderCacher = newTxSenderCacher(runtime.NumCPU())
 // ensure they process the early transactions fast.
 type txSenderCacherRequest struct {
 	signer types.Signer
-	txs    []*types.Transaction
+	txs    []*Transaction
 	inc    int
 }
 
@@ -62,7 +62,7 @@ func newTxSenderCacher(threads int) *txSenderCacher {
 func (cacher *txSenderCacher) cache() {
 	for task := range cacher.tasks {
 		for i := 0; i < len(task.txs); i += task.inc {
-			types.Sender(task.signer, task.txs[i])
+			types.Sender(task.signer, task.txs[i].Transaction)
 		}
 	}
 }
@@ -70,7 +70,7 @@ func (cacher *txSenderCacher) cache() {
 // recover recovers the senders from a batch of transactions and caches them
 // back into the same data structures. There is no validation being done, nor
 // any reaction to invalid signatures. That is up to calling code later.
-func (cacher *txSenderCacher) recover(signer types.Signer, txs []*types.Transaction) {
+func (cacher *txSenderCacher) recover(signer types.Signer, txs []*Transaction) {
 	// If there's nothing to recover, abort
 	if len(txs) == 0 {
 		return
@@ -87,19 +87,4 @@ func (cacher *txSenderCacher) recover(signer types.Signer, txs []*types.Transact
 			inc:    tasks,
 		}
 	}
-}
-
-// recoverFromBlocks recovers the senders from a batch of blocks and caches them
-// back into the same data structures. There is no validation being done, nor
-// any reaction to invalid signatures. That is up to calling code later.
-func (cacher *txSenderCacher) recoverFromBlocks(signer types.Signer, blocks []*EvmBlock) {
-	count := 0
-	for _, block := range blocks {
-		count += len(block.Transactions)
-	}
-	txs := make([]*types.Transaction, 0, count)
-	for _, block := range blocks {
-		txs = append(txs, block.Transactions...)
-	}
-	cacher.recover(signer, txs)
 }

--- a/evmcore/tx_journal.go
+++ b/evmcore/tx_journal.go
@@ -22,7 +22,6 @@ import (
 	"os"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 )
@@ -56,7 +55,7 @@ func newTxJournal(path string) *txJournal {
 
 // load parses a transaction journal dump from disk, loading its contents into
 // the specified pool.
-func (journal *txJournal) load(add func([]*types.Transaction) []error) error {
+func (journal *txJournal) load(add func([]*Transaction) []error) error {
 	// Skip the parsing if the journal file doesn't exist at all
 	if _, err := os.Stat(journal.path); os.IsNotExist(err) {
 		return nil
@@ -79,7 +78,7 @@ func (journal *txJournal) load(add func([]*types.Transaction) []error) error {
 	// Create a method to load a limited batch of transactions and bump the
 	// appropriate progress counters. Then use this method to load all the
 	// journaled transactions in small-ish batches.
-	loadBatch := func(txs types.Transactions) {
+	loadBatch := func(txs Transactions) {
 		for _, err := range add(txs) {
 			if err != nil {
 				log.Debug("Failed to add journaled transaction", "err", err)
@@ -89,11 +88,11 @@ func (journal *txJournal) load(add func([]*types.Transaction) []error) error {
 	}
 	var (
 		failure error
-		batch   types.Transactions
+		batch   Transactions
 	)
 	for {
 		// Parse the next transaction and terminate on error
-		tx := new(types.Transaction)
+		tx := new(Transaction)
 		if err = stream.Decode(tx); err != nil {
 			if err != io.EOF {
 				failure = err
@@ -117,7 +116,7 @@ func (journal *txJournal) load(add func([]*types.Transaction) []error) error {
 }
 
 // insert adds the specified transaction to the local disk journal.
-func (journal *txJournal) insert(tx *types.Transaction) error {
+func (journal *txJournal) insert(tx *Transaction) error {
 	if journal.writer == nil {
 		return errNoActiveJournal
 	}
@@ -129,7 +128,7 @@ func (journal *txJournal) insert(tx *types.Transaction) error {
 
 // rotate regenerates the transaction journal based on the current contents of
 // the transaction pool.
-func (journal *txJournal) rotate(all map[common.Address]types.Transactions) error {
+func (journal *txJournal) rotate(all map[common.Address]Transactions) error {
 	// Close the current journal (if any is open)
 	if journal.writer != nil {
 		if err := journal.writer.Close(); err != nil {

--- a/evmcore/tx_list.go
+++ b/evmcore/tx_list.go
@@ -23,7 +23,6 @@ import (
 	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -50,27 +49,27 @@ func (h *nonceHeap) Pop() interface{} {
 // txSortedMap is a nonce->transaction hash map with a heap based index to allow
 // iterating over the contents in a nonce-incrementing way.
 type txSortedMap struct {
-	items map[uint64]*types.Transaction // Hash map storing the transaction data
-	index *nonceHeap                    // Heap of nonces of all the stored transactions (non-strict mode)
-	cache types.Transactions            // Cache of the transactions already sorted
+	items map[uint64]*Transaction // Hash map storing the transaction data
+	index *nonceHeap              // Heap of nonces of all the stored transactions (non-strict mode)
+	cache Transactions            // Cache of the transactions already sorted
 }
 
 // newTxSortedMap creates a new nonce-sorted transaction map.
 func newTxSortedMap() *txSortedMap {
 	return &txSortedMap{
-		items: make(map[uint64]*types.Transaction),
+		items: make(map[uint64]*Transaction),
 		index: new(nonceHeap),
 	}
 }
 
 // Get retrieves the current transactions associated with the given nonce.
-func (m *txSortedMap) Get(nonce uint64) *types.Transaction {
+func (m *txSortedMap) Get(nonce uint64) *Transaction {
 	return m.items[nonce]
 }
 
 // Put inserts a new transaction into the map, also updating the map's nonce
 // index. If a transaction already exists with the same nonce, it's overwritten.
-func (m *txSortedMap) Put(tx *types.Transaction) {
+func (m *txSortedMap) Put(tx *Transaction) {
 	nonce := tx.Nonce()
 	if m.items[nonce] == nil {
 		heap.Push(m.index, nonce)
@@ -81,8 +80,8 @@ func (m *txSortedMap) Put(tx *types.Transaction) {
 // Forward removes all transactions from the map with a nonce lower than the
 // provided threshold. Every removed transaction is returned for any post-removal
 // maintenance.
-func (m *txSortedMap) Forward(threshold uint64) types.Transactions {
-	var removed types.Transactions
+func (m *txSortedMap) Forward(threshold uint64) Transactions {
+	var removed Transactions
 
 	// Pop off heap items until the threshold is reached
 	for m.index.Len() > 0 && (*m.index)[0] < threshold {
@@ -99,8 +98,8 @@ func (m *txSortedMap) Forward(threshold uint64) types.Transactions {
 
 // Filter iterates over the list of transactions and removes all of them for which
 // the specified function evaluates to true.
-func (m *txSortedMap) Filter(filter func(*types.Transaction) bool) types.Transactions {
-	var removed types.Transactions
+func (m *txSortedMap) Filter(filter func(*Transaction) bool) Transactions {
+	var removed Transactions
 
 	// Collect all the transactions to filter out
 	for nonce, tx := range m.items {
@@ -124,13 +123,13 @@ func (m *txSortedMap) Filter(filter func(*types.Transaction) bool) types.Transac
 
 // Cap places a hard limit on the number of items, returning all transactions
 // exceeding that limit.
-func (m *txSortedMap) Cap(threshold int) types.Transactions {
+func (m *txSortedMap) Cap(threshold int) Transactions {
 	// Short circuit if the number of items is under the limit
 	if len(m.items) <= threshold {
 		return nil
 	}
 	// Otherwise gather and drop the highest nonce'd transactions
-	var drops types.Transactions
+	var drops Transactions
 
 	sort.Sort(*m.index)
 	for size := len(m.items); size > threshold; size-- {
@@ -175,13 +174,13 @@ func (m *txSortedMap) Remove(nonce uint64) bool {
 // Note, all transactions with nonces lower than start will also be returned to
 // prevent getting into and invalid state. This is not something that should ever
 // happen but better to be self correcting than failing!
-func (m *txSortedMap) Ready(start uint64) types.Transactions {
+func (m *txSortedMap) Ready(start uint64) Transactions {
 	// Short circuit if no transactions are available
 	if m.index.Len() == 0 || (*m.index)[0] > start {
 		return nil
 	}
 	// Otherwise start accumulating incremental transactions
-	var ready types.Transactions
+	var ready Transactions
 	for next := (*m.index)[0]; m.index.Len() > 0 && (*m.index)[0] == next; next++ {
 		ready = append(ready, m.items[next])
 		delete(m.items, next)
@@ -200,17 +199,17 @@ func (m *txSortedMap) Len() int {
 // Flatten creates a nonce-sorted slice of transactions based on the loosely
 // sorted internal representation. The result of the sorting is cached in case
 // it's requested again before any modifications are made to the contents.
-func (m *txSortedMap) Flatten() types.Transactions {
+func (m *txSortedMap) Flatten() Transactions {
 	// If the sorting was not cached yet, create and cache it
 	if m.cache == nil {
-		m.cache = make(types.Transactions, 0, len(m.items))
+		m.cache = make(Transactions, 0, len(m.items))
 		for _, tx := range m.items {
 			m.cache = append(m.cache, tx)
 		}
-		sort.Sort(types.TxByNonce(m.cache))
+		sort.Sort(txByNonce(m.cache))
 	}
 	// Copy the cache to prevent accidental modifications
-	txs := make(types.Transactions, len(m.cache))
+	txs := make(Transactions, len(m.cache))
 	copy(txs, m.cache)
 	return txs
 }
@@ -239,7 +238,7 @@ func newTxList(strict bool) *txList {
 
 // Overlaps returns whether the transaction specified has the same nonce as one
 // already contained within the list.
-func (l *txList) Overlaps(tx *types.Transaction) bool {
+func (l *txList) Overlaps(tx *Transaction) bool {
 	return l.txs.Get(tx.Nonce()) != nil
 }
 
@@ -248,7 +247,7 @@ func (l *txList) Overlaps(tx *types.Transaction) bool {
 //
 // If the new transaction is accepted into the list, the lists' cost and gas
 // thresholds are also potentially updated.
-func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transaction) {
+func (l *txList) Add(tx *Transaction, priceBump uint64) (bool, *Transaction) {
 	// If there's an older better transaction, abort
 	old := l.txs.Get(tx.Nonce())
 	if old != nil {
@@ -274,7 +273,7 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 // Forward removes all transactions from the list with a nonce lower than the
 // provided threshold. Every removed transaction is returned for any post-removal
 // maintenance.
-func (l *txList) Forward(threshold uint64) types.Transactions {
+func (l *txList) Forward(threshold uint64) Transactions {
 	return l.txs.Forward(threshold)
 }
 
@@ -287,7 +286,7 @@ func (l *txList) Forward(threshold uint64) types.Transactions {
 // a point in calculating all the costs or if the balance covers all. If the threshold
 // is lower than the costgas cap, the caps will be reset to a new high after removing
 // the newly invalidated transactions.
-func (l *txList) Filter(costLimit *big.Int, gasLimit uint64) (types.Transactions, types.Transactions) {
+func (l *txList) Filter(costLimit *big.Int, gasLimit uint64) (Transactions, Transactions) {
 	// If all transactions are below the threshold, short circuit
 	if l.costcap.Cmp(costLimit) <= 0 && l.gascap <= gasLimit {
 		return nil, nil
@@ -296,10 +295,10 @@ func (l *txList) Filter(costLimit *big.Int, gasLimit uint64) (types.Transactions
 	l.gascap = gasLimit
 
 	// Filter out all the transactions above the account's funds
-	removed := l.txs.Filter(func(tx *types.Transaction) bool { return tx.Cost().Cmp(costLimit) > 0 || tx.Gas() > gasLimit })
+	removed := l.txs.Filter(func(tx *Transaction) bool { return tx.Cost().Cmp(costLimit) > 0 || tx.Gas() > gasLimit })
 
 	// If the list was strict, filter anything above the lowest nonce
-	var invalids types.Transactions
+	var invalids Transactions
 
 	if l.strict && len(removed) > 0 {
 		lowest := uint64(math.MaxUint64)
@@ -308,21 +307,21 @@ func (l *txList) Filter(costLimit *big.Int, gasLimit uint64) (types.Transactions
 				lowest = nonce
 			}
 		}
-		invalids = l.txs.Filter(func(tx *types.Transaction) bool { return tx.Nonce() > lowest })
+		invalids = l.txs.Filter(func(tx *Transaction) bool { return tx.Nonce() > lowest })
 	}
 	return removed, invalids
 }
 
 // Cap places a hard limit on the number of items, returning all transactions
 // exceeding that limit.
-func (l *txList) Cap(threshold int) types.Transactions {
+func (l *txList) Cap(threshold int) Transactions {
 	return l.txs.Cap(threshold)
 }
 
 // Remove deletes a transaction from the maintained list, returning whether the
 // transaction was found, and also returning any transaction invalidated due to
 // the deletion (strict mode only).
-func (l *txList) Remove(tx *types.Transaction) (bool, types.Transactions) {
+func (l *txList) Remove(tx *Transaction) (bool, Transactions) {
 	// Remove the transaction from the set
 	nonce := tx.Nonce()
 	if removed := l.txs.Remove(nonce); !removed {
@@ -330,7 +329,7 @@ func (l *txList) Remove(tx *types.Transaction) (bool, types.Transactions) {
 	}
 	// In strict mode, filter out non-executable transactions
 	if l.strict {
-		return true, l.txs.Filter(func(tx *types.Transaction) bool { return tx.Nonce() > nonce })
+		return true, l.txs.Filter(func(tx *Transaction) bool { return tx.Nonce() > nonce })
 	}
 	return true, nil
 }
@@ -342,7 +341,7 @@ func (l *txList) Remove(tx *types.Transaction) (bool, types.Transactions) {
 // Note, all transactions with nonces lower than start will also be returned to
 // prevent getting into and invalid state. This is not something that should ever
 // happen but better to be self correcting than failing!
-func (l *txList) Ready(start uint64) types.Transactions {
+func (l *txList) Ready(start uint64) Transactions {
 	return l.txs.Ready(start)
 }
 
@@ -359,13 +358,13 @@ func (l *txList) Empty() bool {
 // Flatten creates a nonce-sorted slice of transactions based on the loosely
 // sorted internal representation. The result of the sorting is cached in case
 // it's requested again before any modifications are made to the contents.
-func (l *txList) Flatten() types.Transactions {
+func (l *txList) Flatten() Transactions {
 	return l.txs.Flatten()
 }
 
 // priceHeap is a heap.Interface implementation over transactions for retrieving
 // price-sorted transactions to discard when the pool fills up.
-type priceHeap []*types.Transaction
+type priceHeap []*Transaction
 
 func (h priceHeap) Len() int      { return len(h) }
 func (h priceHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
@@ -383,7 +382,7 @@ func (h priceHeap) Less(i, j int) bool {
 }
 
 func (h *priceHeap) Push(x interface{}) {
-	*h = append(*h, x.(*types.Transaction))
+	*h = append(*h, x.(*Transaction))
 }
 
 func (h *priceHeap) Pop() interface{} {
@@ -411,7 +410,7 @@ func newTxPricedList(all *txLookup) *txPricedList {
 }
 
 // Put inserts a new transaction into the heap.
-func (l *txPricedList) Put(tx *types.Transaction) {
+func (l *txPricedList) Put(tx *Transaction) {
 	heap.Push(l.items, tx)
 }
 
@@ -428,7 +427,7 @@ func (l *txPricedList) Removed(count int) {
 	reheap := make(priceHeap, 0, l.all.Count())
 
 	l.stales, l.items = 0, &reheap
-	l.all.Range(func(hash common.Hash, tx *types.Transaction) bool {
+	l.all.Range(func(hash common.Hash, tx *Transaction) bool {
 		*l.items = append(*l.items, tx)
 		return true
 	})
@@ -437,13 +436,13 @@ func (l *txPricedList) Removed(count int) {
 
 // Cap finds all the transactions below the given price threshold, drops them
 // from the priced list and returns them for further removal from the entire pool.
-func (l *txPricedList) Cap(threshold *big.Int, local *accountSet) types.Transactions {
-	drop := make(types.Transactions, 0, 128) // Remote underpriced transactions to drop
-	save := make(types.Transactions, 0, 64)  // Local underpriced transactions to keep
+func (l *txPricedList) Cap(threshold *big.Int, local *accountSet) Transactions {
+	drop := make(Transactions, 0, 128) // Remote underpriced transactions to drop
+	save := make(Transactions, 0, 64)  // Local underpriced transactions to keep
 
 	for len(*l.items) > 0 {
 		// Discard stale transactions if found during cleanup
-		tx := heap.Pop(l.items).(*types.Transaction)
+		tx := heap.Pop(l.items).(*Transaction)
 		if l.all.Get(tx.Hash()) == nil {
 			l.stales--
 			continue
@@ -468,14 +467,14 @@ func (l *txPricedList) Cap(threshold *big.Int, local *accountSet) types.Transact
 
 // Underpriced checks whether a transaction is cheaper than (or as cheap as) the
 // lowest priced transaction currently being tracked.
-func (l *txPricedList) Underpriced(tx *types.Transaction, local *accountSet) bool {
+func (l *txPricedList) Underpriced(tx *Transaction, local *accountSet) bool {
 	// Local transactions cannot be underpriced
 	if local.containsTx(tx) {
 		return false
 	}
 	// Discard stale price points if found at the heap start
 	for len(*l.items) > 0 {
-		head := []*types.Transaction(*l.items)[0]
+		head := []*Transaction(*l.items)[0]
 		if l.all.Get(head.Hash()) == nil {
 			l.stales--
 			heap.Pop(l.items)
@@ -488,19 +487,19 @@ func (l *txPricedList) Underpriced(tx *types.Transaction, local *accountSet) boo
 		log.Error("Pricing query for empty pool") // This cannot happen, print to catch programming errors
 		return false
 	}
-	cheapest := []*types.Transaction(*l.items)[0]
+	cheapest := []*Transaction(*l.items)[0]
 	return cheapest.GasPrice().Cmp(tx.GasPrice()) >= 0
 }
 
 // Discard finds a number of most underpriced transactions, removes them from the
 // priced list and returns them for further removal from the entire pool.
-func (l *txPricedList) Discard(count int, local *accountSet) types.Transactions {
-	drop := make(types.Transactions, 0, count) // Remote underpriced transactions to drop
-	save := make(types.Transactions, 0, 64)    // Local underpriced transactions to keep
+func (l *txPricedList) Discard(count int, local *accountSet) Transactions {
+	drop := make(Transactions, 0, count) // Remote underpriced transactions to drop
+	save := make(Transactions, 0, 64)    // Local underpriced transactions to keep
 
 	for len(*l.items) > 0 && count > 0 {
 		// Discard stale transactions if found during cleanup
-		tx := heap.Pop(l.items).(*types.Transaction)
+		tx := heap.Pop(l.items).(*Transaction)
 		if l.all.Get(tx.Hash()) == nil {
 			l.stales--
 			continue

--- a/evmcore/tx_list_test.go
+++ b/evmcore/tx_list_test.go
@@ -34,19 +34,19 @@ func TestStrictTxListAdd(t *testing.T) {
 
 	txs := make(types.Transactions, 1024)
 	for i := 0; i < len(txs); i++ {
-		txs[i] = transaction(uint64(i), 0, key)
+		txs[i] = fakeTx(uint64(i), 0, key)
 	}
 	// Insert the transactions in a random order
 	list := newTxList(true)
 	for _, v := range rand.Perm(len(txs)) {
-		list.Add(txs[v], cfg.PriceBump)
+		list.Add(transaction(txs[v]), cfg.PriceBump)
 	}
 	// Verify internal state
 	if len(list.txs.items) != len(txs) {
 		t.Errorf("transaction count mismatch: have %d, want %d", len(list.txs.items), len(txs))
 	}
 	for i, tx := range txs {
-		if list.txs.items[tx.Nonce()] != tx {
+		if list.txs.items[tx.Nonce()].Transaction != tx {
 			t.Errorf("item %d: transaction mismatch: have %v, want %v", i, list.txs.items[tx.Nonce()], tx)
 		}
 	}

--- a/evmcore/tx_meta.go
+++ b/evmcore/tx_meta.go
@@ -11,19 +11,33 @@ import (
 // Transaction and additional fields
 type Transaction struct {
 	*types.Transaction
+	batch struct {
+		FirstTx common.Hash
+		Count   uint
+	}
 }
 
 // EncodeRLP implements rlp.Encoder
-func (tx *Transaction) EncodeRLP(w io.Writer) error {
-	err := rlp.Encode(w, tx.Transaction)
-	return err
+func (tx *Transaction) EncodeRLP(w io.Writer) (err error) {
+	err = rlp.Encode(w, tx.Transaction)
+	if err != nil {
+		return
+	}
+
+	err = rlp.Encode(w, &tx.batch)
+	return
 }
 
 // DecodeRLP implements rlp.Decoder
-func (tx *Transaction) DecodeRLP(s *rlp.Stream) error {
+func (tx *Transaction) DecodeRLP(s *rlp.Stream) (err error) {
 	tx.Transaction = new(types.Transaction)
-	err := s.Decode(tx.Transaction)
-	return err
+	err = s.Decode(tx.Transaction)
+	if err != nil {
+		return
+	}
+
+	err = s.Decode(&tx.batch)
+	return
 }
 
 // Transactions is a Transaction slice type for basic sorting.

--- a/evmcore/tx_meta.go
+++ b/evmcore/tx_meta.go
@@ -1,0 +1,83 @@
+package evmcore
+
+import (
+	"io"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// Transaction and additional fields
+type Transaction struct {
+	*types.Transaction
+}
+
+// EncodeRLP implements rlp.Encoder
+func (tx *Transaction) EncodeRLP(w io.Writer) error {
+	err := rlp.Encode(w, tx.Transaction)
+	return err
+}
+
+// DecodeRLP implements rlp.Decoder
+func (tx *Transaction) DecodeRLP(s *rlp.Stream) error {
+	tx.Transaction = new(types.Transaction)
+	err := s.Decode(tx.Transaction)
+	return err
+}
+
+// Transactions is a Transaction slice type for basic sorting.
+type Transactions []*Transaction
+
+func transaction(tx *types.Transaction) *Transaction {
+	return &Transaction{
+		Transaction: tx,
+	}
+}
+
+func transactions(txs []*types.Transaction) Transactions {
+	res := make(Transactions, len(txs))
+	for i, t := range txs {
+		res[i] = transaction(t)
+	}
+	return res
+}
+
+func (txs Transactions) Transactions() types.Transactions {
+	res := make(types.Transactions, len(txs))
+	for i, t := range txs {
+		res[i] = t.Transaction
+	}
+	return res
+}
+
+func (txs Transactions) Len() int {
+	return len(txs)
+}
+
+// txByNonce implements the sort interface to allow sorting a list of transactions
+// by their nonces. This is usually only useful for sorting transactions from a
+// single account, otherwise a nonce comparison doesn't make much sense.
+type txByNonce Transactions
+
+func (s txByNonce) Len() int           { return len(s) }
+func (s txByNonce) Less(i, j int) bool { return s[i].Nonce() < s[j].Nonce() }
+func (s txByNonce) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+// txsDifference returns a new set which is the difference between a and b.
+func txsDifference(a, b Transactions) Transactions {
+	keep := make(Transactions, 0, len(a))
+
+	remove := make(map[common.Hash]struct{})
+	for _, tx := range b {
+		remove[tx.Hash()] = struct{}{}
+	}
+
+	for _, tx := range a {
+		if _, ok := remove[tx.Hash()]; !ok {
+			keep = append(keep, tx)
+		}
+	}
+
+	return keep
+}

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -1172,8 +1172,14 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 	if len(events) > 0 {
 		var txs []*types.Transaction
 		for _, set := range events {
-			tt := set.Flatten()
-			txs = append(txs, tt.Transactions()...)
+			var tt types.Transactions
+			for _, t := range set.Flatten() {
+				if t.batch.Count > 0 {
+					continue
+				}
+				tt = append(tt, t.Transaction)
+			}
+			txs = append(txs, tt...)
 		}
 		pool.txFeed.Send(NewTxsNotify{txs})
 	}

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -36,6 +36,17 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
+// AddRemotesSync is like AddRemotes, but waits for pool reorganization. Tests use this method.
+func (pool *TxPool) AddRemotesSync(txs []*types.Transaction) []error {
+	return pool.addTxs(transactions(txs), true, txRemote)
+}
+
+// AddRemoteSync is like AddRemotes with a single transaction, but waits for pool reorganization. Tests use this method.
+func (pool *TxPool) AddRemoteSync(tx *types.Transaction) error {
+	errs := pool.AddRemotesSync([]*types.Transaction{tx})
+	return errs[0]
+}
+
 // testTxPoolConfig is a transaction pool configuration without stateful disk
 // sideeffects used during testing.
 var testTxPoolConfig TxPoolConfig
@@ -560,7 +571,7 @@ func TestTransactionNonceRecovery(t *testing.T) {
 	<-pool.requestReset(nil, nil)
 
 	tx := fakeTx(n, 100000, key)
-	if err := pool.addRemoteSync(tx); err != nil {
+	if err := pool.AddRemoteSync(tx); err != nil {
 		t.Error(err)
 	}
 
@@ -824,7 +835,7 @@ func TestTransactionGapFilling(t *testing.T) {
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}
 	// Fill the nonce gap and ensure all transactions become pending
-	if err := pool.addRemoteSync(fakeTx(1, 100000, key)); err != nil {
+	if err := pool.AddRemoteSync(fakeTx(1, 100000, key)); err != nil {
 		t.Fatalf("failed to add gapped transaction: %v", err)
 	}
 	pending, queued = pool.Stats()
@@ -857,7 +868,7 @@ func TestTransactionQueueAccountLimiting(t *testing.T) {
 
 	// Keep queuing up transactions and make sure all above a limit are dropped
 	for i := uint64(1); i <= testTxPoolConfig.AccountQueue+5; i++ {
-		if err := pool.addRemoteSync(fakeTx(i, 100000, key)); err != nil {
+		if err := pool.AddRemoteSync(fakeTx(i, 100000, key)); err != nil {
 			t.Fatalf("tx %d: failed to add transaction: %v", i, err)
 		}
 		if len(pool.pending) != 0 {
@@ -946,7 +957,7 @@ func testTransactionQueueGlobalLimiting(t *testing.T, nolocals bool) {
 	for i := range ltxs {
 		ltxs[i] = transaction(fakeTx(uint64(i)+1, 100000, local))
 	}
-	pool.addLocals(ltxs)
+	pool.AddLocals(ltxs)
 
 	// If locals are disabled, the previous eviction algorithm should apply here too
 	if nolocals {
@@ -1068,7 +1079,7 @@ func TestTransactionPendingLimiting(t *testing.T) {
 
 	// Keep queuing up transactions and make sure all above a limit are dropped
 	for i := uint64(0); i < testTxPoolConfig.AccountQueue+5; i++ {
-		if err := pool.addRemoteSync(fakeTx(i, 100000, key)); err != nil {
+		if err := pool.AddRemoteSync(fakeTx(i, 100000, key)); err != nil {
 			t.Fatalf("tx %d: failed to add transaction: %v", i, err)
 		}
 		if pool.pending[account].Len() != int(i)+1 {
@@ -1590,7 +1601,7 @@ func TestTransactionPoolStableUnderpricing(t *testing.T) {
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}
 	// Ensure that adding high priced transactions drops a cheap, but doesn't produce a gap
-	if err := pool.addRemoteSync(pricedTransaction(0, 100000, big.NewInt(3), keys[1])); err != nil {
+	if err := pool.AddRemoteSync(pricedTransaction(0, 100000, big.NewInt(3), keys[1])); err != nil {
 		t.Fatalf("failed to add well priced transaction: %v", err)
 	}
 	pending, queued = pool.Stats()
@@ -1638,7 +1649,7 @@ func TestTransactionReplacement(t *testing.T) {
 	price := int64(100)
 	threshold := (price * (100 + int64(testTxPoolConfig.PriceBump))) / 100
 
-	if err := pool.addRemoteSync(pricedTransaction(0, 100000, big.NewInt(1), key)); err != nil {
+	if err := pool.AddRemoteSync(pricedTransaction(0, 100000, big.NewInt(1), key)); err != nil {
 		t.Fatalf("failed to add original cheap pending transaction: %v", err)
 	}
 	if err := pool.AddRemote(pricedTransaction(0, 100001, big.NewInt(1), key)); err != ErrReplaceUnderpriced {
@@ -1651,7 +1662,7 @@ func TestTransactionReplacement(t *testing.T) {
 		t.Fatalf("cheap replacement event firing failed: %v", err)
 	}
 
-	if err := pool.addRemoteSync(pricedTransaction(0, 100000, big.NewInt(price), key)); err != nil {
+	if err := pool.AddRemoteSync(pricedTransaction(0, 100000, big.NewInt(price), key)); err != nil {
 		t.Fatalf("failed to add original proper pending transaction: %v", err)
 	}
 	if err := pool.AddRemote(pricedTransaction(0, 100001, big.NewInt(threshold-1), key)); err != ErrReplaceUnderpriced {
@@ -1746,7 +1757,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	if err := pool.AddLocal(pricedTransaction(2, 100000, big.NewInt(1), local)); err != nil {
 		t.Fatalf("failed to add local transaction: %v", err)
 	}
-	if err := pool.addRemoteSync(pricedTransaction(0, 100000, big.NewInt(1), remote)); err != nil {
+	if err := pool.AddRemoteSync(pricedTransaction(0, 100000, big.NewInt(1), remote)); err != nil {
 		t.Fatalf("failed to add remote transaction: %v", err)
 	}
 	pending, queued := pool.Stats()


### PR DESCRIPTION
TxPool.AddTxBatch() and TxPool.Pending() provides all txs of batch only together. So txs of batch will be included into the same block.
RPC PublicTransactionPoolAPI.SendTxBatch() wraps TxPool.AddTxBatch().