### PR TITLE
Separate async DB

### DIFF
--- a/gossip/service.go
+++ b/gossip/service.go
@@ -151,7 +151,7 @@ func NewService(ctx *node.ServiceContext, config *Config, store *Store, engine C
 
 	// create server pool
 	trustedNodes := []string{}
-	svc.serverPool = newServerPool(store.table.Peers, svc.done, &svc.wg, trustedNodes)
+	svc.serverPool = newServerPool(store.async.table.Peers, svc.done, &svc.wg, trustedNodes)
 
 	// create tx pool
 	stateReader := svc.GetEvmStateReader()

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -25,13 +25,12 @@ type Store struct {
 	dbs *flushable.SyncedPool
 	cfg StoreConfig
 
+	async *asyncStore
+
 	mainDb kvdb.KeyValueStore
 	app    *app.Store
 	table  struct {
 		Version kvdb.KeyValueStore `table:"_"`
-
-		// Network tables
-		Peers kvdb.KeyValueStore `table:"Z"`
 
 		// Main DAG tables
 		Events    kvdb.KeyValueStore `table:"e"`
@@ -89,6 +88,7 @@ func NewStore(dbs *flushable.SyncedPool, cfg StoreConfig, appCfg app.StoreConfig
 	s := &Store{
 		dbs:      dbs,
 		cfg:      cfg,
+		async:    newAsyncStore(dbs),
 		mainDb:   dbs.GetDb("gossip-main"),
 		Instance: logger.MakeInstance(),
 	}
@@ -138,6 +138,7 @@ func (s *Store) Close() {
 	table.MigrateCaches(&s.cache, setnil)
 
 	s.mainDb.Close()
+	s.async.Close()
 }
 
 // Commit changes.

--- a/gossip/store_async.go
+++ b/gossip/store_async.go
@@ -1,0 +1,34 @@
+package gossip
+
+import (
+	"github.com/Fantom-foundation/go-lachesis/kvdb"
+	"github.com/Fantom-foundation/go-lachesis/kvdb/flushable"
+	"github.com/Fantom-foundation/go-lachesis/kvdb/table"
+)
+
+type asyncStore struct {
+	dbs    *flushable.SyncedPool
+	mainDb kvdb.KeyValueStore
+	table  struct {
+		// Network tables
+		Peers kvdb.KeyValueStore `table:"Z"`
+	}
+}
+
+func newAsyncStore(dbs *flushable.SyncedPool) *asyncStore {
+	s := &asyncStore{
+		dbs:    dbs,
+		mainDb: dbs.GetDb("gossip-async"),
+	}
+
+	table.MigrateTables(&s.table, s.mainDb)
+
+	return s
+}
+
+// Close leaves underlying database.
+func (s *asyncStore) Close() {
+	table.MigrateTables(&s.table, nil)
+
+	s.mainDb.Close()
+}

--- a/gossip/store_migration.go
+++ b/gossip/store_migration.go
@@ -12,9 +12,10 @@ func (s *Store) Migrate() error {
 func (s *Store) migrations() *migration.Migration {
 	return migration.
 		Begin("lachesis-gossip-store").
-		Next("remove serverPool from PackInfos table",
+		Next("remove async data from sync DBs",
 			func() error {
 				s.rmPrefix(s.table.PackInfos, "serverPool")
+				s.rmPrefix(s.mainDb, "Z")
 				return nil
 			}).
 		Next("remove legacy genesis field",


### PR DESCRIPTION
Use a different DB for storing data which isn't protected by a mutex, namely storing peers in gossip/serverpool.go.

Re-work of #431 for develop2 branch