### PR TITLE
Events export and import

### DIFF
--- a/cmd/lachesis/chaincmd.go
+++ b/cmd/lachesis/chaincmd.go
@@ -1,27 +1,8 @@
 package main
 
 import (
-	"time"
-
 	"github.com/ethereum/go-ethereum/cmd/utils"
-	"github.com/ethereum/go-ethereum/node"
 	"gopkg.in/urfave/cli.v1"
-
-	"github.com/Fantom-foundation/go-lachesis/cmd/lachesis/metrics"
-	"github.com/Fantom-foundation/go-lachesis/gossip"
-	"github.com/Fantom-foundation/go-lachesis/integration"
-	"github.com/Fantom-foundation/go-lachesis/kvdb"
-	"github.com/Fantom-foundation/go-lachesis/utils/errlock"
-)
-
-const (
-	// statsReportLimit is the time limit during import and export after which we
-	// always print out progress. This avoids the user wondering what's going on.
-	statsReportLimit = 8 * time.Second
-
-	importBatchSize = 2500
-
-	importFlushBatch = 300
 )
 
 var (
@@ -40,16 +21,13 @@ var (
 		},
 		Category: "MISCELLANEOUS COMMANDS",
 		Description: `
-The import command imports blocks(events) from an RLP-encoded form. The form can be one file
-with several RLP-encoded blocks(events), or several files can be used.
-If only one file is used, import error will result in failure. If several files are used,
-processing will proceed even if an individual RLP-file import failure occurs.`,
+The import command imports events from an RLP-encoded files.`,
 	}
 	exportCommand = cli.Command{
 		Action:    utils.MigrateFlags(exportChain),
 		Name:      "export",
 		Usage:     "Export blockchain into file",
-		ArgsUsage: "<filename> [<blockNumFirst> <blockNumLast>]",
+		ArgsUsage: "<filename> [<epochFrom> <epochTo>]",
 		Flags: []cli.Flag{
 			DataDirFlag,
 			utils.CacheFlag,
@@ -60,38 +38,7 @@ processing will proceed even if an individual RLP-file import failure occurs.`,
 		Description: `
 Requires a first argument of the file to write to.
 Optional second and third arguments control the first and
-last block to write. In this mode, the file will be appended
-if already existing. If the file ends with .gz, the output will
+last epoch to write. If the file ends with .gz, the output will
 be gzipped.`,
 	}
 )
-
-func makeFNode(ctx *cli.Context, gossipCreate bool) (config, *node.Node, gossip.Consensus, kvdb.KeyValueStore, *gossip.Store) {
-	cfg := makeAllConfigs(ctx)
-
-	// check errlock file
-	errlock.SetDefaultDatadir(cfg.Node.DataDir)
-	errlock.Check()
-
-	stack := makeConfigNode(ctx, &cfg.Node)
-	defer stack.Close()
-
-	engine, dbs, gdb := integration.MakeEngine(cfg.Node.DataDir, &cfg.Lachesis)
-	metrics.SetDataDir(cfg.Node.DataDir)
-
-	if gossipCreate {
-		// Create and register a gossip network service. This is done through the definition
-		// of a node.ServiceConstructor that will instantiate a node.Service. The reason for
-		// the factory method approach is to support service restarts without relying on the
-		// individual implementations' support for such operations.
-		gossipService := func(ctx *node.ServiceContext) (node.Service, error) {
-			return gossip.NewService(ctx, &cfg.Lachesis, gdb, engine)
-		}
-
-		if err := stack.Register(gossipService); err != nil {
-			utils.Fatalf("Failed to register the service: %v", err)
-		}
-	}
-
-	return cfg, stack, engine, dbs.GetDb("gossip-main"), gdb
-}

--- a/cmd/lachesis/chaincmd.go
+++ b/cmd/lachesis/chaincmd.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"fmt"
+	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/log"
+	"gopkg.in/urfave/cli.v1"
+	"runtime"
+	"strconv"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	importCommand = cli.Command{
+		Action:    utils.MigrateFlags(importChain),
+		Name:      "import",
+		Usage:     "Import a blockchain file",
+		ArgsUsage: "<filename> (<filename 2> ... <filename N>) ",
+		Flags: []cli.Flag{
+			DataDirFlag,
+			utils.CacheFlag,
+			utils.SyncModeFlag,
+			utils.GCModeFlag,
+			utils.CacheDatabaseFlag,
+			utils.CacheGCFlag,
+		},
+		Category: "MISCELLANEOUS COMMANDS",
+		Description: `
+The import command imports blocks(events) from an RLP-encoded form. The form can be one file
+with several RLP-encoded blocks(events), or several files can be used.
+If only one file is used, import error will result in failure. If several files are used,
+processing will proceed even if an individual RLP-file import failure occurs.`,
+	}
+	exportCommand = cli.Command{
+		Action:    utils.MigrateFlags(exportChain),
+		Name:      "export",
+		Usage:     "Export blockchain into file",
+		ArgsUsage: "<filename> [<blockNumFirst> <blockNumLast>]",
+		Flags: []cli.Flag{
+			DataDirFlag,
+			utils.CacheFlag,
+			utils.SyncModeFlag,
+			utils.GCModeFlag,
+		},
+		Category: "MISCELLANEOUS COMMANDS",
+		Description: `
+Requires a first argument of the file to write to.
+Optional second and third arguments control the first and
+last block to write. In this mode, the file will be appended
+if already existing. If the file ends with .gz, the output will
+be gzipped.`,
+	}
+)
+
+func importChain(ctx *cli.Context) error {
+	if len(ctx.Args()) < 1 {
+		utils.Fatalf("This command requires an argument.")
+	}
+	stack := makeFullNode(ctx)
+	defer stack.Close()
+
+	chain, db := utils.MakeChain(ctx, stack)
+	defer db.Close()
+
+	// Start periodically gathering memory profiles
+	var peakMemAlloc, peakMemSys uint64
+	go func() {
+		stats := new(runtime.MemStats)
+		for {
+			runtime.ReadMemStats(stats)
+			if atomic.LoadUint64(&peakMemAlloc) < stats.Alloc {
+				atomic.StoreUint64(&peakMemAlloc, stats.Alloc)
+			}
+			if atomic.LoadUint64(&peakMemSys) < stats.Sys {
+				atomic.StoreUint64(&peakMemSys, stats.Sys)
+			}
+			time.Sleep(5 * time.Second)
+		}
+	}()
+	// Import the chain
+	start := time.Now()
+
+	if len(ctx.Args()) == 1 {
+		if err := utils.ImportChain(chain, ctx.Args().First()); err != nil {
+			log.Error("Import error", "err", err)
+		}
+	} else {
+		for _, arg := range ctx.Args() {
+			if err := utils.ImportChain(chain, arg); err != nil {
+				log.Error("Import error", "file", arg, "err", err)
+			}
+		}
+	}
+	chain.Stop()
+	fmt.Printf("Import done in %v.\n\n", time.Since(start))
+
+	// Output pre-compaction stats mostly to see the import trashing
+	stats, err := db.Stat("leveldb.stats")
+	if err != nil {
+		utils.Fatalf("Failed to read database stats: %v", err)
+	}
+	fmt.Println(stats)
+
+	ioStats, err := db.Stat("leveldb.iostats")
+	if err != nil {
+		utils.Fatalf("Failed to read database iostats: %v", err)
+	}
+	fmt.Println(ioStats)
+
+	// Print the memory statistics used by the importing
+	mem := new(runtime.MemStats)
+	runtime.ReadMemStats(mem)
+
+	fmt.Printf("Object memory: %.3f MB current, %.3f MB peak\n", float64(mem.Alloc)/1024/1024, float64(atomic.LoadUint64(&peakMemAlloc))/1024/1024)
+	fmt.Printf("System memory: %.3f MB current, %.3f MB peak\n", float64(mem.Sys)/1024/1024, float64(atomic.LoadUint64(&peakMemSys))/1024/1024)
+	fmt.Printf("Allocations:   %.3f million\n", float64(mem.Mallocs)/1000000)
+	fmt.Printf("GC pause:      %v\n\n", time.Duration(mem.PauseTotalNs))
+
+	if ctx.GlobalBool(utils.NoCompactionFlag.Name) {
+		return nil
+	}
+
+	// Compact the entire database to more accurately measure disk io and print the stats
+	start = time.Now()
+	fmt.Println("Compacting entire database...")
+	if err = db.Compact(nil, nil); err != nil {
+		utils.Fatalf("Compaction failed: %v", err)
+	}
+	fmt.Printf("Compaction done in %v.\n\n", time.Since(start))
+
+	stats, err = db.Stat("leveldb.stats")
+	if err != nil {
+		utils.Fatalf("Failed to read database stats: %v", err)
+	}
+	fmt.Println(stats)
+
+	ioStats, err = db.Stat("leveldb.iostats")
+	if err != nil {
+		utils.Fatalf("Failed to read database iostats: %v", err)
+	}
+	fmt.Println(ioStats)
+	return nil
+}
+
+func exportChain(ctx *cli.Context) error {
+	if len(ctx.Args()) < 1 {
+		utils.Fatalf("This command requires an argument.")
+	}
+	stack := makeFullNode(ctx)
+	defer stack.Close()
+
+	chain, _ := utils.MakeChain(ctx, stack)
+	start := time.Now()
+
+	var err error
+	fp := ctx.Args().First()
+	if len(ctx.Args()) < 3 {
+		err = utils.ExportChain(chain, fp)
+	} else {
+		// This can be improved to allow for numbers larger than 9223372036854775807
+		first, ferr := strconv.ParseInt(ctx.Args().Get(1), 10, 64)
+		last, lerr := strconv.ParseInt(ctx.Args().Get(2), 10, 64)
+		if ferr != nil || lerr != nil {
+			utils.Fatalf("Export error in parsing parameters: block number not an integer\n")
+		}
+		if first < 0 || last < 0 {
+			utils.Fatalf("Export error: block number must be greater than 0\n")
+		}
+		err = utils.ExportAppendChain(chain, fp, uint64(first), uint64(last))
+	}
+
+	if err != nil {
+		utils.Fatalf("Export error: %v\n", err)
+	}
+	fmt.Printf("Export done in %v\n", time.Since(start))
+	return nil
+}

--- a/cmd/lachesis/chaincmd.go
+++ b/cmd/lachesis/chaincmd.go
@@ -10,7 +10,7 @@ var (
 		Action:    utils.MigrateFlags(importChain),
 		Name:      "import",
 		Usage:     "Import a blockchain file",
-		ArgsUsage: "<filename> (<filename 2> ... <filename N>) ",
+		ArgsUsage: "<filename> (<filename 2> ... <filename N>) [check=false]",
 		Flags: []cli.Flag{
 			DataDirFlag,
 			utils.CacheFlag,
@@ -21,7 +21,8 @@ var (
 		},
 		Category: "MISCELLANEOUS COMMANDS",
 		Description: `
-The import command imports events from an RLP-encoded files.`,
+The import command imports events from an RLP-encoded files.
+Events are fully verified by default, unless overridden by check=false flag.`,
 	}
 	exportCommand = cli.Command{
 		Action:    utils.MigrateFlags(exportChain),

--- a/cmd/lachesis/config.go
+++ b/cmd/lachesis/config.go
@@ -234,7 +234,7 @@ func nodeConfigWithFlags(ctx *cli.Context, cfg node.Config) node.Config {
 	return cfg
 }
 
-func makeAllConfigs(ctx *cli.Context) config {
+func makeAllConfigs(ctx *cli.Context) *config {
 	// Defaults (low priority)
 	net := defaultLachesisConfig(ctx)
 	cfg := config{Lachesis: gossip.DefaultConfig(net), Node: defaultNodeConfig()}
@@ -250,7 +250,7 @@ func makeAllConfigs(ctx *cli.Context) config {
 	cfg.Lachesis = gossipConfigWithFlags(ctx, cfg.Lachesis)
 	cfg.Node = nodeConfigWithFlags(ctx, cfg.Node)
 
-	return cfg
+	return &cfg
 }
 
 func defaultNodeConfig() node.Config {

--- a/cmd/lachesis/consolecmd.go
+++ b/cmd/lachesis/consolecmd.go
@@ -77,7 +77,7 @@ JavaScript API. See https://github.com/ethereum/go-ethereum/wiki/JavaScript-Cons
 // same time.
 func localConsole(ctx *cli.Context) error {
 	// Create and start the node based on the CLI flags
-	node := makeFullNode(ctx)
+	node := makeNode(ctx, makeAllConfigs(ctx))
 	startNode(ctx, node)
 	defer node.Close()
 
@@ -177,7 +177,7 @@ func dialRPC(endpoint string) (*rpc.Client, error) {
 // everything down.
 func ephemeralConsole(ctx *cli.Context) error {
 	// Create and start the node based on the CLI flags
-	node := makeFullNode(ctx)
+	node := makeNode(ctx, makeAllConfigs(ctx))
 	startNode(ctx, node)
 	defer node.Close()
 

--- a/cmd/lachesis/export.go
+++ b/cmd/lachesis/export.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/Fantom-foundation/go-lachesis/gossip"
 	"github.com/Fantom-foundation/go-lachesis/inter"
-	"github.com/Fantom-foundation/go-lachesis/inter/idx"
 )
 
 func exportChain(ctx *cli.Context) error {
@@ -73,9 +72,8 @@ func Export(gdb *gossip.Store, w io.Writer) error {
 	start, reported := time.Now(), time.Now()
 
 	var (
-		events      inter.Events
-		sealedEpoch idx.Epoch
-		prevEvent   *inter.Event
+		events    inter.Events
+		prevEvent *inter.Event
 	)
 	gdb.ForEachEventWithoutEpoch(func(event *inter.Event) bool {
 		if event == nil {
@@ -86,7 +84,6 @@ func Export(gdb *gossip.Store, w io.Writer) error {
 			prevEvent = event
 		}
 		if len(event.Parents) == 0 && prevEvent.Epoch != event.Epoch {
-			sealedEpoch = prevEvent.Epoch
 			for _, event := range events {
 				log.Debug("exported", "event", event.String())
 				err := event.EncodeRLP(w)

--- a/cmd/lachesis/export.go
+++ b/cmd/lachesis/export.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"github.com/Fantom-foundation/go-lachesis/gossip"
+	"github.com/Fantom-foundation/go-lachesis/integration"
+	"github.com/Fantom-foundation/go-lachesis/inter"
+	"github.com/Fantom-foundation/go-lachesis/kvdb"
+	"github.com/Fantom-foundation/go-lachesis/kvdb/flushable"
+	"github.com/Fantom-foundation/go-lachesis/utils/errlock"
+	"github.com/Fantom-foundation/go-lachesis/version"
+	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"gopkg.in/urfave/cli.v1"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+func exportChain(ctx *cli.Context) error {
+	if len(ctx.Args()) < 1 {
+		utils.Fatalf("This command requires an argument.")
+	}
+
+	cfg := makeAllConfigs(ctx)
+
+	if !cfg.Lachesis.NoCheckVersion {
+		ver := params.VersionWithCommit(gitCommit, gitDate)
+		status, msg, err := version.CheckRelease(nil, ver)
+		applyVersionCheck(&cfg, status, msg, err)
+	}
+
+	// check errlock file
+	errlock.SetDefaultDatadir(cfg.Node.DataDir)
+	errlock.Check()
+
+	stack := makeConfigNode(ctx, &cfg.Node)
+	defer stack.Close()
+
+	_, gdb := makeGDB(cfg.Node.DataDir, &cfg.Lachesis)
+	defer gdb.Close()
+
+	start := time.Now()
+
+	var err error
+	fp := ctx.Args().First()
+
+	err = ExportChain(gdb, fp)
+	if err != nil {
+		utils.Fatalf("Export error: %v\n", err)
+	}
+	fmt.Printf("Export done in %v\n", time.Since(start))
+	return nil
+}
+
+func makeGDB(dataDir string, gossipCfg *gossip.Config) (kvdb.KeyValueStore, *gossip.Store) {
+	dbs := flushable.NewSyncedPool(integration.DBProducer(dataDir))
+
+	gdb := gossip.NewStore(dbs, gossipCfg.StoreConfig)
+	gdb.SetName("gossip-db")
+	return dbs.GetDb("gossip-main"), gdb
+}
+
+// ExportChain exports a blockchain into the specified file, truncating any data
+// already present in the file.
+func ExportChain(gdb *gossip.Store, fn string) error {
+	log.Info("Exporting events", "file", fn)
+
+	// Open the file handle and potentially wrap with a gzip stream
+	fh, err := os.OpenFile(fn, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+
+	var writer io.Writer = fh
+	if strings.HasSuffix(fn, ".gz") {
+		writer = gzip.NewWriter(writer)
+		defer writer.(*gzip.Writer).Close()
+	}
+	// Iterate over the blocks and export them
+	if err := Export(gdb, writer); err != nil {
+		return err
+	}
+	log.Info("Exported blockchain", "file", fn)
+
+	return nil
+}
+
+// Export writes the active chain to the given writer.
+func Export(gdb *gossip.Store, w io.Writer) error {
+	log.Info("Exporting batch of events")
+	var err error
+	start, reported := time.Now(), time.Now()
+
+	gdb.ForEachEventWithoutEpoch(func(event *inter.Event) bool {
+		log.Debug("export--->", "event", event.String())
+		if event == nil {
+			err = errors.New("export failed, event not found")
+			return false
+		}
+		err := event.EncodeRLP(w)
+		if err != nil {
+			err = fmt.Errorf("export failed, error: %v", err)
+			return false
+		}
+		if time.Since(reported) >= statsReportLimit {
+			log.Info("Exporting events", "exported", event.String(), "elapsed", common.PrettyDuration(time.Since(start)))
+			reported = time.Now()
+		}
+		return true
+	})
+
+	return err
+}

--- a/cmd/lachesis/import.go
+++ b/cmd/lachesis/import.go
@@ -1,159 +1,117 @@
 package main
 
 import (
+	"bytes"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/signal"
-	"runtime"
 	"strings"
-	"sync/atomic"
 	"syscall"
 	"time"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/status-im/keycard-go/hexutils"
 	"gopkg.in/urfave/cli.v1"
 
+	"github.com/Fantom-foundation/go-lachesis/eventcheck"
+	"github.com/Fantom-foundation/go-lachesis/eventcheck/epochcheck"
 	"github.com/Fantom-foundation/go-lachesis/gossip"
+	"github.com/Fantom-foundation/go-lachesis/hash"
 	"github.com/Fantom-foundation/go-lachesis/inter"
-	"github.com/Fantom-foundation/go-lachesis/inter/idx"
 )
 
 func importChain(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
-	_, stack, engine, db, gdb := makeFNode(ctx, true)
-	utils.StartNode(stack)
 
-	// Start periodically gathering memory profiles
-	var peakMemAlloc, peakMemSys uint64
-	go func() {
-		stats := new(runtime.MemStats)
-		for {
-			runtime.ReadMemStats(stats)
-			if atomic.LoadUint64(&peakMemAlloc) < stats.Alloc {
-				atomic.StoreUint64(&peakMemAlloc, stats.Alloc)
-			}
-			if atomic.LoadUint64(&peakMemSys) < stats.Sys {
-				atomic.StoreUint64(&peakMemSys, stats.Sys)
-			}
-			time.Sleep(5 * time.Second)
-		}
-	}()
-	// Import the chain
-	start := time.Now()
+	// avoid P2P interaction, API calls and events emitting
+	cfg := makeAllConfigs(ctx)
+	cfg.Lachesis.Emitter.Validator = common.Address{}
+	cfg.Lachesis.TxPool.Journal = ""
+	cfg.Node.IPCPath = ""
+	cfg.Node.HTTPHost = ""
+	cfg.Node.WSHost = ""
+	cfg.Node.NoUSB = true
+	cfg.Node.P2P.ListenAddr = ""
+	cfg.Node.P2P.NoDiscovery = true
+	cfg.Node.P2P.BootstrapNodes = nil
+	cfg.Node.P2P.DiscoveryV5 = false
+	cfg.Node.P2P.BootstrapNodesV5 = nil
+	cfg.Node.P2P.StaticNodes = nil
+	cfg.Node.P2P.TrustedNodes = nil
 
-	if len(ctx.Args()) == 1 {
-		if err := ImportChain(engine, gdb, ctx.Args().First()); err != nil {
-			log.Error("Import error", "err", err)
-		}
-	} else {
-		for _, arg := range ctx.Args() {
-			if err := ImportChain(engine, gdb, arg); err != nil {
-				log.Error("Import error", "file", arg, "err", err)
-			}
-		}
-	}
-
-	fmt.Printf("Import done in %v.\n\n", time.Since(start))
-
-	// Output pre-compaction stats mostly to see the import trashing
-	stats, err := db.Stat("leveldb.stats")
+	err := importToNode(ctx, cfg, ctx.Args()...)
 	if err != nil {
-		utils.Fatalf("Failed to read database stats: %v", err)
-	}
-	fmt.Println(stats)
-
-	ioStats, err := db.Stat("leveldb.iostats")
-	if err != nil {
-		utils.Fatalf("Failed to read database iostats: %v", err)
-	}
-	fmt.Println(ioStats)
-
-	// Print the memory statistics used by the importing
-	mem := new(runtime.MemStats)
-	runtime.ReadMemStats(mem)
-
-	fmt.Printf("Object memory: %.3f MB current, %.3f MB peak\n", float64(mem.Alloc)/1024/1024, float64(atomic.LoadUint64(&peakMemAlloc))/1024/1024)
-	fmt.Printf("System memory: %.3f MB current, %.3f MB peak\n", float64(mem.Sys)/1024/1024, float64(atomic.LoadUint64(&peakMemSys))/1024/1024)
-	fmt.Printf("Allocations:   %.3f million\n", float64(mem.Mallocs)/1000000)
-	fmt.Printf("GC pause:      %v\n\n", time.Duration(mem.PauseTotalNs))
-
-	if ctx.GlobalBool(utils.NoCompactionFlag.Name) {
-		stack.Stop()
-		return nil
+		return err
 	}
 
-	// Compact the entire database to more accurately measure disk io and print the stats
-	start = time.Now()
-	fmt.Println("Compacting entire database...")
-	if err = db.Compact(nil, nil); err != nil {
-		utils.Fatalf("Compaction failed: %v", err)
-	}
-	fmt.Printf("Compaction done in %v.\n\n", time.Since(start))
-
-	stats, err = db.Stat("leveldb.stats")
-	if err != nil {
-		utils.Fatalf("Failed to read database stats: %v", err)
-	}
-	fmt.Println(stats)
-
-	ioStats, err = db.Stat("leveldb.iostats")
-	if err != nil {
-		utils.Fatalf("Failed to read database iostats: %v", err)
-	}
-	fmt.Println(ioStats)
-
-	var (
-		networkMsgFlag string
-		hint           = " flag when starting a node"
-		fakenet        = ctx.GlobalString(FakeNetFlag.Name)
-		testnet        = ctx.GlobalString(utils.TestnetFlag.Name)
-	)
-	if fakenet != "" {
-		networkMsgFlag = "--" + FakeNetFlag.Name + " " + fakenet
-		hint = "Use " + networkMsgFlag + hint
-	} else if testnet != "" {
-		networkMsgFlag = "--" + utils.TestnetFlag.Name
-		hint = "Use " + networkMsgFlag + hint
-	} else {
-		networkMsgFlag = "mainnet"
-		hint = "Mainnet installed by default" + hint
-	}
-
-	log.Warn("Import was made for "+networkMsgFlag+" network, imported events apply only to this network", "hint", hint)
-	stack.Stop()
 	return nil
 }
 
-func ImportChain(engine gossip.Consensus, gdb *gossip.Store, fn string) error {
-	// Watch for Ctrl-C while the import is running.
-	// If a signal is received, the import will stop at the next batch.
-	interrupt := make(chan os.Signal, 1)
-	stop := make(chan struct{})
-	signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
-	defer signal.Stop(interrupt)
-	defer close(interrupt)
-	go func() {
-		if _, ok := <-interrupt; ok {
-			log.Info("Interrupted during import, stopping at next batch")
-		}
-		close(stop)
-	}()
-	checkInterrupt := func() bool {
-		select {
-		case <-stop:
-			return true
-		default:
-			return false
+func importToNode(ctx *cli.Context, cfg *config, args ...string) error {
+	node := makeNode(ctx, cfg)
+	defer node.Close()
+	startNode(ctx, node)
+
+	var srv *gossip.Service
+	if err := node.Service(&srv); err != nil {
+		return err
+	}
+
+	check := true
+	for _, arg := range ctx.Args() {
+		if arg == "check=false" || arg == "check=0" {
+			check = false
 		}
 	}
 
-	log.Info("Importing events", "file", fn)
+	for _, fn := range args {
+		if strings.HasPrefix(fn, "check=") {
+			continue
+		}
+		if err := importFile(srv, check, fn); err != nil {
+			log.Error("Import error", "file", fn, "err", err)
+			return err
+		}
+	}
+	return nil
+}
+
+func checkEventsFileHeader(reader io.Reader) error {
+	headerAndVersion := make([]byte, len(eventsFileHeader)+len(eventsFileVersion))
+	n, err := reader.Read(headerAndVersion)
+	if err != nil {
+		return err
+	}
+	if n != len(headerAndVersion) {
+		return errors.New("expected an events file, the given file is too short")
+	}
+	if bytes.Compare(headerAndVersion[:len(eventsFileHeader)], eventsFileHeader) != 0 {
+		return errors.New("expected an events file, mismatched file header")
+	}
+	if bytes.Compare(headerAndVersion[len(eventsFileHeader):], eventsFileVersion) != 0 {
+		got := hexutils.BytesToHex(headerAndVersion[len(eventsFileHeader):])
+		expected := hexutils.BytesToHex(eventsFileVersion)
+		return errors.New(fmt.Sprintf("wrong version of events file, got=%s, expected=%s", got, expected))
+	}
+	return nil
+}
+
+func importFile(srv *gossip.Service, check bool, fn string) error {
+	// Watch for Ctrl-C while the import is running.
+	// If a signal is received, the import will stop.
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(interrupt)
+
+	log.Info("Importing events from file", "file", fn, "check", check)
 
 	// Open the file handle and potentially unwrap the gzip stream
 	fh, err := os.Open(fn)
@@ -168,102 +126,52 @@ func ImportChain(engine gossip.Consensus, gdb *gossip.Store, fn string) error {
 			return err
 		}
 	}
+
+	// Check file version and header
+	if err := checkEventsFileHeader(reader); err != nil {
+		return err
+	}
+
 	stream := rlp.NewStream(reader, 0)
-	// Run actual the import.
-	for batch := 0; ; batch++ {
-		// Load a batch of RLP events.
-		if checkInterrupt() {
+
+	start := time.Now()
+	skipped := 0
+	imported := 0
+	last := hash.Event{}
+	for {
+		select {
+		case <-interrupt:
 			return fmt.Errorf("interrupted")
+		default:
 		}
-		eventsBatch := make(inter.Events, 0, importBatchSize)
-		i := 0
-		for ; i < importBatchSize; i++ {
-			var e inter.Event
-			if err = stream.Decode(&e); err == io.EOF {
-				break
-			} else if err != nil {
-				return fmt.Errorf("at event decode error: %v", err)
-			}
-			eventsBatch = append(eventsBatch, &e)
-		}
-		if len(eventsBatch) == 0 {
+		e := new(inter.Event)
+		err = stream.Decode(e)
+		if err == io.EOF {
 			break
 		}
-		// Import the batch.
-		if checkInterrupt() {
-			return fmt.Errorf("interrupted")
+		if err != nil {
+			return err
 		}
 
-		missing := missingEvents(gdb, eventsBatch)
-		if len(missing) == 0 {
-			log.Info(
-				"Skipping batch as all events present", "batch", batch,
-				"first", eventsBatch[0].Hash(), "last", eventsBatch[len(eventsBatch)-1].Hash())
-			continue
-		}
-		if err := insertEvents(engine, gdb, missing); err != nil {
-			return fmt.Errorf("insert events error: %v", err)
-		}
-		log.Debug(
-			"events batch inserted", "batch", batch,
-			"first", eventsBatch[0].Hash(), "last", eventsBatch[len(eventsBatch)-1].Hash())
-	}
-	return nil
-}
-
-func missingEvents(gdb *gossip.Store, events []*inter.Event) []*inter.Event {
-	var missingEvents []*inter.Event
-	for _, event := range events {
-		if gdb.HasEvent(event.Hash()) {
-			log.Debug("event exist", "event", event)
-			continue
-		}
-		missingEvents = append(missingEvents, event)
-	}
-	return missingEvents
-}
-
-func insertEvents(engine gossip.Consensus, gdb *gossip.Store, events []*inter.Event) error {
-	if len(events) == 0 {
-		return nil
-	}
-	var (
-		current     int
-		newEpoch    idx.Epoch
-		sealedEpoch idx.Epoch
-	)
-	for _, event := range events {
-		if newEpoch < event.Epoch {
-			sealedEpoch = newEpoch
-			newEpoch = event.Epoch
-		}
-		if current == importFlushBatch {
-			current = 0
-			err := gdb.Commit(nil, true)
-			if err != nil {
+		eStart := time.Now()
+		if check {
+			err := srv.ValidateEvent(e)
+			if err != nil && err != epochcheck.ErrNotRelevant && err != eventcheck.ErrAlreadyConnectedEvent {
 				return err
 			}
 		}
-		current++
-		if gdb.HasEventHeader(event.Hash()) {
-			continue
-		}
-
-		ev := engine.Prepare(event)
-		if ev == nil {
-			continue
-		}
-		gdb.SetEvent(ev)
-		err := engine.ProcessEvent(ev)
-		if err != nil {
-			gdb.DeleteEvent(ev.Epoch, ev.Hash())
+		err := srv.ProcessEvent(e)
+		if err == epochcheck.ErrNotRelevant || err == eventcheck.ErrAlreadyConnectedEvent {
+			skipped++
+		} else if err != nil {
 			return err
+		} else {
+			log.Info("New event imported", "id", e.Hash(), "checked", check, "t", time.Since(eStart), "imported", imported, "skipped", skipped, "elapsed", common.PrettyDuration(time.Since(start)))
+			last = e.Hash()
+			imported++
 		}
-		gdb.EpochDbs.Del(uint64(sealedEpoch))
 	}
-	err := gdb.Commit(nil, true)
-	if err != nil {
-		return err
-	}
+	log.Info("Events import is finished", "file", fn, "checked", check, "last", last.String(), "imported", imported, "skipped", skipped, "elapsed", common.PrettyDuration(time.Since(start)))
+
 	return nil
 }

--- a/cmd/lachesis/import.go
+++ b/cmd/lachesis/import.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
+	"gopkg.in/urfave/cli.v1"
+
+	"github.com/Fantom-foundation/go-lachesis/gossip"
+	"github.com/Fantom-foundation/go-lachesis/inter"
+	"github.com/Fantom-foundation/go-lachesis/inter/idx"
+)
+
+func importChain(ctx *cli.Context) error {
+	if len(ctx.Args()) < 1 {
+		utils.Fatalf("This command requires an argument.")
+	}
+	cfg, stack, engine, db, gdb := makeFNode(ctx, true)
+	log.Debug("CONFIG LACHESIS STORE", "store config", cfg.Lachesis.StoreConfig)
+	utils.StartNode(stack)
+
+	// Start periodically gathering memory profiles
+	var peakMemAlloc, peakMemSys uint64
+	go func() {
+		stats := new(runtime.MemStats)
+		for {
+			runtime.ReadMemStats(stats)
+			if atomic.LoadUint64(&peakMemAlloc) < stats.Alloc {
+				atomic.StoreUint64(&peakMemAlloc, stats.Alloc)
+			}
+			if atomic.LoadUint64(&peakMemSys) < stats.Sys {
+				atomic.StoreUint64(&peakMemSys, stats.Sys)
+			}
+			time.Sleep(5 * time.Second)
+		}
+	}()
+	// Import the chain
+	start := time.Now()
+
+	if len(ctx.Args()) == 1 {
+		if err := ImportChain(engine, gdb, ctx.Args().First()); err != nil {
+			log.Error("Import error", "err", err)
+		}
+	} else {
+		for _, arg := range ctx.Args() {
+			if err := ImportChain(engine, gdb, arg); err != nil {
+				log.Error("Import error", "file", arg, "err", err)
+			}
+		}
+	}
+
+	fmt.Printf("Import done in %v.\n\n", time.Since(start))
+
+	// Output pre-compaction stats mostly to see the import trashing
+	stats, err := db.Stat("leveldb.stats")
+	if err != nil {
+		utils.Fatalf("Failed to read database stats: %v", err)
+	}
+	fmt.Println(stats)
+
+	ioStats, err := db.Stat("leveldb.iostats")
+	if err != nil {
+		utils.Fatalf("Failed to read database iostats: %v", err)
+	}
+	fmt.Println(ioStats)
+
+	// Print the memory statistics used by the importing
+	mem := new(runtime.MemStats)
+	runtime.ReadMemStats(mem)
+
+	fmt.Printf("Object memory: %.3f MB current, %.3f MB peak\n", float64(mem.Alloc)/1024/1024, float64(atomic.LoadUint64(&peakMemAlloc))/1024/1024)
+	fmt.Printf("System memory: %.3f MB current, %.3f MB peak\n", float64(mem.Sys)/1024/1024, float64(atomic.LoadUint64(&peakMemSys))/1024/1024)
+	fmt.Printf("Allocations:   %.3f million\n", float64(mem.Mallocs)/1000000)
+	fmt.Printf("GC pause:      %v\n\n", time.Duration(mem.PauseTotalNs))
+
+	if ctx.GlobalBool(utils.NoCompactionFlag.Name) {
+		stack.Stop()
+		return nil
+	}
+
+	// Compact the entire database to more accurately measure disk io and print the stats
+	start = time.Now()
+	fmt.Println("Compacting entire database...")
+	if err = db.Compact(nil, nil); err != nil {
+		utils.Fatalf("Compaction failed: %v", err)
+	}
+	fmt.Printf("Compaction done in %v.\n\n", time.Since(start))
+
+	stats, err = db.Stat("leveldb.stats")
+	if err != nil {
+		utils.Fatalf("Failed to read database stats: %v", err)
+	}
+	fmt.Println(stats)
+
+	ioStats, err = db.Stat("leveldb.iostats")
+	if err != nil {
+		utils.Fatalf("Failed to read database iostats: %v", err)
+	}
+	fmt.Println(ioStats)
+
+	var (
+		networkMsgFlag string
+		hint           = " flag when starting a node"
+		fakenet        = ctx.GlobalString(FakeNetFlag.Name)
+		testnet        = ctx.GlobalString(utils.TestnetFlag.Name)
+	)
+	if fakenet != "" {
+		networkMsgFlag = "--" + FakeNetFlag.Name + " " + fakenet
+		hint = "Use " + networkMsgFlag + hint
+	} else if testnet != "" {
+		networkMsgFlag = "--" + utils.TestnetFlag.Name
+		hint = "Use " + networkMsgFlag + hint
+	} else {
+		networkMsgFlag = "mainnet"
+		hint = "Mainnet installed by default" + hint
+	}
+
+	log.Warn("Import was made for "+networkMsgFlag+" network, imported events apply only to this network", "hint", hint)
+	stack.Stop()
+	return nil
+}
+
+func ImportChain(engine gossip.Consensus, gdb *gossip.Store, fn string) error {
+	// Watch for Ctrl-C while the import is running.
+	// If a signal is received, the import will stop at the next batch.
+	interrupt := make(chan os.Signal, 1)
+	stop := make(chan struct{})
+	signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(interrupt)
+	defer close(interrupt)
+	go func() {
+		if _, ok := <-interrupt; ok {
+			log.Info("Interrupted during import, stopping at next batch")
+		}
+		close(stop)
+	}()
+	checkInterrupt := func() bool {
+		select {
+		case <-stop:
+			return true
+		default:
+			return false
+		}
+	}
+
+	log.Info("Importing events", "file", fn)
+
+	// Open the file handle and potentially unwrap the gzip stream
+	fh, err := os.Open(fn)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+
+	var reader io.Reader = fh
+	if strings.HasSuffix(fn, ".gz") {
+		if reader, err = gzip.NewReader(reader); err != nil {
+			return err
+		}
+	}
+	stream := rlp.NewStream(reader, 0)
+	// Run actual the import.
+	for batch := 0; ; batch++ {
+		// Load a batch of RLP events.
+		if checkInterrupt() {
+			return fmt.Errorf("interrupted")
+		}
+		eventsBatch := make(inter.Events, 0, importBatchSize)
+		i := 0
+		for ; i < importBatchSize; i++ {
+			var e inter.Event
+			if err = stream.Decode(&e); err == io.EOF {
+				break
+			} else if err != nil {
+				return fmt.Errorf("at event decode error: %v", err)
+			}
+			eventsBatch = append(eventsBatch, &e)
+		}
+		if len(eventsBatch) == 0 {
+			break
+		}
+		// Import the batch.
+		if checkInterrupt() {
+			return fmt.Errorf("interrupted")
+		}
+
+		missing := missingEvents(gdb, eventsBatch)
+		if len(missing) == 0 {
+			log.Info(
+				"Skipping batch as all events present", "batch", batch,
+				"first", eventsBatch[0].Hash(), "last", eventsBatch[len(eventsBatch)-1].Hash())
+			continue
+		}
+		if err := insertEvents(engine, gdb, missing); err != nil {
+			return fmt.Errorf("insert events error: %v", err)
+		}
+		log.Debug(
+			"events batch inserted", "batch", batch,
+			"first", eventsBatch[0].Hash(), "last", eventsBatch[len(eventsBatch)-1].Hash())
+	}
+	return nil
+}
+
+func missingEvents(gdb *gossip.Store, events []*inter.Event) []*inter.Event {
+	var missingEvents []*inter.Event
+	for _, event := range events {
+		if gdb.HasEvent(event.Hash()) {
+			log.Debug("event exist", "event", event)
+			continue
+		}
+		missingEvents = append(missingEvents, event)
+	}
+	return missingEvents
+}
+
+func insertEvents(engine gossip.Consensus, gdb *gossip.Store, events []*inter.Event) error {
+	if len(events) == 0 {
+		return nil
+	}
+	var (
+		current     int
+		newEpoch    idx.Epoch
+		sealedEpoch idx.Epoch
+	)
+	for _, event := range events {
+		if newEpoch < event.Epoch {
+			sealedEpoch = newEpoch
+			newEpoch = event.Epoch
+		}
+		if current == importFlushBatch {
+			current = 0
+			err := gdb.Commit(nil, true)
+			if err != nil {
+				return err
+			}
+			gdb.EpochDbs.Del(uint64(sealedEpoch))
+		}
+		current++
+		if gdb.HasEventHeader(event.Hash()) {
+			continue
+		}
+
+		ev := engine.Prepare(event)
+		if ev == nil {
+			continue
+		}
+		gdb.SetEvent(ev)
+		err := engine.ProcessEvent(ev)
+		if err != nil {
+			gdb.DeleteEvent(ev.Epoch, ev.Hash())
+			return err
+		}
+	}
+	err := gdb.Commit(nil, true)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/lachesis/import.go
+++ b/cmd/lachesis/import.go
@@ -26,8 +26,7 @@ func importChain(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
-	cfg, stack, engine, db, gdb := makeFNode(ctx, true)
-	log.Debug("CONFIG LACHESIS STORE", "store config", cfg.Lachesis.StoreConfig)
+	_, stack, engine, db, gdb := makeFNode(ctx, true)
 	utils.StartNode(stack)
 
 	// Start periodically gathering memory profiles
@@ -244,7 +243,6 @@ func insertEvents(engine gossip.Consensus, gdb *gossip.Store, events []*inter.Ev
 			if err != nil {
 				return err
 			}
-			gdb.EpochDbs.Del(uint64(sealedEpoch))
 		}
 		current++
 		if gdb.HasEventHeader(event.Hash()) {
@@ -261,6 +259,7 @@ func insertEvents(engine gossip.Consensus, gdb *gossip.Store, events []*inter.Ev
 			gdb.DeleteEvent(ev.Epoch, ev.Hash())
 			return err
 		}
+		gdb.EpochDbs.Del(uint64(sealedEpoch))
 	}
 	err := gdb.Commit(nil, true)
 	if err != nil {

--- a/cmd/lachesis/main.go
+++ b/cmd/lachesis/main.go
@@ -162,6 +162,9 @@ func init() {
 		// See misccmd.go:
 		versionCommand,
 		licenseCommand,
+		// See chaincmd.go
+		importCommand,
+		exportCommand,
 	}
 	sort.Sort(cli.CommandsByName(app.Commands))
 

--- a/cmd/lachesis/main.go
+++ b/cmd/lachesis/main.go
@@ -234,7 +234,7 @@ func makeFullNode(ctx *cli.Context) *node.Node {
 
 	stack := makeConfigNode(ctx, &cfg.Node)
 
-	engine, gdb := integration.MakeEngine(cfg.Node.DataDir, &cfg.Lachesis)
+	engine, _, gdb := integration.MakeEngine(cfg.Node.DataDir, &cfg.Lachesis)
 	metrics.SetDataDir(cfg.Node.DataDir)
 
 	// configure emitter

--- a/cmd/lachesis/main.go
+++ b/cmd/lachesis/main.go
@@ -218,16 +218,14 @@ func lachesisMain(ctx *cli.Context) error {
 	}
 	defer tracingStop()
 
-	node := makeFullNode(ctx)
+	node := makeNode(ctx, makeAllConfigs(ctx))
 	defer node.Close()
 	startNode(ctx, node)
 	node.Wait()
 	return nil
 }
 
-func makeFullNode(ctx *cli.Context) *node.Node {
-	cfg := makeAllConfigs(ctx)
-
+func makeNode(ctx *cli.Context, cfg *config) *node.Node {
 	// check errlock file
 	errlock.SetDefaultDatadir(cfg.Node.DataDir)
 	errlock.Check()

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -94,7 +94,7 @@ type Backend interface {
 	CurrentEpoch(ctx context.Context) idx.Epoch
 	GetEpochStats(ctx context.Context, requestedEpoch rpc.BlockNumber) (*sfctype.EpochStats, error)
 	TtfReport(ctx context.Context, untilBlock rpc.BlockNumber, maxBlocks idx.Block, mode string) (map[hash.Event]time.Duration, error)
-	ForEachEvent(ctx context.Context, epoch rpc.BlockNumber, onEvent func(event *inter.Event) bool) error
+	ForEachEpochEvent(ctx context.Context, epoch rpc.BlockNumber, onEvent func(event *inter.Event) bool) error
 	ValidatorTimeDrifts(ctx context.Context, epoch rpc.BlockNumber, maxEvents idx.Event) (map[idx.StakerID]map[hash.Event]time.Duration, error)
 
 	// Lachesis SFC API

--- a/ethapi/dag_api.go
+++ b/ethapi/dag_api.go
@@ -186,7 +186,7 @@ func (s *PublicDebugAPI) ValidatorVersions(ctx context.Context, epoch rpc.BlockN
 	prefix := []byte("v-")
 	versions := map[hexutil.Uint64]string{}
 
-	err := s.b.ForEachEvent(ctx, epoch, func(event *inter.Event) bool {
+	err := s.b.ForEachEpochEvent(ctx, epoch, func(event *inter.Event) bool {
 		creator := hexutil.Uint64(event.Creator)
 		if bytes.HasPrefix(event.Extra, prefix) {
 			version := string(event.Extra[len(prefix):])

--- a/eventcheck/all.go
+++ b/eventcheck/all.go
@@ -18,7 +18,7 @@ type Checkers struct {
 	Heavycheck    *heavycheck.Checker
 }
 
-// Validate runs all the checks except Poset-related. intended only for tests
+// Validate runs all the checks except Poset-related
 func (v *Checkers) Validate(e *inter.Event, parents []*inter.EventHeaderData) error {
 	if err := v.Basiccheck.Validate(e); err != nil {
 		return err

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -230,15 +230,15 @@ func (b *EthAPIBackend) GetHeads(ctx context.Context, epoch rpc.BlockNumber) (he
 	return
 }
 
-// ForEachEvent iterates all the events which are observed by head, and accepted by a filter.
+// ForEachEpochEvent iterates all the events which are observed by head, and accepted by a filter.
 // filter CANNOT called twice for the same event.
-func (b *EthAPIBackend) ForEachEvent(ctx context.Context, epoch rpc.BlockNumber, onEvent func(event *inter.Event) bool) error {
+func (b *EthAPIBackend) ForEachEpochEvent(ctx context.Context, epoch rpc.BlockNumber, onEvent func(event *inter.Event) bool) error {
 	requested, err := b.epochWithDefault(ctx, epoch)
 	if err != nil {
 		return err
 	}
 
-	b.svc.store.ForEachEvent(requested, onEvent)
+	b.svc.store.ForEachEpochEvent(requested, onEvent)
 	return nil
 }
 
@@ -677,7 +677,7 @@ func (b *EthAPIBackend) ValidatorTimeDrifts(ctx context.Context, epoch rpc.Block
 
 	processed := 0
 
-	err := b.ForEachEvent(ctx, epoch, func(event *inter.Event) bool {
+	err := b.ForEachEpochEvent(ctx, epoch, func(event *inter.Event) bool {
 		arrivalTime := b.GetEventTime(ctx, event.Hash(), true)
 		claimedTime := event.ClaimedTime
 

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -176,6 +176,11 @@ func NewService(ctx *node.ServiceContext, config *Config, store *Store, engine C
 	return svc, err
 }
 
+// GetEngine returns service's engine
+func (s *Service) GetEngine() Consensus {
+	return s.engine
+}
+
 // makeCheckers builds event checkers
 func makeCheckers(net *lachesis.Config, heavyCheckReader *HeavyCheckReader, gasPowerCheckReader *GasPowerCheckReader, engine Consensus, store *Store) *eventcheck.Checkers {
 	// create signatures checker

--- a/gossip/store_event.go
+++ b/gossip/store_event.go
@@ -84,6 +84,22 @@ func (s *Store) ForEachEvent(epoch idx.Epoch, onEvent func(event *inter.Event) b
 	}
 }
 
+func (s *Store) ForEachEventWithoutEpoch(onEvent func(event *inter.Event) bool) {
+	it := s.table.Events.NewIterator()
+	defer it.Release()
+	for it.Next() {
+		event := &inter.Event{}
+		err := rlp.DecodeBytes(it.Value(), event)
+		if err != nil {
+			s.Log.Crit("Failed to decode event", "err", err)
+		}
+
+		if !onEvent(event) {
+			return
+		}
+	}
+}
+
 func (s *Store) FindEventHashes(epoch idx.Epoch, lamport idx.Lamport, hashPrefix []byte) hash.Events {
 	prefix := bytes.NewBuffer(epoch.Bytes())
 	prefix.Write(lamport.Bytes())

--- a/integration/assembly.go
+++ b/integration/assembly.go
@@ -16,8 +16,8 @@ import (
 )
 
 // MakeEngine makes consensus engine from config.
-func MakeEngine(dataDir string, gossipCfg *gossip.Config) (*poset.Poset, *gossip.Store) {
-	dbs := flushable.NewSyncedPool(DBProducer(dataDir))
+func MakeEngine(dataDir string, gossipCfg *gossip.Config) (*poset.Poset, *flushable.SyncedPool, *gossip.Store) {
+	dbs := flushable.NewSyncedPool(dbProducer(dataDir))
 
 	appStoreConfig := app.StoreConfig{
 		ReceiptsCacheSize:    gossipCfg.ReceiptsCacheSize,
@@ -57,7 +57,7 @@ func MakeEngine(dataDir string, gossipCfg *gossip.Config) (*poset.Poset, *gossip
 	// create consensus
 	engine := poset.New(gossipCfg.Net.Dag, cdb, gdb)
 
-	return engine, gdb
+	return engine, dbs, gdb
 }
 
 // SetAccountKey sets key into accounts manager and unlocks it with pswd.

--- a/integration/assembly.go
+++ b/integration/assembly.go
@@ -17,7 +17,7 @@ import (
 
 // MakeEngine makes consensus engine from config.
 func MakeEngine(dataDir string, gossipCfg *gossip.Config) (*poset.Poset, *flushable.SyncedPool, *gossip.Store) {
-	dbs := flushable.NewSyncedPool(dbProducer(dataDir))
+	dbs := flushable.NewSyncedPool(DBProducer(dataDir))
 
 	appStoreConfig := app.StoreConfig{
 		ReceiptsCacheSize:    gossipCfg.ReceiptsCacheSize,

--- a/integration/assembly.go
+++ b/integration/assembly.go
@@ -17,7 +17,7 @@ import (
 
 // MakeEngine makes consensus engine from config.
 func MakeEngine(dataDir string, gossipCfg *gossip.Config) (*poset.Poset, *gossip.Store) {
-	dbs := flushable.NewSyncedPool(dbProducer(dataDir))
+	dbs := flushable.NewSyncedPool(DBProducer(dataDir))
 
 	appStoreConfig := app.StoreConfig{
 		ReceiptsCacheSize:    gossipCfg.ReceiptsCacheSize,

--- a/integration/db.go
+++ b/integration/db.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/kvdb/memorydb"
 )
 
-func DBProducer(dbdir string) kvdb.DbProducer {
+func dbProducer(dbdir string) kvdb.DbProducer {
 	if dbdir == "inmemory" || dbdir == "" {
 		return memorydb.NewProducer("")
 	}

--- a/integration/db.go
+++ b/integration/db.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/kvdb/memorydb"
 )
 
-func dbProducer(dbdir string) kvdb.DbProducer {
+func DBProducer(dbdir string) kvdb.DbProducer {
 	if dbdir == "inmemory" || dbdir == "" {
 		return memorydb.NewProducer("")
 	}

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -13,7 +13,7 @@ import (
 func NewIntegration(ctx *adapters.ServiceContext, network lachesis.Config) *gossip.Service {
 	gossipCfg := gossip.DefaultConfig(network)
 
-	engine, gdb := MakeEngine(ctx.Config.DataDir, &gossipCfg)
+	engine, _, gdb := MakeEngine(ctx.Config.DataDir, &gossipCfg)
 
 	coinbase := SetAccountKey(
 		ctx.NodeContext.AccountManager,

--- a/version/version.go
+++ b/version/version.go
@@ -5,8 +5,8 @@ import (
 )
 
 func init() {
-	params.VersionMajor = 0    // Major version component of the current release
-	params.VersionMinor = 6    // Minor version component of the current release
-	params.VersionPatch = 0    // Patch version component of the current release
+	params.VersionMajor = 0     // Major version component of the current release
+	params.VersionMinor = 6     // Minor version component of the current release
+	params.VersionPatch = 0     // Patch version component of the current release
 	params.VersionMeta = "rc.2" // Version metadata to append to the version string
 }


### PR DESCRIPTION
- Add export command
- - Dumps current events into a file, parents are always ordered before children
- - Creates an events file in specified location
- - Events file has a header and version
- - Optionally, only a specified range of epochs may be dumped
- Add import command
- - Imports events from specified events file(s)
- - Events are fully verified by default, unless overridden by check=false flag. If events are fully verified, then the process is trustless.
- - Import of events with full verification takes ~2 times longer than without full verification.

Re-work of #481 for develop2 branch