### PR TITLE
Add debug API call BlocksTransactionTimes

### DIFF
--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -93,7 +93,7 @@ type Backend interface {
 	GetHeads(ctx context.Context, epoch rpc.BlockNumber) (hash.Events, error)
 	CurrentEpoch(ctx context.Context) idx.Epoch
 	GetEpochStats(ctx context.Context, requestedEpoch rpc.BlockNumber) (*sfctype.EpochStats, error)
-	TtfReport(ctx context.Context, untilBlock rpc.BlockNumber, maxBlocks idx.Block, mode string) (map[hash.Event]time.Duration, error)
+	BlocksTTF(ctx context.Context, untilBlock rpc.BlockNumber, maxBlocks idx.Block, mode string) (map[hash.Event]time.Duration, error)
 	ForEachEvent(ctx context.Context, epoch rpc.BlockNumber, onEvent func(event *inter.Event) bool) error
 	ValidatorTimeDrifts(ctx context.Context, epoch rpc.BlockNumber, maxEvents idx.Event) (map[idx.StakerID]map[hash.Event]time.Duration, error)
 

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -111,7 +111,7 @@ type Backend interface {
 	GetStakerID(ctx context.Context, addr common.Address) (idx.StakerID, error)
 	GetStakers(ctx context.Context) ([]sfctype.SfcStakerAndID, error)
 	GetDelegationsOf(ctx context.Context, stakerID idx.StakerID) ([]sfctype.SfcDelegationAndID, error)
-	GetDelegations(ctx context.Context, addr common.Address) ([]sfctype.SfcDelegationAndID, error)
+	GetDelegationsByAddress(ctx context.Context, addr common.Address) ([]sfctype.SfcDelegationAndID, error)
 	GetDelegation(ctx context.Context, id sfctype.DelegationID) (*sfctype.SfcDelegation, error)
 }
 

--- a/ethapi/dag_api.go
+++ b/ethapi/dag_api.go
@@ -117,7 +117,7 @@ func rpcEncodeEventsTimeStats(data map[hash.Event]time.Duration, verbosity hexut
 	minTtf := time.Duration(0)
 	maxTtf := time.Duration(0)
 	for id, ttf := range data {
-		raw[id.FullID()] = hexutil.Uint64(ttf)
+		raw[id.FullID()] = durationToRPC(ttf)
 
 		// stats
 		totalTtf += ttf
@@ -161,12 +161,12 @@ func rpcEncodeEventsTimeStats(data map[hash.Event]time.Duration, verbosity hexut
 }
 
 // BlocksTTF for a range of blocks
-// maxEvents. Number.  maximum number of events to process
+// maxBlocks. Number.  maximum number of blocks to process
+// Mode. String. One of {"arrival_time", "claimed_time"}
 // Verbosity. Number. If 0, then include only avg, min, max.
 // Verbosity. Number. If >= 1, then include histogram with 6 bins.
 // Verbosity. Number. If >= 2, then include histogram with 16 bins.
 // Verbosity. Number. If >= 3, then include raw data.
-// Mode. String. One of {"arrival_time", "claimed_time"}
 func (s *PublicDebugAPI) BlocksTTF(ctx context.Context, untilBlock rpc.BlockNumber, maxBlocks hexutil.Uint64, mode string, verbosity hexutil.Uint64) (map[string]interface{}, error) {
 	if mode != "arrival_time" && mode != "claimed_time" {
 		return nil, errors.New("mode must be one of {arrival_time, claimed_time}")

--- a/ethapi/dag_api.go
+++ b/ethapi/dag_api.go
@@ -160,19 +160,19 @@ func rpcEncodeEventsTimeStats(data map[hash.Event]time.Duration, verbosity hexut
 	return resRPC, nil
 }
 
-// TtfReport for a range of blocks
+// BlocksTTF for a range of blocks
 // maxEvents. Number.  maximum number of events to process
 // Verbosity. Number. If 0, then include only avg, min, max.
 // Verbosity. Number. If >= 1, then include histogram with 6 bins.
 // Verbosity. Number. If >= 2, then include histogram with 16 bins.
 // Verbosity. Number. If >= 3, then include raw data.
 // Mode. String. One of {"arrival_time", "claimed_time"}
-func (s *PublicDebugAPI) TtfReport(ctx context.Context, untilBlock rpc.BlockNumber, maxBlocks hexutil.Uint64, mode string, verbosity hexutil.Uint64) (map[string]interface{}, error) {
+func (s *PublicDebugAPI) BlocksTTF(ctx context.Context, untilBlock rpc.BlockNumber, maxBlocks hexutil.Uint64, mode string, verbosity hexutil.Uint64) (map[string]interface{}, error) {
 	if mode != "arrival_time" && mode != "claimed_time" {
 		return nil, errors.New("mode must be one of {arrival_time, claimed_time}")
 	}
 
-	ttfs, err := s.b.TtfReport(ctx, untilBlock, idx.Block(maxBlocks), mode)
+	ttfs, err := s.b.BlocksTTF(ctx, untilBlock, idx.Block(maxBlocks), mode)
 	if err != nil {
 		return nil, err
 	}

--- a/ethapi/sfc_api.go
+++ b/ethapi/sfc_api.go
@@ -318,10 +318,10 @@ func (s *PublicSfcAPI) GetDelegation(ctx context.Context, addr common.Address, s
 	return s.addDelegationMetricFields(ctx, delegationRPC, id)
 }
 
-// GetDelegations returns SFC delegations by address
+// GetDelegationsByAddress returns SFC delegations by address
 // Verbosity. Number. If >= 1, then include base fields. If >= 2, then include metrics.
-func (s *PublicSfcAPI) GetDelegations(ctx context.Context, addr common.Address, verbosity hexutil.Uint64) ([]interface{}, error) {
-	delegations, err := s.b.GetDelegations(ctx, addr)
+func (s *PublicSfcAPI) GetDelegationsByAddress(ctx context.Context, addr common.Address, verbosity hexutil.Uint64) ([]interface{}, error) {
+	delegations, err := s.b.GetDelegationsByAddress(ctx, addr)
 	if err != nil {
 		return nil, err
 	}

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -623,8 +623,8 @@ func (b *EthAPIBackend) GetEventTime(ctx context.Context, id hash.Event, arrival
 	return t
 }
 
-// TtfReport for a range of blocks
-func (b *EthAPIBackend) TtfReport(ctx context.Context, untilBlock rpc.BlockNumber, maxBlocks idx.Block, mode string) (map[hash.Event]time.Duration, error) {
+// BlocksTTF for a range of blocks
+func (b *EthAPIBackend) BlocksTTF(ctx context.Context, untilBlock rpc.BlockNumber, maxBlocks idx.Block, mode string) (map[hash.Event]time.Duration, error) {
 	if !b.svc.config.DecisiveEventsIndex {
 		return nil, errors.New("decisive-events index is disabled (enable DecisiveEventsIndex and re-process the DAGs)")
 	}

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -587,8 +587,8 @@ func (b *EthAPIBackend) GetDelegation(ctx context.Context, id sfctype.Delegation
 	return b.svc.app.GetSfcDelegation(id), nil
 }
 
-// GetDelegations returns SFC delegations info by address
-func (b *EthAPIBackend) GetDelegations(ctx context.Context, addr common.Address) ([]sfctype.SfcDelegationAndID, error) {
+// GetDelegationsByAddress returns SFC delegations info by address
+func (b *EthAPIBackend) GetDelegationsByAddress(ctx context.Context, addr common.Address) ([]sfctype.SfcDelegationAndID, error) {
 	return b.svc.app.GetSfcDelegationsByAddr(addr, 1000), nil
 }
 


### PR DESCRIPTION
- add debug API call BlocksTransactionTimes, used for debug.BlocksTPS call in web3.js console
- rename non-released API call GetDelegations -> GetDelegationsByAddress
- rename debug API call TtfReport -> BlocksTTF to be consistent with debug.BlocksTPS
- refactor comments and raw formatting for BlocksTTF