### PR TITLE
Node waits until the P2P goroutines are stopped

### DIFF
--- a/cmd/lachesis/config.go
+++ b/cmd/lachesis/config.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
-	"unicode"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
@@ -65,11 +64,7 @@ var tomlSettings = toml.Config{
 		return field
 	},
 	MissingField: func(rt reflect.Type, field string) error {
-		link := ""
-		if unicode.IsUpper(rune(rt.Name()[0])) && rt.PkgPath() != "main" {
-			link = fmt.Sprintf(", see https://godoc.org/%s#%s for available fields", rt.PkgPath(), rt.Name())
-		}
-		return fmt.Errorf("field '%s' is not defined in %s%s", field, rt.String(), link)
+		return fmt.Errorf("field '%s' is not defined in %s", field, rt.String())
 	},
 }
 
@@ -89,6 +84,11 @@ func loadAllConfigs(file string, cfg *config) error {
 	// Add file name to errors that have a line number.
 	if _, ok := err.(*toml.LineError); ok {
 		err = errors.New(file + ", " + err.Error())
+	}
+	if err != nil {
+		return errors.New(fmt.Sprintf("TOML config file error: %v.\n"+
+			"Use 'dumpconfig' command to get an example config file.\n"+
+			"If node was recently upgraded and a previous network config file is used, then check updates for the config file.", err))
 	}
 	return err
 }

--- a/gossip/consensus_callbacks.go
+++ b/gossip/consensus_callbacks.go
@@ -21,6 +21,10 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/tracing"
 )
 
+var (
+	errStopped = errors.New("service is stopped")
+)
+
 // ProcessEvent takes event into processing.
 // Event order matter: parents first.
 // ProcessEvent is safe for concurrent use
@@ -55,6 +59,9 @@ func (s *Service) ValidateEvent(e *inter.Event) error {
 // processEvent extends the engine.ProcessEvent with gossip-specific actions on each event processing
 func (s *Service) processEvent(realEngine Consensus, e *inter.Event) error {
 	// s.engineMu is locked here
+	if s.stopped {
+		return errStopped
+	}
 
 	if s.store.HasEventHeader(e.Hash()) { // sanity check
 		return eventcheck.ErrAlreadyConnectedEvent

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -115,6 +115,8 @@ type Service struct {
 	EthAPI        *EthAPIBackend
 	netRPCService *ethapi.PublicNetAPI
 
+	stopped bool
+
 	logger.Instance
 }
 
@@ -327,6 +329,7 @@ func (s *Service) Stop() error {
 	// flush the state at exit, after all the routines stopped
 	s.engineMu.Lock()
 	defer s.engineMu.Unlock()
+	s.stopped = true
 
 	return s.store.Commit(nil, true)
 }

--- a/gossip/sync.go
+++ b/gossip/sync.go
@@ -110,10 +110,6 @@ func (pm *ProtocolManager) txsyncLoop() {
 // downloading hashes and events as well as handling the announcement handler.
 func (pm *ProtocolManager) syncer() {
 	// Start and ensure cleanup of sync mechanisms
-	pm.fetcher.Start()
-	defer pm.fetcher.Stop()
-	defer pm.downloader.Terminate()
-
 	for {
 		select {
 		case <-pm.newPeerCh:


### PR DESCRIPTION
- Fix race conditions during node shutdown
- - The fixes are not critical for the safety, yet the previous race conditions could lead to a dirty flag inside DB after node shutdown. The chances of non-finished flushing were higher if node was stopping just before DB flushing would be needed
- Refactor errors logging