### PR TITLE
Snapshot service start/stop example

### DIFF
--- a/docker/Dockerfile.snapshots
+++ b/docker/Dockerfile.snapshots
@@ -13,7 +13,7 @@ RUN export GIT_COMMIT=$(git rev-list -1 HEAD) && \
 
 FROM nginx:latest
 COPY --from=lachesis /tmp/lachesis /usr/bin
-RUN apt update && apt install -y musl
+RUN apt update && apt install -y sudo musl
 RUN ln -s /lib/x86_64-linux-musl/libc.so /lib/libc.musl-x86_64.so
 RUN ln -s /lib/libc.musl-x86_64.so /lib/libc.musl-x86_64.so.1
 RUN mkdir /snapshots
@@ -21,8 +21,11 @@ COPY ./docker/snapshots/index.html /snapshots/
 COPY ./docker/snapshots/snapshotting.sh /snapshots/
 COPY ./docker/snapshots/90.start-snapshotting.sh /docker-entrypoint.d/
 
+ENV NODE_UID=0
+RUN mkdir -p /snapshots/files
 VOLUME /snapshots/files
-VOLUME /root/.lachesis
+RUN mkdir -p /lachesis/datadir
+VOLUME /lachesis/datadir
 
 EXPOSE 80
 

--- a/docker/SNAPSHOTS.md
+++ b/docker/SNAPSHOTS.md
@@ -11,13 +11,15 @@ See details at [snapshotting.sh](./snapshots/snapshotting.sh).
 
 Build it by `make snapshots` from [Dockerfile.snapshots](./Dockerfile.snapshots).
 
-Run it by (volumes mapping is optional)
+Run it by
 ```sh
 docker run --rm -d \
-    -v ${PWD}/files:/snapshots/files \
-    -v ${PWD}/node-db:/root/.lachesis \
     -p 127.0.0.1:8080:80 \
     lachesis-snapshots:latest
-    
 ```
-and see the download page at http://127.0.0.1:8080.
+and see the download page at [localhost:8080](http://127.0.0.1:8080).
+
+
+## Deploy
+
+example at [snapshots/deploy_example/](./snapshots/deploy_example).

--- a/docker/snapshots/90.start-snapshotting.sh
+++ b/docker/snapshots/90.start-snapshotting.sh
@@ -1,3 +1,13 @@
 #!/usr/bin/env bash
 
-nohup /snapshots/snapshotting.sh &
+WD=/snapshots
+DB=/lachesis/datadir
+
+chmod 777 ${WD}/files
+chmod 777 ${DB}
+
+ln -s ${WD}/files /usr/share/nginx/html/snapshots
+rm -f /usr/share/nginx/html/index.html
+ln -s ${WD}/files/index.html /usr/share/nginx/html/index.html
+
+sudo -u "#${NODE_UID}" nohup ${WD}/snapshotting.sh ${DB} &

--- a/docker/snapshots/deploy_example/.gitignore
+++ b/docker/snapshots/deploy_example/.gitignore
@@ -1,0 +1,2 @@
+datadir
+snapshots

--- a/docker/snapshots/deploy_example/logs.sh
+++ b/docker/snapshots/deploy_example/logs.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+
+docker logs -f --tail 100 \
+    lachesis-snapshots

--- a/docker/snapshots/deploy_example/start.sh
+++ b/docker/snapshots/deploy_example/start.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+cd $(dirname $0)
+
+mkdir -p datadir
+mkdir -p snapshots
+
+docker run --rm -d \
+	--name lachesis-snapshots \
+	-e NODE_UID=$(id -u) \
+	-v ${PWD}/datadir:/lachesis/datadir \
+	-v ${PWD}/snapshots:/snapshots/files \
+	-p 127.0.0.1:8080:80 \
+	lachesis-snapshots:latest

--- a/docker/snapshots/deploy_example/stop.sh
+++ b/docker/snapshots/deploy_example/stop.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+
+docker stop \
+	lachesis-snapshots


### PR DESCRIPTION
- start/stop scripts at docker/snapshots/deploy_example/;
- Dockerfile.snapshots: env NODE_UID to set files owner in volumes;