### PR TITLE
Human-readable version

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -13,19 +13,14 @@ func init() {
 	params.VersionMeta = "rc.1" // Version metadata to append to the version string
 }
 
-func AsBigInt() *big.Int {
-	return asBigInt(uint64(params.VersionMajor), uint64(params.VersionMinor), uint64(params.VersionPatch))
+func AsU64() uint64 {
+	return asU64(uint16(params.VersionMajor), uint16(params.VersionMinor), uint16(params.VersionPatch))
 }
 
-func asBigInt(vMajor, vMinor, vPatch uint64) *big.Int {
-	return new(big.Int).Add(
-		new(big.Int).Add(
-			new(big.Int).Lsh(
-				new(big.Int).SetUint64(vMajor), 64*3),
-			new(big.Int).Lsh(
-				new(big.Int).SetUint64(vMinor), 64*2),
-		), new(big.Int).Lsh(
-			new(big.Int).SetUint64(vPatch), 64*1),
-		// VersionMeta is not used here
-	)
+func AsBigInt() *big.Int {
+	return new(big.Int).SetUint64(AsU64())
+}
+
+func asU64(vMajor, vMinor, vPatch uint16) uint64 {
+	return uint64(vMajor) * 1e12 + uint64(vMinor) * 1e6 + uint64(vPatch)
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -7,26 +7,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testcase struct {
+	vMajor, vMinor, vPatch uint16
+	result                 uint64
+}
+
 func TestAsBigInt(t *testing.T) {
 	require := require.New(t)
 
-	prev := [3]uint64{0, 0, 0}
-	for _, next := range [][3]uint64{
-		{0, 0, 1},
-		{0, 0, 2},
-		{0, 1, 0},
-		{0, 1, math.MaxUint64},
-		{1, 0, 0},
-		{1, 0, math.MaxUint64},
-		{1, 1, 0},
-		{2, 9, 9},
-		{3, 1, 0},
-		{math.MaxUint64, 0, 0},
+	prev := testcase{0, 0, 0, 0}
+	for _, next := range []testcase{
+		{0, 0, 1, 1},
+		{0, 0, 2, 2},
+		{0, 1, 0, 1000000},
+		{0, 1, math.MaxUint16, 1065535},
+		{1, 0, 0, 1000000000000},
+		{1, 0, math.MaxUint16, 1000000065535},
+		{1, 1, 0, 1000001000000},
+		{2, 9, 9, 2000009000009},
+		{3, 1, 0, 3000001000000},
+		{math.MaxUint16, math.MaxUint16, math.MaxUint16, 65535065535065535},
 	} {
-		a := asBigInt(prev[0], prev[1], prev[2])
-		b := asBigInt(next[0], next[1], next[2])
-		require.Greater(b.Cmp(a), 0)
-		require.LessOrEqual(len(b.Bytes()), 32)
+		a := asU64(prev.vMajor, prev.vMinor, prev.vPatch)
+		b := asU64(next.vMajor, next.vMinor, next.vPatch)
+		require.Greater(b, a)
+		require.Equal(b, next.result)
 		prev = next
 	}
 }


### PR DESCRIPTION
- Convert version (e.g. 0.8.0) to a human-readable decimal number instead of a binary
  Examples:
```
  0.0.0    ->  0
  0.0.1    ->  1
  0.2.0    ->  2000000
  0.2.1    ->  2000001
  3.2.1    ->  3000002000001
  33.22.11 -> 33000022000011
```