### PR TITLE
Configurable behavior for non-supported upgrade

### DIFF
--- a/gossip/config.go
+++ b/gossip/config.go
@@ -14,6 +14,11 @@ type (
 		LatencyImportance    int
 		ThroughputImportance int
 	}
+	// UpgradeConfig defines behaviour for network upgrades
+	UpgradeConfig struct {
+		ShutDownIfNotUpgraded bool // shut down the node in a case of non-supported network upgrade
+		WarningIfNotUpgraded  bool // show a warning in a case of non-supported network upgrade
+	}
 	// Config for the gossip service.
 	Config struct {
 		Net     lachesis.Config
@@ -24,6 +29,8 @@ type (
 		TxIndex             bool // Whether to enable indexing transactions and receipts or not
 		DecisiveEventsIndex bool // Whether to enable indexing events which decide blocks or not
 		EventLocalTimeIndex bool // Whether to enable indexing arrival time of events or not
+
+		Upgrade UpgradeConfig
 
 		// Protocol options
 		Protocol ProtocolConfig
@@ -82,6 +89,11 @@ func DefaultConfig(network lachesis.Config) Config {
 		Emitter:     DefaultEmitterConfig(),
 		TxPool:      evmcore.DefaultTxPoolConfig(),
 		StoreConfig: DefaultStoreConfig(),
+
+		Upgrade: UpgradeConfig{
+			ShutDownIfNotUpgraded: false,
+			WarningIfNotUpgraded:  true,
+		},
 
 		TxIndex:             true,
 		DecisiveEventsIndex: false,

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -32,6 +32,9 @@ type Store struct {
 	table  struct {
 		Version kvdb.KeyValueStore `table:"_"`
 
+		// network version table
+		NetworkVersion kvdb.KeyValueStore `table:"J"`
+
 		// Main DAG tables
 		Events    kvdb.KeyValueStore `table:"e"`
 		Blocks    kvdb.KeyValueStore `table:"b"`

--- a/gossip/store_network_version.go
+++ b/gossip/store_network_version.go
@@ -1,0 +1,52 @@
+package gossip
+
+import (
+	"math/big"
+)
+
+const (
+	nvKey = "v"
+	diKey = "d"
+)
+
+// SetNetworkVersion stores network version.
+func (s *Store) SetNetworkVersion(v *big.Int) {
+	err := s.table.NetworkVersion.Put([]byte(nvKey), v.Bytes())
+	if err != nil {
+		s.Log.Crit("Failed to put key", "err", err)
+	}
+}
+
+// GetNetworkVersion returns stored network version.
+func (s *Store) GetNetworkVersion() *big.Int {
+	valBytes, err := s.table.NetworkVersion.Get([]byte(nvKey))
+	if err != nil {
+		s.Log.Crit("Failed to get key", "err", err)
+	}
+	if valBytes == nil {
+		return big.NewInt(0)
+	}
+
+	return new(big.Int).SetBytes(valBytes)
+}
+
+// SetNonSupportedUpgrade stores non-supported network upgrade.
+func (s *Store) SetNonSupportedUpgrade(v *big.Int) {
+	err := s.table.NetworkVersion.Put([]byte(diKey), v.Bytes())
+	if err != nil {
+		s.Log.Crit("Failed to put key", "err", err)
+	}
+}
+
+// GetNonSupportedUpgrade returns stored non-supported network upgrade.
+func (s *Store) GetNonSupportedUpgrade() *big.Int {
+	valBytes, err := s.table.NetworkVersion.Get([]byte(diKey))
+	if err != nil {
+		s.Log.Crit("Failed to get key", "err", err)
+	}
+	if valBytes == nil {
+		return big.NewInt(0)
+	}
+
+	return new(big.Int).SetBytes(valBytes)
+}

--- a/gossip/upgnotifier/non_supported_upgrade_notifier.go
+++ b/gossip/upgnotifier/non_supported_upgrade_notifier.go
@@ -1,0 +1,58 @@
+package upgnotifier
+
+import (
+	"fmt"
+	"math/big"
+	"sync"
+	"time"
+
+	"github.com/Fantom-foundation/go-lachesis/logger"
+	"github.com/Fantom-foundation/go-lachesis/version"
+)
+
+type Reader interface {
+	GetNetworkVersion() *big.Int
+	GetNonSupportedUpgrade() *big.Int
+}
+
+type Logger struct {
+	logger.Instance
+	reader Reader
+	done   chan struct{}
+	wg     sync.WaitGroup
+}
+
+func New(reader Reader) *Logger {
+	return &Logger{
+		reader:   reader,
+		done:     make(chan struct{}),
+		Instance: logger.MakeInstance(),
+	}
+}
+
+func (l *Logger) Start() {
+	l.wg.Add(1)
+	go func() {
+		defer l.wg.Done()
+		ticker := time.NewTicker(5 * time.Second)
+		for {
+			select {
+			case <-ticker.C:
+				if l.reader.GetNetworkVersion().Cmp(version.AsBigInt()) > 0 {
+					l.Log.Warn(fmt.Sprintf("Network upgrade %s was activated. Current node version is %s. "+
+						"Please upgrade your node and re-sync the chain data.", version.BigToString(l.reader.GetNetworkVersion()), version.AsString()))
+				} else if l.reader.GetNonSupportedUpgrade().Sign() > 0 {
+					l.Log.Warn(fmt.Sprintf("Node's state is dirty because node was upgraded after the network upgrade %s was activated. "+
+						"Please re-sync the chain data to continue.", version.BigToString(l.reader.GetNonSupportedUpgrade())))
+				}
+			case <-l.done:
+				return
+			}
+		}
+	}()
+}
+
+func (l *Logger) Stop() {
+	close(l.done)
+	l.wg.Wait()
+}

--- a/utils/errlock/errlock.go
+++ b/utils/errlock/errlock.go
@@ -12,7 +12,7 @@ import (
 func Check() {
 	locked, reason, eLockPath, _ := read(datadir)
 	if locked {
-		utils.Fatalf("Node isn't allowed to start due to a previous error. Please fix the issue and then delete file \"%s\". Error message:\n%s", eLockPath, reason)
+		utils.Fatalf("Node isn't allowed to start due to a previous error. Please fix the issue and then delete file \"%s\".\nError message:\n%s", eLockPath, reason)
 	}
 }
 
@@ -28,7 +28,7 @@ func SetDefaultDatadir(dir string) {
 // Permanent error
 func Permanent(err error) {
 	eLockPath, _ := write(datadir, err.Error())
-	utils.Fatalf("Node is permanently stopping due to an issue. Please fix the issue and then delete file \"%s\". Error message:\n%s", eLockPath, err.Error())
+	utils.Fatalf("Node is stopping due to an issue. Please fix the issue and then delete file \"%s\".\nError message:\n%s", eLockPath, err.Error())
 }
 
 // read errlock file

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/params"
@@ -13,6 +14,21 @@ func init() {
 	params.VersionMeta = "rc.1" // Version metadata to append to the version string
 }
 
+func BigToString(b *big.Int) string {
+	if len(b.Bytes()) > 8 {
+		return "_malformed_version_"
+	}
+	return U64ToString(b.Uint64())
+}
+
+func U64ToString(v uint64) string {
+	return fmt.Sprintf("%d.%d.%d", (v/1e12)%1e6, (v/1e6)%1e6, v%1e6)
+}
+
+func AsString() string {
+	return fmt.Sprintf("%d.%d.%d", params.VersionMajor, params.VersionMinor, params.VersionPatch)
+}
+
 func AsU64() uint64 {
 	return asU64(uint16(params.VersionMajor), uint16(params.VersionMinor), uint16(params.VersionPatch))
 }
@@ -22,5 +38,5 @@ func AsBigInt() *big.Int {
 }
 
 func asU64(vMajor, vMinor, vPatch uint16) uint64 {
-	return uint64(vMajor) * 1e12 + uint64(vMinor) * 1e6 + uint64(vPatch)
+	return uint64(vMajor)*1e12 + uint64(vMinor)*1e6 + uint64(vPatch)
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -10,28 +10,32 @@ import (
 type testcase struct {
 	vMajor, vMinor, vPatch uint16
 	result                 uint64
+	str                    string
 }
 
 func TestAsBigInt(t *testing.T) {
 	require := require.New(t)
 
-	prev := testcase{0, 0, 0, 0}
+	prev := testcase{0, 0, 0, 0, "0.0.0"}
 	for _, next := range []testcase{
-		{0, 0, 1, 1},
-		{0, 0, 2, 2},
-		{0, 1, 0, 1000000},
-		{0, 1, math.MaxUint16, 1065535},
-		{1, 0, 0, 1000000000000},
-		{1, 0, math.MaxUint16, 1000000065535},
-		{1, 1, 0, 1000001000000},
-		{2, 9, 9, 2000009000009},
-		{3, 1, 0, 3000001000000},
-		{math.MaxUint16, math.MaxUint16, math.MaxUint16, 65535065535065535},
+		{0, 0, 1, 1, "0.0.1"},
+		{0, 0, 2, 2, "0.0.2"},
+		{0, 1, 0, 1000000, "0.1.0"},
+		{0, 1, math.MaxUint16, 1065535, "0.1.65535"},
+		{1, 0, 0, 1000000000000, "1.0.0"},
+		{1, 0, math.MaxUint16, 1000000065535, "1.0.65535"},
+		{1, 1, 0, 1000001000000, "1.1.0"},
+		{2, 9, 9, 2000009000009, "2.9.9"},
+		{3, 1, 0, 3000001000000, "3.1.0"},
+		{math.MaxUint16, math.MaxUint16, math.MaxUint16, 65535065535065535, "65535.65535.65535"},
 	} {
 		a := asU64(prev.vMajor, prev.vMinor, prev.vPatch)
 		b := asU64(next.vMajor, next.vMinor, next.vPatch)
-		require.Greater(b, a)
+		require.Equal(a, prev.result)
 		require.Equal(b, next.result)
+		require.Equal(U64ToString(a), prev.str)
+		require.Equal(U64ToString(b), next.str)
+		require.Greater(b, a)
 		prev = next
 	}
 }


### PR DESCRIPTION
In a case if network activates an upgrade above current's node version:
- Show a warning if current node's version is below a network's version. If node was upgraded after the network upgrade, show a warning indicating a dirty node's state. (enabled by default)
- Shut down the node. (disabled by default)