### PR TITLE
EVM preimages

### DIFF
--- a/app/store.go
+++ b/app/store.go
@@ -104,9 +104,9 @@ func (s *Store) initCache() {
 }
 
 // Commit changes.
-func (s *Store) Commit() error {
+func (s *Store) Commit(root common.Hash) error {
 	// Flush trie on the DB
-	err := s.table.EvmState.TrieDB().Cap(0)
+	err := s.table.EvmState.TrieDB().Commit(root, false, nil)
 	if err != nil {
 		s.Log.Error("Failed to flush trie DB into main DB", "err", err)
 	}

--- a/cmd/lachesis/chaincmd.go
+++ b/cmd/lachesis/chaincmd.go
@@ -6,40 +6,96 @@ import (
 )
 
 var (
+	EventsCheckFlag = cli.BoolTFlag{
+		Name:  "check",
+		Usage: "true if events should be fully checked before importing",
+	}
 	importCommand = cli.Command{
-		Action:    utils.MigrateFlags(importChain),
 		Name:      "import",
 		Usage:     "Import a blockchain file",
 		ArgsUsage: "<filename> (<filename 2> ... <filename N>) [check=false]",
-		Flags: []cli.Flag{
-			DataDirFlag,
-			utils.CacheFlag,
-			utils.SyncModeFlag,
-			utils.GCModeFlag,
-			utils.CacheDatabaseFlag,
-			utils.CacheGCFlag,
-		},
-		Category: "MISCELLANEOUS COMMANDS",
+		Category:  "MISCELLANEOUS COMMANDS",
 		Description: `
 The import command imports events from an RLP-encoded files.
 Events are fully verified by default, unless overridden by check=false flag.`,
+
+		Subcommands: []cli.Command{
+			{
+				Action:    utils.MigrateFlags(importEvents),
+				Name:      "events",
+				Usage:     "Import blockchain events",
+				ArgsUsage: "<filename> (<filename 2> ... <filename N>) [--check=false]",
+				Flags: []cli.Flag{
+					DataDirFlag,
+					EventsCheckFlag,
+					utils.CacheFlag,
+					utils.SyncModeFlag,
+					utils.GCModeFlag,
+					utils.CacheDatabaseFlag,
+					utils.CacheGCFlag,
+				},
+				Description: `
+The import command imports events from an RLP-encoded files.
+Events are fully verified by default, unless overridden by --check=false flag.`,
+			},
+			{
+				Action:    utils.MigrateFlags(importPreimages),
+				Name:      "preimages",
+				Usage:     "Import accounts preimages",
+				ArgsUsage: "<filename>",
+				Flags: []cli.Flag{
+					DataDirFlag,
+					EventsCheckFlag,
+					utils.CacheFlag,
+					utils.SyncModeFlag,
+					utils.GCModeFlag,
+					utils.CacheDatabaseFlag,
+					utils.CacheGCFlag,
+				},
+				Description: `
+The import command imports account preimages from an RLP-encoded file.`,
+			},
+		},
 	}
 	exportCommand = cli.Command{
-		Action:    utils.MigrateFlags(exportChain),
-		Name:      "export",
-		Usage:     "Export blockchain into file",
-		ArgsUsage: "<filename> [<epochFrom> <epochTo>]",
-		Flags: []cli.Flag{
-			DataDirFlag,
-			utils.CacheFlag,
-			utils.SyncModeFlag,
-			utils.GCModeFlag,
-		},
+		Name:     "export",
+		Usage:    "Export blockchain",
 		Category: "MISCELLANEOUS COMMANDS",
-		Description: `
+
+		Subcommands: []cli.Command{
+			{
+				Name:      "events",
+				Usage:     "Export blockchain events",
+				ArgsUsage: "<filename> [<epochFrom> <epochTo>]",
+				Action:    utils.MigrateFlags(exportEvents),
+				Flags: []cli.Flag{
+					DataDirFlag,
+					utils.CacheFlag,
+				},
+				Description: `
+    lachesis export events
+
 Requires a first argument of the file to write to.
 Optional second and third arguments control the first and
 last epoch to write. If the file ends with .gz, the output will
-be gzipped.`,
+be gzipped
+`,
+			},
+			{
+				Name:      "preimages",
+				Usage:     "Export account preimages",
+				ArgsUsage: "<filename>",
+				Action:    utils.MigrateFlags(exportPreimages),
+				Flags: []cli.Flag{
+					DataDirFlag,
+					utils.CacheFlag,
+				},
+				Description: `
+    lachesis export preimages
+
+Exports account preimages into a file.
+`,
+			},
+		},
 	}
 )

--- a/cmd/lachesis/import.go
+++ b/cmd/lachesis/import.go
@@ -26,7 +26,7 @@ import (
 	"github.com/Fantom-foundation/go-lachesis/inter"
 )
 
-func importChain(ctx *cli.Context) error {
+func importEvents(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")
 	}
@@ -60,17 +60,9 @@ func importToNode(ctx *cli.Context, cfg *config, args ...string) error {
 	defer node.Close()
 	startNode(ctx, node)
 
-	check := true
-	for _, arg := range ctx.Args() {
-		if arg == "check=false" || arg == "check=0" {
-			check = false
-		}
-	}
+	check := ctx.BoolT(EventsCheckFlag.Name)
 
 	for _, fn := range args {
-		if strings.HasPrefix(fn, "check=") {
-			continue
-		}
 		if err := importFile(svc, check, fn); err != nil {
 			log.Error("Import error", "file", fn, "err", err)
 			return err

--- a/cmd/lachesis/preimages.go
+++ b/cmd/lachesis/preimages.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/cmd/utils"
+	"gopkg.in/urfave/cli.v1"
+)
+
+// importPreimages imports preimage data from the specified file.
+func importPreimages(ctx *cli.Context) error {
+	if len(ctx.Args()) < 1 {
+		utils.Fatalf("This command requires an argument.")
+	}
+
+	cfg := makeAllConfigs(ctx)
+
+	gdb, cdb := makeStores(cfg.Node.DataDir, &cfg.Lachesis)
+	defer gdb.Close()
+	defer cdb.Close()
+
+	start := time.Now()
+
+	if err := utils.ImportPreimages(gdb.App().EvmTable(), ctx.Args().First()); err != nil {
+		utils.Fatalf("Import error: %v\n", err)
+	}
+	lastBlockIdx := cdb.GetCheckpoint().LastBlockN
+	lastBlock := gdb.GetBlock(lastBlockIdx)
+	err := gdb.Commit(lastBlock.Root, nil, true)
+	if err != nil {
+		utils.Fatalf("DB flushing error: %v\n", err)
+	}
+	fmt.Printf("Import done in %v\n", time.Since(start))
+	return nil
+}
+
+// exportPreimages dumps the preimage data to specified json file in streaming way.
+func exportPreimages(ctx *cli.Context) error {
+	if len(ctx.Args()) < 1 {
+		utils.Fatalf("This command requires an argument.")
+	}
+
+	cfg := makeAllConfigs(ctx)
+
+	gdb, _ := makeStores(cfg.Node.DataDir, &cfg.Lachesis)
+	defer gdb.Close()
+
+	start := time.Now()
+
+	if err := utils.ExportPreimages(gdb.App().EvmTable(), ctx.Args().First()); err != nil {
+		utils.Fatalf("Export error: %v\n", err)
+	}
+	fmt.Printf("Export done in %v\n", time.Since(start))
+	return nil
+}

--- a/evmcore/apply_genesis.go
+++ b/evmcore/apply_genesis.go
@@ -56,7 +56,7 @@ func ApplyGenesis(db ethdb.Database, net *lachesis.Config) (*EvmBlock, error) {
 	}
 	block := genesisBlock(net, root)
 
-	err = statedb.Database().TrieDB().Cap(0)
+	err = statedb.Database().TrieDB().Commit(root, false, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/gossip/consensus_callbacks.go
+++ b/gossip/consensus_callbacks.go
@@ -132,7 +132,9 @@ func (s *Service) processEvent(realEngine Consensus, e *inter.Event) error {
 
 	immediately := (newEpoch != oldEpoch)
 
-	return s.store.Commit(e.Hash().Bytes(), immediately)
+	lastBlockIdx, _ := realEngine.LastBlock()
+	lastBlock := s.store.GetBlock(lastBlockIdx)
+	return s.store.Commit(lastBlock.Root, e.Hash().Bytes(), immediately)
 }
 
 // applyNewState moves the state according to new block (txs execution, SFC logic, epoch sealing)

--- a/gossip/handler_test.go
+++ b/gossip/handler_test.go
@@ -153,7 +153,12 @@ func testBroadcastEvent(t *testing.T, totalPeers int, forcedAggressiveBroadcast 
 
 	// create consensus engine
 	engine := poset.New(net.Dag, engineStore, store)
-	engine.Bootstrap(inter.ConsensusCallbacks{})
+	engine.Bootstrap(inter.ConsensusCallbacks{
+		ApplyBlock: func(block *inter.Block, decidedFrame idx.Frame, cheaters inter.Cheaters) (newAppHash common.Hash, sealEpoch bool) {
+			store.SetBlock(block)
+			return common.Hash{}, false
+		},
+	})
 
 	// create service
 	svc, err := newService(&config, store, engine)

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -356,7 +356,9 @@ func (s *Service) Stop() error {
 	defer s.engineMu.Unlock()
 	s.stopped = true
 
-	return s.store.Commit(nil, true)
+	lastBlockIdx, _ := s.engine.LastBlock()
+	lastBlock := s.store.GetBlock(lastBlockIdx)
+	return s.store.Commit(lastBlock.Root, nil, true)
 }
 
 // AccountManager return node's account manager

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -167,6 +167,10 @@ func (s *Store) Commit(root common.Hash, flushID []byte, immediately bool) error
 	return s.dbs.Flush(flushID)
 }
 
+func (s *Store) App() *app.Store {
+	return s.app
+}
+
 /*
  * Utils:
  */

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/rlp"
 	lru "github.com/hashicorp/golang-lru"
@@ -145,7 +146,7 @@ func (s *Store) Close() {
 }
 
 // Commit changes.
-func (s *Store) Commit(flushID []byte, immediately bool) error {
+func (s *Store) Commit(root common.Hash, flushID []byte, immediately bool) error {
 	if flushID == nil {
 		// if flushId not specified, use current time
 		buf := bytes.NewBuffer(nil)
@@ -159,7 +160,7 @@ func (s *Store) Commit(flushID []byte, immediately bool) error {
 	}
 
 	// Flush the DBs
-	err := s.app.Commit()
+	err := s.app.Commit(root)
 	if err != nil {
 		return err
 	}

--- a/inter/ascii_scheme.go
+++ b/inter/ascii_scheme.go
@@ -260,7 +260,7 @@ func DAGtoASCIIscheme(events Events) (string, error) {
 		if len(r.Name) < 1 {
 			r.Name = hash.GetNodeName(e.Creator)
 			if len(r.Name) < 1 {
-				r.Name = string('a' + r.Self)
+				r.Name = string(rune('a' + r.Self))
 			}
 			r.Name = fmt.Sprintf("%s%03d", r.Name, e.Seq)
 		}

--- a/inter/common.go
+++ b/inter/common.go
@@ -22,7 +22,7 @@ func GenNodes(
 	for i := 0; i < nodeCount; i++ {
 		addr := hash.FakePeer()
 		nodes[i] = addr
-		hash.SetNodeName(addr, "node"+string('A'+i))
+		hash.SetNodeName(addr, "node"+string(rune('A'+i)))
 	}
 
 	return
@@ -114,7 +114,7 @@ func ForEachRandFork(
 				}
 			}
 		}
-		name := fmt.Sprintf("%s%03d", string('a'+self), len(events[creator]))
+		name := fmt.Sprintf("%s%03d", string(rune('a'+self)), len(events[creator]))
 		// buildEvent callback
 		if callback.Build != nil {
 			e = callback.Build(e, name)
@@ -126,7 +126,7 @@ func ForEachRandFork(
 		e.RecacheHash()
 		e.RecacheSize()
 		// save and name event
-		hash.SetEventName(e.Hash(), fmt.Sprintf("%s%03d", string('a'+self), len(events[creator])))
+		hash.SetEventName(e.Hash(), fmt.Sprintf("%s%03d", string(rune('a'+self)), len(events[creator])))
 		events[creator] = append(events[creator], e)
 		// callback
 		if callback.Process != nil {


### PR DESCRIPTION
- the full list of EVM account preimages is flushed on disk on every DB commit. Previously preimages were flushed only if exceeded 4 MB. Preimages are needed for an ability to dump EVM accounts state
- add commands to export/import EVM account preimages: `lachesis export preimages`, `lachesis import preimages`
- rename commands for events export/import: `lachesis export events`, `lachesis import events`