### PR TITLE
Fix API error handling of a missing trie node in 0.8.x

### DIFF
--- a/app/store.go
+++ b/app/store.go
@@ -114,12 +114,8 @@ func (s *Store) Commit(root common.Hash) error {
 }
 
 // StateDB returns state database.
-func (s *Store) StateDB(from common.Hash) *state.StateDB {
-	db, err := state.New(common.Hash(from), s.table.EvmState, nil)
-	if err != nil {
-		s.Log.Crit("Failed to open state", "err", err)
-	}
-	return db
+func (s *Store) StateDB(from common.Hash) (*state.StateDB, error) {
+	return state.New(common.Hash(from), s.table.EvmState, nil)
 }
 
 // StateDB returns state database.

--- a/gossip/consensus_callbacks.go
+++ b/gossip/consensus_callbacks.go
@@ -173,7 +173,10 @@ func (s *Service) applyNewState(
 
 	// Get stateDB
 	stateHash := s.store.GetBlock(block.Index - 1).Root
-	statedb := s.app.StateDB(stateHash)
+	statedb, err := s.app.StateDB(stateHash)
+	if err != nil {
+		s.Log.Crit("Failed to open state", "block", block.Index - 1, "root", stateHash.String())
+	}
 
 	// Process EVM txs
 	block, evmBlock, totalFee, receipts := s.executeEvmTransactions(block, evmBlock, statedb)

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -100,8 +100,8 @@ func (b *EthAPIBackend) StateAndHeaderByNumber(ctx context.Context, number rpc.B
 	if header == nil {
 		return nil, nil, errors.New("header not found")
 	}
-	stateDb := b.svc.app.StateDB(header.Root)
-	return stateDb, header, nil
+	stateDb, err := b.svc.app.StateDB(header.Root)
+	return stateDb, header, err
 }
 
 // decodeShortEventID decodes ShortID
@@ -484,7 +484,10 @@ func (b *EthAPIBackend) GetEpochStats(ctx context.Context, requestedEpoch rpc.Bl
 
 	// read total reward weights from SFC contract
 	header := b.state.CurrentHeader()
-	statedb := b.svc.app.StateDB(header.Root)
+	statedb, err := b.svc.app.StateDB(header.Root)
+	if err != nil {
+		return nil, err
+	}
 
 	epochPosition := sfcpos.EpochSnapshot(epoch)
 	stats.TotalBaseRewardWeight = statedb.GetState(sfc.ContractAddress, epochPosition.TotalBaseRewardWeight()).Big()
@@ -523,7 +526,10 @@ func (b *EthAPIBackend) GetRewardWeights(ctx context.Context, stakerID idx.Stake
 		return nil, nil, nil
 	}
 	header := b.state.CurrentHeader()
-	statedb := b.svc.app.StateDB(header.Root)
+	statedb, err := b.svc.app.StateDB(header.Root)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// read reward weight from SFC contract
 	epoch := b.svc.engine.GetEpoch()
@@ -554,7 +560,10 @@ func (b *EthAPIBackend) GetStaker(ctx context.Context, stakerID idx.StakerID) (*
 // GetStakerID returns SFC staker's Id by address
 func (b *EthAPIBackend) GetStakerID(ctx context.Context, addr common.Address) (idx.StakerID, error) {
 	header := b.state.CurrentHeader()
-	statedb := b.svc.app.StateDB(header.Root)
+	statedb, err := b.svc.app.StateDB(header.Root)
+	if err != nil {
+		return 0, err
+	}
 
 	position := sfcpos.StakerID(addr)
 	stakerID256 := statedb.GetState(sfc.ContractAddress, position)

--- a/gossip/evm_state_reader.go
+++ b/gossip/evm_state_reader.go
@@ -119,5 +119,5 @@ func (r *EvmStateReader) getBlock(h hash.Event, n idx.Block, readTxs bool) *evmc
 }
 
 func (r *EvmStateReader) StateAt(root common.Hash) (*state.StateDB, error) {
-	return r.app.StateDB(root), nil
+	return r.app.StateDB(root)
 }

--- a/gossip/sfc_common_test.go
+++ b/gossip/sfc_common_test.go
@@ -264,7 +264,8 @@ func (env *testEnv) ReadOnly() *bind.CallOpts {
 }
 
 func (env *testEnv) State() *state.StateDB {
-	return env.Store.StateDB(env.lastState)
+	s, _ := env.Store.StateDB(env.lastState)
+	return s
 }
 
 func (env *testEnv) incNonce(account common.Address) {

--- a/version/version.go
+++ b/version/version.go
@@ -10,8 +10,8 @@ import (
 func init() {
 	params.VersionMajor = 0     // Major version component of the current release
 	params.VersionMinor = 8     // Minor version component of the current release
-	params.VersionPatch = 0     // Patch version component of the current release
-	params.VersionMeta = "rc.2" // Version metadata to append to the version string
+	params.VersionPatch = 1     // Patch version component of the current release
+	params.VersionMeta = "rc.1" // Version metadata to append to the version string
 }
 
 func BigToString(b *big.Int) string {


### PR DESCRIPTION
- fix API error handling in a case if trie node was pruned. Trie nodes pruning is active since 0.8.x
- version is set to 0.8.1-rc1