### PR TITLE
EstimateGas API call has optional blockNr argument

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1049,8 +1049,12 @@ func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNr rpc.Bl
 
 // EstimateGas returns an estimate of the amount of gas needed to execute the
 // given transaction against the current pending block.
-func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs, blockNr rpc.BlockNumber) (hexutil.Uint64, error) {
-	return DoEstimateGas(ctx, s.b, args, blockNr, s.b.RPCGasCap())
+func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs, blockNr *rpc.BlockNumber) (hexutil.Uint64, error) {
+	if blockNr == nil {
+		latest := rpc.LatestBlockNumber
+		blockNr = &latest
+	}
+	return DoEstimateGas(ctx, s.b, args, *blockNr, s.b.RPCGasCap())
 }
 
 // ExecutionResult groups all structured logs emitted by the EVM

--- a/ethapi/api_blockchain_test.go
+++ b/ethapi/api_blockchain_test.go
@@ -86,7 +86,8 @@ func TestPublicBlockChainAPI_EstimateGas(t *testing.T) {
 
 	api := NewPublicBlockChainAPI(b)
 	require.NotPanics(t, func() {
-		_, _ = api.EstimateGas(ctx, CallArgs{}, rpc.PendingBlockNumber)
+		blockNr := rpc.PendingBlockNumber
+		_, _ = api.EstimateGas(ctx, CallArgs{}, &blockNr)
 	})
 }
 


### PR DESCRIPTION
In Ethereum web3 API, second argument of EstimateGas is optional. This PR implements this behavior