### PR TITLE
Optimize synchronization of ongoing epochs

### DIFF
--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -164,9 +164,9 @@ func DefaultTxPoolConfig() TxPoolConfig {
 		PriceBump:  10,
 
 		AccountSlots: 16,
-		GlobalSlots:  4096,
-		AccountQueue: 64,
-		GlobalQueue:  1024,
+		GlobalSlots:  1024,
+		AccountQueue: 32,
+		GlobalQueue:  256,
 
 		Lifetime: 3 * time.Hour,
 	}

--- a/gossip/config_emitter.go
+++ b/gossip/config_emitter.go
@@ -47,9 +47,9 @@ func DefaultEmitterConfig() EmitterConfig {
 		VersionToPublish: _params.VersionWithMeta(),
 
 		EmitIntervals: EmitIntervals{
-			Min:                250 * time.Millisecond,
+			Min:                400 * time.Millisecond,
 			Max:                12 * time.Minute,
-			Confirming:         300 * time.Millisecond,
+			Confirming:         500 * time.Millisecond,
 			SelfForkProtection: 30 * time.Minute, // should be at least 2x of MaxEmitInterval
 		},
 

--- a/gossip/consensus_callbacks.go
+++ b/gossip/consensus_callbacks.go
@@ -114,6 +114,13 @@ func (s *Service) processEvent(realEngine Consensus, e *inter.Event) error {
 		newEpoch = realEngine.GetEpoch()
 	}
 
+	// update highest lamport
+	if newEpoch != oldEpoch {
+		s.store.SetHighestLamport(0)
+	} else if e.Lamport > s.store.GetHighestLamport() {
+		s.store.SetHighestLamport(e.Lamport)
+	}
+
 	if newEpoch != oldEpoch {
 		// notify event checkers about new validation data
 		s.heavyCheckReader.Addrs.Store(ReadEpochPubKeys(s.app, newEpoch))

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -174,6 +174,15 @@ func newService(config *Config, store *Store, engine Consensus) (*Service, error
 		IsEventAllowedIntoBlock: svc.isEventAllowedIntoBlock,
 	})
 
+	// find highest lamport
+	var highestLamport idx.Lamport
+	for _, id := range store.GetHeads(svc.engine.GetEpoch()) {
+		if highestLamport < id.Lamport() {
+			highestLamport = id.Lamport()
+		}
+	}
+	store.SetHighestLamport(highestLamport)
+
 	// create server pool
 	trustedNodes := []string{}
 	svc.serverPool = newServerPool(store.async.table.Peers, svc.done, &svc.wg, trustedNodes)

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -36,11 +37,12 @@ type Store struct {
 		NetworkVersion kvdb.KeyValueStore `table:"J"`
 
 		// Main DAG tables
-		Events    kvdb.KeyValueStore `table:"e"`
-		Blocks    kvdb.KeyValueStore `table:"b"`
-		PackInfos kvdb.KeyValueStore `table:"p"`
-		Packs     kvdb.KeyValueStore `table:"P"`
-		PacksNum  kvdb.KeyValueStore `table:"n"`
+		Events         kvdb.KeyValueStore `table:"e"`
+		Blocks         kvdb.KeyValueStore `table:"b"`
+		PackInfos      kvdb.KeyValueStore `table:"p"`
+		Packs          kvdb.KeyValueStore `table:"P"`
+		PacksNum       kvdb.KeyValueStore `table:"n"`
+		HighestLamport kvdb.KeyValueStore `table:"u"`
 
 		// general economy tables
 		EpochStats kvdb.KeyValueStore `table:"E"`
@@ -60,13 +62,14 @@ type Store struct {
 	EpochDbs *temporary.Dbs
 
 	cache struct {
-		Events        *lru.Cache `cache:"-"` // store by pointer
-		EventsHeaders *lru.Cache `cache:"-"` // store by pointer
-		Blocks        *lru.Cache `cache:"-"` // store by pointer
-		PackInfos     *lru.Cache `cache:"-"` // store by value
-		EpochStats    *lru.Cache `cache:"-"` // store by value
-		TxPositions   *lru.Cache `cache:"-"` // store by pointer
-		BlockHashes   *lru.Cache `cache:"-"` // store by pointer
+		Events         *lru.Cache   `cache:"-"` // store by pointer
+		EventsHeaders  *lru.Cache   `cache:"-"` // store by pointer
+		Blocks         *lru.Cache   `cache:"-"` // store by pointer
+		PackInfos      *lru.Cache   `cache:"-"` // store by value
+		EpochStats     *lru.Cache   `cache:"-"` // store by value
+		TxPositions    *lru.Cache   `cache:"-"` // store by pointer
+		BlockHashes    *lru.Cache   `cache:"-"` // store by pointer
+		HighestLamport atomic.Value // store by value
 	}
 
 	mutex struct {

--- a/gossip/store_event.go
+++ b/gossip/store_event.go
@@ -133,3 +133,15 @@ func (s *Store) GetEventRLP(id hash.Event) rlp.RawValue {
 func (s *Store) HasEvent(h hash.Event) bool {
 	return s.has(s.table.Events, h.Bytes())
 }
+
+func (s *Store) GetHighestLamport() idx.Lamport {
+	cache := s.cache.HighestLamport.Load()
+	if cache != nil {
+		return cache.(idx.Lamport)
+	}
+	return 0
+}
+
+func (s *Store) SetHighestLamport(lamport idx.Lamport) {
+	s.cache.HighestLamport.Store(lamport)
+}

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ func init() {
 	params.VersionMajor = 0     // Major version component of the current release
 	params.VersionMinor = 8     // Minor version component of the current release
 	params.VersionPatch = 1     // Patch version component of the current release
-	params.VersionMeta = "rc.3" // Version metadata to append to the version string
+	params.VersionMeta = "rc.5" // Version metadata to append to the version string
 }
 
 func BigToString(b *big.Int) string {


### PR DESCRIPTION
- ignore event broadcasts with too high lamport
- decrease default maximum txpool size